### PR TITLE
style: 优化测试类代码，增加tcp例子

### DIFF
--- a/laokou-common/laokou-common-crypto/src/test/java/org/laokou/common/crypto/Jasypt2Test.java
+++ b/laokou-common/laokou-common-crypto/src/test/java/org/laokou/common/crypto/Jasypt2Test.java
@@ -23,8 +23,6 @@ import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * 只针对 spring-boot 2.x.x.
  *
@@ -41,8 +39,7 @@ class Jasypt2Test {
 		String decryptWithMD5AndDESStr = decryptWithMD5AndDES(encryptWithMD5AndDESStr, factor);
 		log.info("采用PBEWithMD5AndDES加密前原文密文：{}", encryptWithMD5AndDESStr);
 		log.info("采用PBEWithMD5AndDES解密后密文原文：{}", decryptWithMD5AndDESStr);
-		Assertions.assertArrayEquals(decryptWithMD5AndDESStr.getBytes(StandardCharsets.UTF_8),
-				plainText.getBytes(StandardCharsets.UTF_8));
+		Assertions.assertEquals(decryptWithMD5AndDESStr, plainText);
 	}
 
 	/**

--- a/laokou-common/laokou-common-crypto/src/test/java/org/laokou/common/crypto/Jasypt3Test.java
+++ b/laokou-common/laokou-common-crypto/src/test/java/org/laokou/common/crypto/Jasypt3Test.java
@@ -23,8 +23,6 @@ import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * 只针对 spring-boot 3.x.x.
  *
@@ -41,8 +39,7 @@ class Jasypt3Test {
 		String decryptWithMD5ANDAES256Str = decryptWithHMACSHA512ANDAES256(encryptWithMD5ANDAES256Str, factor);
 		log.info("采用PBEWITHHMACSHA512ANDAES_256加密前原文密文：{}", encryptWithMD5ANDAES256Str);
 		log.info("采用PBEWITHHMACSHA512ANDAES_256解密后密文原文：{}", decryptWithMD5ANDAES256Str);
-		Assertions.assertArrayEquals(decryptWithMD5ANDAES256Str.getBytes(StandardCharsets.UTF_8),
-				plainText.getBytes(StandardCharsets.UTF_8));
+		Assertions.assertEquals(decryptWithMD5ANDAES256Str, plainText);
 	}
 
 	/**
@@ -51,7 +48,7 @@ class Jasypt3Test {
 	 * @param factor 加密秘钥
 	 * @return java.lang.String
 	 */
-	public String encryptWithHMACSHA512ANDAES256(String plainText, String factor) {
+	private String encryptWithHMACSHA512ANDAES256(String plainText, String factor) {
 		return pooledPBEStringEncryptor(factor).encrypt(plainText);
 	}
 
@@ -61,11 +58,11 @@ class Jasypt3Test {
 	 * @param factor 解密秘钥
 	 * @return java.lang.String
 	 */
-	public String decryptWithHMACSHA512ANDAES256(String encryptedText, String factor) {
+	private String decryptWithHMACSHA512ANDAES256(String encryptedText, String factor) {
 		return pooledPBEStringEncryptor(factor).decrypt(encryptedText);
 	}
 
-	public PooledPBEStringEncryptor pooledPBEStringEncryptor(String factor) {
+	private PooledPBEStringEncryptor pooledPBEStringEncryptor(String factor) {
 		PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
 		SimpleStringPBEConfig config = new SimpleStringPBEConfig();
 		config.setPassword(factor);

--- a/laokou-sample/laokou-sample-tcp/pom.xml
+++ b/laokou-sample/laokou-sample-tcp/pom.xml
@@ -5,18 +5,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.laokou</groupId>
-    <artifactId>KCloud-Platform-IoT</artifactId>
+    <artifactId>laokou-sample</artifactId>
     <version>3.4.0</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>laokou-sample</artifactId>
+  <artifactId>laokou-sample-tcp</artifactId>
   <version>3.4.0</version>
-  <packaging>pom</packaging>
-  <modules>
-      <module>laokou-sample-websocket</module>
-      <module>laokou-sample-shardingsphere</module>
-      <module>laokou-sample-tcp</module>
-  </modules>
 
 </project>


### PR DESCRIPTION
## Summary by Sourcery

通过更新断言和修改方法访问级别以实现更好的封装，重构测试类 Jasypt3Test 和 Jasypt2Test。

增强功能：
- 在 Jasypt3Test 和 Jasypt2Test 中重构测试断言，将字符串比较从 assertArrayEquals 改为 assertEquals。
- 将 Jasypt3Test 中方法的访问修饰符从 public 改为 private 以封装功能。
- 将 Jasypt2Test 中方法的访问修饰符从 public 改为 private 以封装功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor test classes Jasypt3Test and Jasypt2Test by updating assertions and modifying method access levels for better encapsulation.

Enhancements:
- Refactor test assertions in Jasypt3Test and Jasypt2Test to use assertEquals instead of assertArrayEquals for string comparison.
- Change access modifiers of methods in Jasypt3Test from public to private to encapsulate functionality.
- Change access modifiers of methods in Jasypt2Test from public to private to encapsulate functionality.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Maven POM file for the `laokou-sample-tcp` module, enhancing project modularity.
	- Added `laokou-sample-tcp` as a new module in the main project structure.

- **Bug Fixes**
	- Updated test assertions in `Jasypt2Test` and `Jasypt3Test` to simplify string equality checks.

- **Refactor**
	- Changed access modifiers for encryption and decryption methods in `Jasypt3Test` to private, improving encapsulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->