### PR TITLE
feat: 提交k8s dashboard脚本相关文件

### DIFF
--- a/doc/deploy/kubernetes/cluster-role-binding-admin-user.yaml
+++ b/doc/deploy/kubernetes/cluster-role-binding-admin-user.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: admin-user
+    namespace: kubernetes-dashboard

--- a/doc/deploy/kubernetes/dashboard-admin-user.yaml
+++ b/doc/deploy/kubernetes/dashboard-admin-user.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/doc/deploy/kubernetes/dashboard-secret-admin-user.yaml
+++ b/doc/deploy/kubernetes/dashboard-secret-admin-user.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/service-account.name: "admin-user"
+type: kubernetes.io/service-account-token

--- a/doc/deploy/kubernetes/readme.adoc
+++ b/doc/deploy/kubernetes/readme.adoc
@@ -1,0 +1,21 @@
+== 安装Kubernetes Dashboard
+
+[source%nowrap,shell]
+----
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
+
+kubectl proxy
+
+# 生成token【长期】
+# https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md
+kubectl apply -f dashboard-admin-user.yaml
+kubectl apply -f cluster-role-binding-admin-user.yaml
+kubectl apply -f dashboard-secret-admin-user.yaml
+kubectl -n kubernetes-dashboard create token admin-user
+
+# 浏览器 
+# http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
+
+----
+


### PR DESCRIPTION
## Sourcery的总结

添加Kubernetes仪表板部署脚本和配置文件，以设置具有集群管理员权限的管理员用户，包括ClusterRoleBinding、Secret和ServiceAccount定义，以及部署文档。

新功能：
- 引入Kubernetes仪表板脚本以设置管理员用户访问权限。

部署：
- 添加Kubernetes ClusterRoleBinding以授予admin-user集群管理员角色。
- 在kubernetes-dashboard命名空间中为admin-user服务账户创建一个Kubernetes Secret。
- 在kubernetes-dashboard命名空间中定义一个admin-user的ServiceAccount。

文档：
- 添加部署Kubernetes仪表板脚本的文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Kubernetes dashboard deployment scripts and configuration files to set up an admin user with cluster-admin privileges, including ClusterRoleBinding, Secret, and ServiceAccount definitions, along with deployment documentation.

New Features:
- Introduce Kubernetes dashboard scripts for setting up admin user access.

Deployment:
- Add Kubernetes ClusterRoleBinding for admin-user to grant cluster-admin role.
- Create a Kubernetes Secret for the admin-user service account in the kubernetes-dashboard namespace.
- Define a ServiceAccount for admin-user in the kubernetes-dashboard namespace.

Documentation:
- Add documentation for deploying Kubernetes dashboard scripts.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Kubernetes ServiceAccount for admin users to manage dashboard access.
	- Added a ClusterRoleBinding to grant admin privileges to the ServiceAccount.
	- Created a Secret resource to store the service account token securely.
	- Updated documentation with installation instructions for the Kubernetes Dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->