### PR TITLE
build: 归退版本至3.3.4

### DIFF
--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <laokou.version>3.4.0</laokou.version>
     <!--spring-boot版本-->
-    <spring-boot.version>3.4.0-M3</spring-boot.version>
+    <spring-boot.version>3.3.4</spring-boot.version>
     <!--lombok版本-->
     <lombok.version>1.18.34</lombok.version>
     <!--postgresql版本-->
@@ -62,10 +62,10 @@
     <!--easyexcel版本-->
     <easyexcel.version>4.0.3</easyexcel.version>
     <!--spring-security-oauth2-authorization-server版本-->
-    <spring-security-oauth2-authorization-server.version>1.4.0-RC1
+    <spring-security-oauth2-authorization-server.version>1.3.3
     </spring-security-oauth2-authorization-server.version>
     <!--spring-boot-starter-oauth2版本-->
-    <spring-boot-starter-oauth2.version>3.4.0-M3
+    <spring-boot-starter-oauth2.version>3.3.4
     </spring-boot-starter-oauth2.version>
     <!--aws-java-sdk-s3版本-->
     <aws-java-sdk-s3.version>1.12.777</aws-java-sdk-s3.version>

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SpringWebSocketServerProperties.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SpringWebSocketServerProperties.java
@@ -66,18 +66,39 @@ public class SpringWebSocketServerProperties {
 	 */
 	private String serviceId;
 
+	/**
+	 * 最大内容长度.
+	 */
 	private int maxContentLength = 65536;
 
+	/**
+	 * WebSocket路径.
+	 */
 	private String websocketPath = "/ws";
 
+	/**
+	 * 显示刷新Flush大小.
+	 */
 	private int explicitFlushAfterFlushes = 10;
 
+	/**
+	 * 当没有正在进行的读取时进行合并.
+	 */
 	private boolean consolidateWhenNoReadInProgress = true;
 
+	/**
+	 * 读取空闲时间.
+	 */
 	private long readerIdleTime = 60;
 
+	/**
+	 * 写入空闲时间.
+	 */
 	private long writerIdleTime = 0;
 
+	/**
+	 * 全部时间.
+	 */
 	private long allIdleTime = 0;
 
 }

--- a/laokou-common/laokou-common-rocketmq/src/main/java/org/laokou/common/rocketmq/template/RocketMqTemplate.java
+++ b/laokou-common/laokou-common-rocketmq/src/main/java/org/laokou/common/rocketmq/template/RocketMqTemplate.java
@@ -84,7 +84,6 @@ public class RocketMqTemplate {
 	public <T> void sendTransactionMessage(String topic, String tag, T payload, Long transactionId, String traceId,
 			String spanId) {
 		try {
-			MdcUtil.put(traceId, spanId);
 			Message<T> message = MessageBuilder.withPayload(payload)
 				.setHeader(RocketMQHeaders.TRANSACTION_ID, transactionId)
 				.setHeader(TRACE_ID, traceId)
@@ -92,6 +91,7 @@ public class RocketMqTemplate {
 				.build();
 			SendStatus sendStatus = rocketMQTemplate.sendMessageInTransaction(getTopicTag(topic, tag), message, null)
 				.getSendStatus();
+			MdcUtil.put(traceId, spanId);
 			if (ObjectUtil.equals(sendStatus, SEND_OK)) {
 				log.info("RocketMQ事务消息发送成功【Tag标签】");
 			}
@@ -100,6 +100,7 @@ public class RocketMqTemplate {
 			}
 		}
 		catch (Exception e) {
+			MdcUtil.put(traceId, spanId);
 			log.error("RocketMQ事务消息发送失败【Tag标签】，报错信息：{}", e.getMessage(), e);
 		}
 		finally {

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2AuthorizationServerConfig.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2AuthorizationServerConfig.java
@@ -104,7 +104,7 @@ class OAuth2AuthorizationServerConfig {
 			AuthorizationServerSettings authorizationServerSettings,
 			OAuth2AuthorizationService authorizationService) throws Exception {
 		// https://docs.spring.io/spring-authorization-server/docs/current/reference/html/configuration-model.html
-		applyDefaultSecurity(http);
+		OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
         http.getConfigurer(OAuth2AuthorizationServerConfigurer.class)
 			// https://docs.spring.io/spring-authorization-server/docs/current/reference/html/protocol-endpoints.html#oauth2-token-endpoint
 			.tokenEndpoint((tokenEndpoint) -> tokenEndpoint.accessTokenRequestConverter(new DelegatingAuthenticationConverter(List.of(
@@ -245,19 +245,6 @@ class OAuth2AuthorizationServerConfig {
 		catch (Exception var2) {
 			throw new IllegalStateException(var2);
 		}
-	}
-
-	private void applyDefaultSecurity(HttpSecurity http) throws Exception {
-		// @formatter:off
-        OAuth2AuthorizationServerConfigurer authorizationServerConfigurer =
-                OAuth2AuthorizationServerConfigurer.authorizationServer();
-        http
-                .securityMatcher(authorizationServerConfigurer.getEndpointsMatcher())
-                .with(authorizationServerConfigurer, Customizer.withDefaults())
-                .authorizeHttpRequests((authorize) ->
-                        authorize.anyRequest().authenticated()
-                );
-        // @formatter:on
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     <spring-boot-maven-plugin.version>3.3.4</spring-boot-maven-plugin.version>
     <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
     <!--spring-boot版本-->
-    <spring-boot.version>3.4.0-M3</spring-boot.version>
+    <spring-boot.version>3.3.4</spring-boot.version>
     <!--spring-cloud版本-->
-    <spring-cloud.version>2024.0.0-M2</spring-cloud.version>
+    <spring-cloud.version>2023.0.3</spring-cloud.version>
     <!--spring-framework版本-->
     <spring-framework.version>6.1.14</spring-framework.version>
     <!--cloud-alibaba版本-->


### PR DESCRIPTION
## Summary by Sourcery

增强 WebSocket 服务器属性，增加额外的配置选项，重构 OAuth2 授权服务器配置以使用标准的安全方法，并通过确保一致的 MDC 上下文设置来改进 RocketMQ 事务消息处理。

增强功能：
- 为 WebSocket 设置添加新的配置属性到 SpringWebSocketServerProperties，包括最大内容长度、WebSocket 路径、显式刷新大小和空闲时间。
- 重构 OAuth2AuthorizationServerConfig 以使用 OAuth2AuthorizationServerConfiguration.applyDefaultSecurity 方法，移除自定义的 applyDefaultSecurity 方法。
- 调整 RocketMqTemplate 以确保在事务消息发送期间一致地设置 MDC 上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance WebSocket server properties with additional configuration options, refactor OAuth2 authorization server configuration to use a standard security method, and improve RocketMQ transaction message handling by ensuring consistent MDC context setting.

Enhancements:
- Add new configuration properties to SpringWebSocketServerProperties for WebSocket settings, including max content length, WebSocket path, explicit flush size, and idle times.
- Refactor OAuth2AuthorizationServerConfig to use OAuth2AuthorizationServerConfiguration.applyDefaultSecurity method, removing the custom applyDefaultSecurity method.
- Adjust RocketMqTemplate to ensure MDC context is set consistently during transaction message sending.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced WebSocket server configuration with new properties for content length, path, and idle times.
  
- **Bug Fixes**
	- Updated dependencies to more stable versions for improved compatibility and stability.

- **Refactor**
	- Streamlined security configuration in the OAuth2 authorization server setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->