### PR TITLE
fix: 修复前端react ci打包成docker镜像报错

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,7 +17,7 @@ FROM docker.io/nginx:latest
 LABEL maintainer="laokou"
 LABEL description="ui"
 COPY dist /usr/share/nginx
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/conf/nginx.conf /etc/nginx/nginx.conf
 COPY nginx/ssl/cert.pem /etc/nginx/ssl/cert.pem
 COPY nginx/ssl/key.pem /etc/nginx/ssl/key.pem
 EXPOSE 443


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration file path in the Docker setup for the UI component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->