### PR TITLE
feat(): 提交k8s脚本[postgresql]

### DIFF
--- a/doc/deploy/kubernetes/postgresql17/postgresql-persistent-volume-claim.yaml
+++ b/doc/deploy/kubernetes/postgresql17/postgresql-persistent-volume-claim.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   storageClassName: manual
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 5Gi

--- a/doc/deploy/kubernetes/postgresql17/postgresql-persistent-volume.yaml
+++ b/doc/deploy/kubernetes/postgresql17/postgresql-persistent-volume.yaml
@@ -28,7 +28,7 @@ spec:
   capacity:
     storage: 5Gi
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
     path: "/opt/data"

--- a/doc/deploy/kubernetes/postgresql17/postgresql-service.yaml
+++ b/doc/deploy/kubernetes/postgresql17/postgresql-service.yaml
@@ -21,10 +21,11 @@ metadata:
   labels:
     app: postgresql
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
     - port: 5432
       targetPort: 5432
+      nodePort: 32345
       protocol: TCP
   selector:
     app: postgresql


### PR DESCRIPTION
## Summary by Sourcery

为在 Kubernetes 上部署配置 PostgreSQL。

部署：
- 将 PostgreSQL 服务类型更改为 NodePort 并公开端口 32345。
- 更新持久卷声明和持久卷以使用 ReadWriteOnce 访问模式，而不是 ReadWriteMany。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure PostgreSQL for deployment on Kubernetes.

Deployment:
- Change PostgreSQL service type to NodePort and expose port 32345.
- Update persistent volume claim and persistent volume to use ReadWriteOnce access mode instead of ReadWriteMany.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated PostgreSQL service configuration to use NodePort, allowing external access.
	- Introduced a specific node port (32345) for traffic forwarding to the service.

- **Changes**
	- Adjusted access modes for PersistentVolumeClaim and PersistentVolume to restrict access to a single writer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->