### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SessionHeartBeatManager.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SessionHeartBeatManager.java
@@ -19,24 +19,33 @@ package org.laokou.common.netty.config;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author laokou
  */
 public class SessionHeartBeatManager {
 
-	private static final Map<String, Integer> HEART_BEAT_MAP = new ConcurrentHashMap<>(4096);
+	private static final Map<String, AtomicInteger> HEART_BEAT_MAP = new ConcurrentHashMap<>(4096);
 
-	public static void increase(String clientId) {
-		HEART_BEAT_MAP.put(clientId, getHeartBeatCount(clientId) + 1);
+	public static void incrementHeartBeat(String clientId) {
+		HEART_BEAT_MAP.get(clientId).incrementAndGet();
 	}
 
-	public static void decrease(String clientId) {
-		HEART_BEAT_MAP.put(clientId, getHeartBeatCount(clientId) - 1);
+	public static void decrementHeartBeat(String clientId) {
+		HEART_BEAT_MAP.get(clientId).decrementAndGet();
 	}
 
-	public static int getHeartBeatCount(String clientId) {
-		return HEART_BEAT_MAP.getOrDefault(clientId, 0);
+	public static int getHeartBeat(String clientId) {
+		return HEART_BEAT_MAP.get(clientId).get();
+	}
+
+	public static void removeHeartBeat(String clientId) {
+		HEART_BEAT_MAP.remove(clientId);
+	}
+
+	public static void initHeartbeat(String clientId) {
+		HEART_BEAT_MAP.putIfAbsent(clientId, new AtomicInteger(0));
 	}
 
 }

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SpringTcpServerProperties.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SpringTcpServerProperties.java
@@ -91,4 +91,9 @@ public class SpringTcpServerProperties {
 	 */
 	private boolean keepAlive = true;
 
+	/**
+	 * 最大心跳次数.
+	 */
+	private int maxHeartBeatCount = 5;
+
 }

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SpringWebSocketServerProperties.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/SpringWebSocketServerProperties.java
@@ -111,4 +111,9 @@ public class SpringWebSocketServerProperties {
 	 */
 	private boolean keepAlive = true;
 
+	/**
+	 * 最大心跳次数.
+	 */
+	private int maxHeartBeatCount = 5;
+
 }

--- a/laokou-sample/laokou-sample-tcp/src/main/resources/application.yml
+++ b/laokou-sample/laokou-sample-tcp/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
     reader-idle-time: 60
     writer-idle-time: 0
     keep-alive: true
+    max-heart-beat-count: 5
 
 logging:
   config: classpath:log4j2.xml

--- a/laokou-sample/laokou-sample-websocket/src/main/java/org/laokou/app/handler/WebSocketMessageProcessor.java
+++ b/laokou-sample/laokou-sample-websocket/src/main/java/org/laokou/app/handler/WebSocketMessageProcessor.java
@@ -47,11 +47,12 @@ final class WebSocketMessageProcessor {
 		switch (MessageType.valueOf(message.getType().toUpperCase())) {
 			case PONG -> {
 				log.info("接收{}心跳{}", clientId, message.getPayload());
-				WebSocketSessionHeartBeatManager.decrease(clientId);
+				WebSocketSessionHeartBeatManager.decrementHeartBeat(clientId);
 			}
 			case CONNECT -> {
 				log.info("已连接ClientID：{}", message.getPayload());
 				WebSocketSessionManager.add(message.getPayload().toString(), channel);
+				WebSocketSessionHeartBeatManager.initHeartbeat(clientId);
 			}
 			case MESSAGE -> {
 				log.info("接收消息：{}", message.getPayload());

--- a/laokou-sample/laokou-sample-websocket/src/main/resources/application.yml
+++ b/laokou-sample/laokou-sample-websocket/src/main/resources/application.yml
@@ -27,6 +27,7 @@ spring:
     backlog-length: 4096
     tcp-nodelay: true
     keep-alive: true
+    max-heart-beat-count: 5
   thymeleaf:
     servlet:
       content-type: text/html


### PR DESCRIPTION
## Summary by Sourcery

重构 `SessionHeartBeatManager` 中的心跳管理，使用 `AtomicInteger` 以提高线程安全性，并在 `application.yml` 文件中为 TCP 和 WebSocket 示例添加最大心跳计数的配置。

增强功能：
- 重构 `SessionHeartBeatManager` 以使用 `AtomicInteger` 进行线程安全的心跳计数管理。

构建：
- 为 TCP 和 WebSocket 示例在 `application.yml` 中添加 `max-heart-beat-count` 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the heartbeat management in SessionHeartBeatManager to use AtomicInteger for improved thread safety and add configuration for maximum heartbeat count in application.yml files for TCP and WebSocket samples.

Enhancements:
- Refactor SessionHeartBeatManager to use AtomicInteger for thread-safe heartbeat count management.

Build:
- Add max-heart-beat-count configuration to application.yml for both TCP and WebSocket samples.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `maxHeartBeatCount` property for both TCP and WebSocket servers, allowing configuration of maximum heartbeat messages (default set to 5).
  - Enhanced heartbeat management with new methods to initialize and remove heartbeat entries.

- **Bug Fixes**
  - Updated heartbeat decrement logic to ensure proper handling of connection events.

- **Improvements**
  - Refined connection handling for WebSocket, making it more configurable and descriptive in logging heartbeat events. 

These changes enhance the reliability and configurability of heartbeat management in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->