### PR TITLE
feat: 增加ws的服务端发送5次心跳，客户端没有应答，直接关闭连接

### DIFF
--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SessionHeartBeatManager.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SessionHeartBeatManager.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.netty.config;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author laokou
+ */
+public class SessionHeartBeatManager {
+
+	private static final Map<String, Integer> HEART_BEAT_MAP = new ConcurrentHashMap<>(4096);
+
+	public static void increase(String clientId) {
+		HEART_BEAT_MAP.put(clientId, getHeartBeatCount(clientId) + 1);
+	}
+
+	public static void decrease(String clientId) {
+		HEART_BEAT_MAP.put(clientId, getHeartBeatCount(clientId) - 1);
+	}
+
+	public static int getHeartBeatCount(String clientId) {
+		return HEART_BEAT_MAP.getOrDefault(clientId, 0);
+	}
+
+}

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/WebSocketSessionHeartBeatManager.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/WebSocketSessionHeartBeatManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.netty.config;
+
+/**
+ * @author laokou
+ */
+public class WebSocketSessionHeartBeatManager extends SessionHeartBeatManager {
+
+}

--- a/laokou-sample/laokou-sample-crawler/src/test/java/org/laokou/CrawlerTest.java
+++ b/laokou-sample/laokou-sample-crawler/src/test/java/org/laokou/CrawlerTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 class CrawlerTest {
 
 	private static final Map<String, String> MAP = new LinkedHashMap<>();
+
 	private static final String DIRECTORY = "D:/crawl/data/";
 
 	static {
@@ -117,10 +118,9 @@ class CrawlerTest {
 	}
 
 	private String getHeadContent() {
-		return "<link rel='stylesheet' href='css/index.css'>" +
-			"<link rel='stylesheet' href='css/highlight.min.css'>" +
-			"<script src='js/highlight.min.js'></script>" +
-			"<script defer src='js/script.js' data-website-id='83e5d5db-9d06-40e3-b780-cbae722fdf8c'></script>";
+		return "<link rel='stylesheet' href='css/index.css'>" + "<link rel='stylesheet' href='css/highlight.min.css'>"
+				+ "<script src='js/highlight.min.js'></script>"
+				+ "<script defer src='js/script.js' data-website-id='83e5d5db-9d06-40e3-b780-cbae722fdf8c'></script>";
 	}
 
 }

--- a/laokou-sample/laokou-sample-grpc/pom.xml
+++ b/laokou-sample/laokou-sample-grpc/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.laokou</groupId>
+    <artifactId>laokou-sample</artifactId>
+    <version>3.4.0</version>
+  </parent>
+
+  <artifactId>laokou-sample-grpc</artifactId>
+  <version>3.4.0</version>
+
+
+
+</project>

--- a/laokou-sample/pom.xml
+++ b/laokou-sample/pom.xml
@@ -19,6 +19,7 @@
       <module>laokou-sample-tcp</module>
       <module>laokou-sample-rpc</module>
       <module>laokou-sample-crawler</module>
+    <module>laokou-sample-grpc</module>
   </modules>
 
 </project>


### PR DESCRIPTION
## Sourcery总结

实现一个功能，在5次未响应的心跳ping后关闭WebSocket连接，并引入WebSocketSessionHeartBeatManager来管理心跳计数。向项目中添加一个新的gRPC模块。

新功能：
- 引入一种机制，如果客户端未能响应连续5次心跳ping，则关闭WebSocket连接。

增强：
- 添加WebSocketSessionHeartBeatManager以管理WebSocket会话的心跳计数。

构建：
- 向项目中添加一个新模块laokou-sample-grpc。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a feature to close WebSocket connections after 5 unanswered heartbeat pings and introduce a WebSocketSessionHeartBeatManager for managing heartbeat counts. Add a new gRPC module to the project.

New Features:
- Introduce a mechanism to close WebSocket connections if the client fails to respond to 5 consecutive heartbeat pings.

Enhancements:
- Add WebSocketSessionHeartBeatManager to manage heartbeat counts for WebSocket sessions.

Build:
- Add a new module laokou-sample-grpc to the project.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced heartbeat management for clients in a concurrent environment.
	- Added specialized WebSocket session heartbeat management.
	- Enhanced message processing for WebSocket connections, including heartbeat tracking.
- **Bug Fixes**
	- Improved handling of heartbeat pings to close connections exceeding limits.
- **Chores**
	- Added new Maven POM file for the `laokou-sample-grpc` module.
	- Updated project structure to include the new gRPC module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->