### PR TITLE
feat: otel的grpc，修改端口，4317=>grpc 4318=>http

### DIFF
--- a/doc/db/kcloud_platform_nacos.sql
+++ b/doc/db/kcloud_platform_nacos.sql
@@ -1637,7 +1637,7 @@ management:
       probability: 1
   otlp:
     tracing:
-      endpoint: http://otel-collector:4318/v1/traces
+      endpoint: http://otel-collector:4317/v1/traces
       compression: gzip
       timeout: 10s
       transport: grpc
@@ -2083,7 +2083,7 @@ management:
       probability: 1
   otlp:
     tracing:
-      endpoint: http://otel-collector:4318/v1/traces
+      endpoint: http://otel-collector:4317/v1/traces
       compression: gzip
       timeout: 10s
       transport: grpc
@@ -3485,7 +3485,7 @@ management:
       probability: 1
   otlp:
     tracing:
-      endpoint: http://otel-collector:4318/v1/traces
+      endpoint: http://otel-collector:4317/v1/traces
       compression: gzip
       timeout: 10s
       transport: grpc


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 将OpenTelemetry跟踪端点端口从4318更改为4317以用于gRPC传输。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Change the OpenTelemetry tracing endpoint port from 4318 to 4317 for gRPC transport.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multiple new tables for enhanced data management, including `users`, `tenant_info`, `roles`, and more.
	- Added initial data population for user credentials and configuration settings.

- **Improvements**
	- Established primary keys and unique indexes to ensure data integrity and improve query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->