### PR TITLE
fix: #3012

### DIFF
--- a/laokou-common/laokou-common-crypto/src/test/java/org/laokou/common/crypto/CryptoTest.java
+++ b/laokou-common/laokou-common-crypto/src/test/java/org/laokou/common/crypto/CryptoTest.java
@@ -37,15 +37,15 @@ class CryptoTest {
 		String encryptPassword = RSAUtil.encryptByPublicKey(PASSWORD);
 		String decryptUsername = RSAUtil.decryptByPrivateKey(encryptUsername);
 		String decryptPassword = RSAUtil.decryptByPrivateKey(encryptPassword);
-		Assertions.assertEquals(decryptUsername, USERNAME);
-		Assertions.assertEquals(decryptPassword, PASSWORD);
+		Assertions.assertEquals(USERNAME, decryptUsername);
+		Assertions.assertEquals(PASSWORD, decryptPassword);
 	}
 
 	@Test
 	void testAES() {
 		String encryptUsername = AESUtil.encrypt(USERNAME);
 		String decryptUsername = AESUtil.decrypt(encryptUsername);
-		Assertions.assertEquals(decryptUsername, USERNAME);
+		Assertions.assertEquals(USERNAME, decryptUsername);
 	}
 
 }

--- a/laokou-sample/laokou-sample-shardingsphere/src/test/java/org/laokou/CryptoTest.java
+++ b/laokou-sample/laokou-sample-shardingsphere/src/test/java/org/laokou/CryptoTest.java
@@ -40,8 +40,8 @@ class CryptoTest {
 		log.info("密码加密后：{}", encryptPassword);
 		String decryptUsername = CryptoUtils.decrypt(encryptUsername);
 		String decryptPassword = CryptoUtils.decrypt(encryptPassword);
-		Assertions.assertEquals(decryptUsername, username);
-		Assertions.assertEquals(decryptPassword, password);
+		Assertions.assertEquals(username, decryptUsername);
+		Assertions.assertEquals(password, decryptPassword);
 	}
 
 }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正 CryptoTest.java 中断言参数的顺序，以匹配预期值和实际值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct assertion parameter order in CryptoTest.java to match expected and actual values.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the order of parameters in assertions within the `CryptoTest` class to align with preferred conventions, enhancing readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->