### PR TITLE
feat: 安装docker portainer，Linux docker可视化

### DIFF
--- a/doc/deploy/docker-compose.yml
+++ b/doc/deploy/docker-compose.yml
@@ -435,7 +435,21 @@ services:
       - gateway
       - auth
       - admin
-
+  # 控制台 => admin/laokou123456789
+  portainer:
+   image: portainer/portainer-ce:latest
+   container_name: portainer
+   # 保持容器在没有守护程序的情况下运行
+   tty: true
+   restart: always
+   privileged: true
+   ports:
+     - "9010:9000"
+   volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
+     - ./portainer/data:/data
+   networks:
+     - laokou_network
 networks:
   laokou_network:
     driver: bridge


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 在 Docker Compose 配置中添加 Portainer 服务，用于可视化和管理 Docker 容器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add Portainer service to the Docker Compose configuration for visualizing and managing Docker containers.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new service for Portainer, allowing users to manage Docker containers through a web interface.
	- Portainer is accessible via port 9010 on the host for enhanced usability. 

- **Chores**
	- Updated the Docker Compose configuration to include the new Portainer service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->