### PR TITLE
移除docker-compose version（已废弃）

### DIFF
--- a/doc/deploy/docker-compose.yml
+++ b/doc/deploy/docker-compose.yml
@@ -13,7 +13,6 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 #  */
-version: '3'
 services:
   prometheus:
     image: prom/prometheus:latest


### PR DESCRIPTION
## Summary by Sourcery

构建：
- 从 docker-compose.yml 中移除已弃用的 'version' 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Remove deprecated 'version' field from docker-compose.yml.

</details>