### PR TITLE
feat: 设备key改为设备sn

### DIFF
--- a/doc/db/kcloud_platform_iot数据库设计文档.html
+++ b/doc/db/kcloud_platform_iot数据库设计文档.html
@@ -104,14 +104,14 @@
 		</tr>
 		<tr>
 			<td class="text-center">2</td>
-			<td>key</td>
+			<td>sn</td>
 			<td class="text-center">varchar</td>
 			<td class="text-center">(64)</td>
 			<td class="text-center"></td>
 			<td class="text-center"></td>
 			<td class="text-center"></td>
 			<td class="text-center"></td>
-			<td>设备标识</td>
+			<td>设备序列号</td>
 		</tr>
 		<tr>
 			<td class="text-center">3</td>

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/device/dto/DevicePageQry.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/device/dto/DevicePageQry.java
@@ -30,9 +30,9 @@ import org.laokou.common.i18n.dto.PageQuery;
 public class DevicePageQry extends PageQuery {
 
 	/**
-	 * 设备标识.
+	 * 设备序列号.
 	 */
-	private String key;
+	private String sn;
 
 	/**
 	 * 设备名称.

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/device/dto/clientobject/DeviceCO.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/device/dto/clientobject/DeviceCO.java
@@ -39,8 +39,8 @@ public class DeviceCO extends ClientObject {
 	@Schema(name = "ID", description = "ID")
 	private Long id;
 
-	@Schema(name = "设备标识", description = "设备标识")
-	private String key;
+	@Schema(name = "设备序列号", description = "设备序列号")
+	private String sn;
 
 	@Schema(name = "设备名称", description = "设备名称")
 	private String name;

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/device/model/DeviceE.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/device/model/DeviceE.java
@@ -34,9 +34,9 @@ public class DeviceE {
 	private Long id;
 
 	/**
-	 * 设备标识.
+	 * 设备序列号.
 	 */
-	private String key;
+	private String sn;
 
 	/**
 	 * 设备名称.

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/device/convertor/DeviceConvertor.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/device/convertor/DeviceConvertor.java
@@ -37,7 +37,7 @@ public class DeviceConvertor {
 		else {
 			deviceDO.setId(deviceE.getId());
 		}
-		deviceDO.setKey(deviceE.getKey());
+		deviceDO.setSn(deviceE.getSn());
 		deviceDO.setName(deviceE.getName());
 		deviceDO.setStatus(deviceE.getStatus());
 		return deviceDO;
@@ -45,7 +45,7 @@ public class DeviceConvertor {
 
 	public static DeviceCO toClientObject(DeviceDO deviceDO) {
 		DeviceCO deviceCO = new DeviceCO();
-		deviceCO.setKey(deviceDO.getKey());
+		deviceCO.setSn(deviceDO.getSn());
 		deviceCO.setName(deviceDO.getName());
 		deviceCO.setStatus(deviceDO.getStatus());
 		return deviceCO;
@@ -53,7 +53,7 @@ public class DeviceConvertor {
 
 	public static DeviceE toEntity(DeviceCO deviceCO) {
 		DeviceE deviceE = new DeviceE();
-		deviceE.setKey(deviceCO.getKey());
+		deviceE.setSn(deviceCO.getSn());
 		deviceE.setName(deviceCO.getName());
 		deviceE.setStatus(deviceCO.getStatus());
 		return deviceE;

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/device/gatewayimpl/database/dataobject/DeviceDO.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/device/gatewayimpl/database/dataobject/DeviceDO.java
@@ -32,9 +32,9 @@ import org.laokou.common.mybatisplus.mapper.BaseDO;
 public class DeviceDO extends BaseDO {
 
 	/**
-	 * 设备标识.
+	 * 设备序列号.
 	 */
-	private String key;
+	private String sn;
 
 	/**
 	 * 设备名称.

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/resources/mapper/device/DeviceMapper.xml
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/resources/mapper/device/DeviceMapper.xml
@@ -23,7 +23,7 @@
 	<select id="selectObjectPage"
 			resultType="org.laokou.admin.device.gatewayimpl.database.dataobject.DeviceDO">
 		SELECT id,
-                 key,
+                 sn,
                  name,
                  status,
              create_time


### PR DESCRIPTION
## Summary by Sourcery

在 laokou-admin 模块的各个类中，将设备标识符从 'key' 更改为 'sn'。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Change device identifier from 'key' to 'sn' across various classes in the laokou-admin module.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the database design documentation to reflect a more precise column naming for device identification, changing "key" to "sn" (Device Serial Number).
  
- **Bug Fixes**
	- Corrected SQL queries in the mapping layer to ensure accurate data retrieval by renaming the column from "key" to "sn".

- **Documentation**
	- Revised documentation to clarify the changes in device identification terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->