### PR TITLE
feat: 升级sas至1.4.0

### DIFF
--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -59,7 +59,7 @@
     <!--easyexcel版本-->
     <easyexcel.version>4.0.3</easyexcel.version>
     <!--spring-security-oauth2-authorization-server版本-->
-    <spring-security-oauth2-authorization-server.version>1.4.0-RC1</spring-security-oauth2-authorization-server.version>
+    <spring-security-oauth2-authorization-server.version>1.4.0</spring-security-oauth2-authorization-server.version>
     <!--spring-boot-starter-oauth2版本-->
     <spring-boot-starter-oauth2.version>3.4.0-RC1</spring-boot-starter-oauth2.version>
     <!--aws-java-sdk-s3版本-->

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/annotation/WebSocketServer.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/annotation/WebSocketServer.java
@@ -21,10 +21,10 @@ import org.springframework.stereotype.Component;
 
 import java.lang.annotation.*;
 
+@Component
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Component("webSocketServerChannelInitializer")
 public @interface WebSocketServer {
 
 }

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/TcpServerConfig.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/TcpServerConfig.java
@@ -40,3 +40,4 @@ public class TcpServerConfig {
     }
 
 }
+// @formatter:on

--- a/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/WebSocketServerConfig.java
+++ b/laokou-common/laokou-common-netty/src/main/java/org/laokou/common/netty/config/WebSocketServerConfig.java
@@ -22,6 +22,9 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.UnorderedThreadPoolEventExecutor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.util.Assert;
+
+import java.util.List;
 
 // @formatter:off
 /**
@@ -30,8 +33,10 @@ import org.springframework.context.annotation.Bean;
 public class WebSocketServerConfig {
 
     @Bean(name = "webSocketServer", initMethod = "start", destroyMethod = "stop")
-	public Server webSocketServer(ChannelHandler webSocketServerChannelInitializer,SpringWebSocketServerProperties springWebSocketServerProperties) {
-        return new WebSocketServer(webSocketServerChannelInitializer, springWebSocketServerProperties);
+	public Server webSocketServer(List<ChannelHandler> channelHandlers, SpringWebSocketServerProperties springWebSocketServerProperties) {
+		List<ChannelHandler> webSocketServerList = channelHandlers.stream().filter(item -> item.getClass().isAnnotationPresent(org.laokou.common.netty.annotation.WebSocketServer.class)).toList();
+		Assert.noNullElements(webSocketServerList, "WebSocket Server Not Found");
+		return new WebSocketServer(webSocketServerList.getFirst(), springWebSocketServerProperties);
     }
 
     @Bean
@@ -40,3 +45,4 @@ public class WebSocketServerConfig {
     }
 
 }
+// @formatter:on

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -278,6 +278,7 @@ class OAuth2ApiTest {
 
 	@Test
 	void testRemoveCache() {
+		MDCUtil.put("0", "0");
 		rocketMQDomainEventPublisher.publish(new RemoveCacheEvent(TENANT_ID, "1"), SendMessageType.ASYNC);
 	}
 


### PR DESCRIPTION
## Sourcery总结

将spring-security-oauth2-authorization-server依赖升级到版本1.4.0，并增强WebSocket服务器配置以使用自定义注解过滤通道处理程序。改进OAuth2ApiTest中的测试日志记录。

新功能：
- 引入一种机制，使用注解过滤和验证WebSocket服务器通道处理程序。

增强功能：
- 重构WebSocketServerConfig以使用通过自定义注解过滤的通道处理程序列表。

构建：
- 在项目依赖项中将spring-security-oauth2-authorization-server的版本更新到1.4.0。

测试：
- 在OAuth2ApiTest的testRemoveCache方法中添加日志上下文设置，以便更好地进行调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the spring-security-oauth2-authorization-server dependency to version 1.4.0 and enhance the WebSocket server configuration to filter channel handlers using a custom annotation. Improve test logging in OAuth2ApiTest.

New Features:
- Introduce a mechanism to filter and validate WebSocket server channel handlers using annotations.

Enhancements:
- Refactor WebSocketServerConfig to use a list of channel handlers filtered by a custom annotation.

Build:
- Update the version of spring-security-oauth2-authorization-server to 1.4.0 in the project dependencies.

Tests:
- Add a logging context setup in the testRemoveCache method of OAuth2ApiTest to facilitate better debugging.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependencies to stable versions for improved reliability and compatibility.
	- Enhanced `WebSocketServer` configuration to support multiple channel handlers.
  
- **Bug Fixes**
	- Added assertion to ensure no null elements in WebSocket server handlers, improving error handling.

- **Tests**
	- Added logging context in `OAuth2ApiTest` to enhance traceability during cache removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->