### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/laokou-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/laokou-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Sourcery的总结

构建：
- 更改Gradle分发URL以使用腾讯云镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Change the Gradle distribution URL to use Tencent Cloud mirrors.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Gradle distribution URL to a new mirror for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->