### PR TITLE
admin和auth不依赖job

### DIFF
--- a/doc/deploy/docker-compose.yml
+++ b/doc/deploy/docker-compose.yml
@@ -355,7 +355,6 @@ services:
     networks:
       - laokou_network
     depends_on:
-      - job
       - nacos
       - admin
       - rocketmq-namesrv
@@ -376,7 +375,6 @@ services:
     networks:
       - laokou_network
     depends_on:
-      - job
       - nacos
       - elasticsearch
       - rocketmq-namesrv


### PR DESCRIPTION
## Summary by Sourcery

部署：
- 在 Docker Compose 配置中，移除 'admin' 和 'auth' 服务对 'job' 服务的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deployment:
- Remove the dependency on the 'job' service for the 'admin' and 'auth' services in the Docker Compose configuration.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated service dependencies in the Docker Compose configuration for `auth` and `admin` services, removing reliance on the `job` service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->