### PR TITLE
feat: mybatis-spring魔改源码，去掉synchronized，防止死锁

### DIFF
--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/mybatis/spring/MyBatisExceptionTranslator.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/mybatis/spring/MyBatisExceptionTranslator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Copyright 2010-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mybatis.spring;
+
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import javax.sql.DataSource;
+
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.laokou.common.core.utils.SpringContextUtil;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+import org.springframework.jdbc.UncategorizedSQLException;
+import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
+import org.springframework.jdbc.support.SQLExceptionTranslator;
+import org.springframework.transaction.TransactionException;
+
+/**
+ * Default exception translator.
+ * <p>
+ * Translates MyBatis SqlSession returned exception into a Spring
+ * {@code DataAccessException} using Spring's {@code SQLExceptionTranslator} Can load
+ * {@code SQLExceptionTranslator} eagerly or when the first exception is translated.
+ *
+ * @author Eduardo Macarron
+ * @author laokou
+ */
+public class MyBatisExceptionTranslator implements PersistenceExceptionTranslator {
+
+	private SQLExceptionTranslator exceptionTranslator;
+
+	/**
+	 * Creates a new {@code PersistenceExceptionTranslator} instance with
+	 * {@code SQLErrorCodeSQLExceptionTranslator}.
+	 * @param dataSource DataSource to use to find metadata and establish which error
+	 * codes are usable.
+	 * @param exceptionTranslatorLazyInit if true, the translator instantiates internal
+	 * stuff only the first time will have the need to translate exceptions.
+	 */
+	public MyBatisExceptionTranslator(DataSource dataSource, boolean exceptionTranslatorLazyInit) {
+		this(() -> new SQLErrorCodeSQLExceptionTranslator(dataSource), exceptionTranslatorLazyInit);
+	}
+
+	/**
+	 * Creates a new {@code PersistenceExceptionTranslator} instance with specified
+	 * {@code SQLExceptionTranslator}.
+	 * @param exceptionTranslatorSupplier Supplier for creating a
+	 * {@code SQLExceptionTranslator} instance
+	 * @param exceptionTranslatorLazyInit if true, the translator instantiates internal
+	 * stuff only the first time will have the need to translate exceptions.
+	 *
+	 * @since 2.0.3
+	 */
+	public MyBatisExceptionTranslator(Supplier<SQLExceptionTranslator> exceptionTranslatorSupplier,
+			boolean exceptionTranslatorLazyInit) {
+		if (!exceptionTranslatorLazyInit) {
+			this.initExceptionTranslator();
+		}
+	}
+
+	@Override
+	public DataAccessException translateExceptionIfPossible(RuntimeException e) {
+		if (e instanceof PersistenceException) {
+			// Batch exceptions come inside another PersistenceException
+			// recursion has a risk of infinite loop so better make another if
+			var msg = e.getMessage();
+			if (e.getCause() instanceof PersistenceException) {
+				e = (PersistenceException) e.getCause();
+				if (msg == null) {
+					msg = e.getMessage();
+				}
+			}
+			if (e.getCause() instanceof SQLException se) {
+				this.initExceptionTranslator();
+				var task = e.getMessage() + "\n";
+				var dae = this.exceptionTranslator.translate(task, null, se);
+				return dae != null ? dae : new UncategorizedSQLException(task, null, se);
+			}
+			if (e.getCause() instanceof TransactionException) {
+				throw (TransactionException) e.getCause();
+			}
+			return new MyBatisSystemException(msg, e);
+		}
+		return null;
+	}
+
+	/**
+	 * Initializes the internal translator reference.
+	 */
+	private void initExceptionTranslator() {
+		if (this.exceptionTranslator == null) {
+			SqlSessionFactory sessionFactory = SpringContextUtil.getBean(SqlSessionFactory.class);
+			this.exceptionTranslator = new SQLErrorCodeSQLExceptionTranslator(
+					sessionFactory.getConfiguration().getEnvironment().getDataSource());
+		}
+	}
+
+}

--- a/laokou-common/laokou-common-rocketmq/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageConcurrentlyService.java
+++ b/laokou-common/laokou-common-rocketmq/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageConcurrentlyService.java
@@ -81,6 +81,7 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.laokou.common.core.config.TtlVirtualThreadFactory;
 import org.laokou.common.core.utils.SpringContextUtil;
 import org.laokou.common.core.utils.SpringUtil;
+import org.laokou.common.i18n.utils.ObjectUtil;
 
 /**
  * @author laokou
@@ -103,6 +104,8 @@ public class ConsumeMessageConcurrentlyService implements ConsumeMessageService 
 
 	private final ScheduledExecutorService cleanExpireMsgExecutors;
 
+	private SpringUtil springUtil;
+
 	public ConsumeMessageConcurrentlyService(DefaultMQPushConsumerImpl defaultMQPushConsumerImpl,
 			MessageListenerConcurrently messageListener) {
 		this.defaultMQPushConsumerImpl = defaultMQPushConsumerImpl;
@@ -115,7 +118,7 @@ public class ConsumeMessageConcurrentlyService implements ConsumeMessageService 
 		String consumerGroupTag = (consumerGroup.length() > 100 ? consumerGroup.substring(0, 100) : consumerGroup)
 				+ "_";
 
-		SpringUtil springUtil = SpringContextUtil.getBean(SpringUtil.class);
+		initSpringUtil();
 		if (springUtil.isVirtualThread()) {
 			this.consumeExecutor = new ThreadPoolExecutor(0, // corePoolSize为0，因为不需要保留核心线程
 					Integer.MAX_VALUE, // maximumPoolSize: 无限制，允许任意数量的虚拟线程
@@ -511,6 +514,12 @@ public class ConsumeMessageConcurrentlyService implements ConsumeMessageService 
 			}
 		}
 
+	}
+
+	private void initSpringUtil() {
+		if (ObjectUtil.isNull(springUtil)) {
+			this.springUtil = SpringContextUtil.getBean(SpringUtil.class);
+		}
 	}
 
 }

--- a/laokou-common/laokou-common-trace/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/prometheus/PrometheusExemplarsAutoConfiguration.java
+++ b/laokou-common/laokou-common-trace/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/prometheus/PrometheusExemplarsAutoConfiguration.java
@@ -74,6 +74,8 @@ public class PrometheusExemplarsAutoConfiguration {
 	 */
 	static class TracingSpanContext implements SpanContext {
 
+		private Span span;
+
 		@Override
 		public String getCurrentTraceId() {
 			Span currentSpan = currentSpan();
@@ -92,7 +94,7 @@ public class PrometheusExemplarsAutoConfiguration {
 			if (ObjectUtil.isNull(currentSpan)) {
 				return false;
 			}
-			return currentSpan.context().sampled();
+			return Boolean.TRUE.equals(currentSpan.context().sampled());
 		}
 
 		@Override
@@ -101,7 +103,10 @@ public class PrometheusExemplarsAutoConfiguration {
 
 		private Span currentSpan() {
 			try {
-				return SpringContextUtil.getBean(Tracer.class).currentSpan();
+				if (ObjectUtil.isNull(this.span)) {
+					this.span = SpringContextUtil.getBean(Tracer.class).currentSpan();
+				}
+				return this.span;
 			}
 			catch (Exception e) {
 				return null;

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -45,6 +45,7 @@ import org.laokou.auth.api.TenantsServiceI;
 import org.laokou.common.core.utils.SpringContextUtil;
 import org.laokou.common.i18n.dto.Option;
 import org.laokou.common.i18n.dto.Result;
+import org.laokou.common.i18n.utils.ObjectUtil;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -102,6 +103,8 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 	private Map<String, String> oauth2AuthenticationUrlToClientName;
 
 	private Map<String, String> saml2AuthenticationUrlToProviderName;
+
+	private TenantsServiceI tenantsServiceI;
 
 	private Function<HttpServletRequest, Map<String, String>> resolveHiddenInputs = (request) -> Collections.emptyMap();
 
@@ -162,8 +165,8 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 	}
 
 	private String generateLoginPageHtml(HttpServletRequest request, boolean loginError, boolean logoutSuccess) {
-		TenantsServiceI serviceI = SpringContextUtil.getBean(TenantsServiceI.class);
-		Result<List<Option>> result = serviceI.listOption();
+		initTenantsServiceI();
+		Result<List<Option>> result = tenantsServiceI.listOption();
 		String errorMsg = loginError ? getLoginErrorMessage(request) : "Invalid credentials";
 		String contextPath = request.getContextPath();
 		StringBuilder sb = new StringBuilder();
@@ -315,6 +318,12 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			return uri.equals(url);
 		}
 		return uri.equals(request.getContextPath() + url);
+	}
+
+	private void initTenantsServiceI() {
+		if (ObjectUtil.isNull(tenantsServiceI)) {
+			tenantsServiceI = SpringContextUtil.getBean(TenantsServiceI.class);
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary by Sourcery

引入 MyBatisExceptionTranslator 进行异常处理，并重构代码以延迟初始化服务 bean，移除同步块以防止死锁。

新功能：
- 引入 MyBatisExceptionTranslator，将 MyBatis 异常转换为 Spring DataAccessExceptions，使用 Spring 的 SQLExceptionTranslator。

增强功能：
- 重构代码以延迟初始化服务 bean，通过移除同步块来降低死锁风险。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce MyBatisExceptionTranslator for exception handling and refactor code to initialize service beans lazily, removing synchronized blocks to prevent deadlocks.

New Features:
- Introduce MyBatisExceptionTranslator to translate MyBatis exceptions into Spring DataAccessExceptions using Spring's SQLExceptionTranslator.

Enhancements:
- Refactor code to initialize service beans lazily, reducing the risk of deadlocks by removing synchronized blocks.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new exception translator for MyBatis to enhance compatibility with Spring's data access exceptions.
	- Added tenant management capabilities to the login page generation process.

- **Improvements**
	- Enhanced initialization logic for services to improve code readability and maintainability.
	- Implemented lazy loading for span handling in tracing, improving efficiency. 

- **Bug Fixes**
	- Improved handling of potential null values in span sampling checks to prevent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->