### PR TITLE
feat(): influxDB销毁bean，关闭客户端

### DIFF
--- a/laokou-common/laokou-common-influxdb/src/main/java/org/laokou/common/influxdb/config/InfluxDBAutoConfig.java
+++ b/laokou-common/laokou-common-influxdb/src/main/java/org/laokou/common/influxdb/config/InfluxDBAutoConfig.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Bean;
 @AutoConfiguration
 public class InfluxDBAutoConfig {
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	@ConditionalOnProperty(prefix = "spring.influx-db", matchIfMissing = true, name = "type", havingValue = "TOKEN")
 	public InfluxDBClient tokenInfluxDBClient(SpringInfluxDBProperties springInfluxDBProperties) {
 		return InfluxDBClientFactory.create(springInfluxDBProperties.getUrl(),
@@ -37,7 +37,7 @@ public class InfluxDBAutoConfig {
 				springInfluxDBProperties.getBucket());
 	}
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	@ConditionalOnProperty(prefix = "spring.influx-db", matchIfMissing = true, name = "type", havingValue = "USERNAME_PASSWORD")
 	public InfluxDBClient usernamePasswordInfluxDBClient(SpringInfluxDBProperties springInfluxDBProperties) {
 		return InfluxDBClientFactory.create(springInfluxDBProperties.getUrl(), springInfluxDBProperties.getUsername(),


### PR DESCRIPTION
## Sourcery的总结

增强功能：
- 为InfluxDBClient beans添加destroy方法，以确保客户端的正确关闭。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add destroy method to InfluxDBClient beans to ensure proper closure of clients.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management for InfluxDB client instances by ensuring proper cleanup when the application context is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->