### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -120,8 +120,6 @@
     <commons-io.version>2.18.0</commons-io.version>
     <!--fastjson版本-->
     <fastjson.version>2.0.53</fastjson.version>
-    <!--httpclient版本-->
-    <httpclient.versin>4.5.14</httpclient.versin>
     <!--commons-text版本-->
     <commons-text.version>1.13.0</commons-text.version>
     <!--commons-lang3版本-->
@@ -383,11 +381,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>${commons-text.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${httpclient.versin}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba</groupId>

--- a/laokou-common/laokou-common-elasticsearch/pom.xml
+++ b/laokou-common/laokou-common-elasticsearch/pom.xml
@@ -17,16 +17,6 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
     </dependency>
   </dependencies>
 

--- a/laokou-sample/laokou-sample-grpc/laokou-sample-grpc-client/src/main/java/org/laokou/start/GrpcClientSampleApp.java
+++ b/laokou-sample/laokou-sample-grpc/laokou-sample-grpc-client/src/main/java/org/laokou/start/GrpcClientSampleApp.java
@@ -28,13 +28,13 @@ import java.net.InetAddress;
  * @author laokou
  */
 @SpringBootApplication(scanBasePackages = { "org.laokou" })
-public class GrpcClientTestApp {
+public class GrpcClientSampleApp {
 
 	@SneakyThrows
 	public static void main(String[] args) {
 		System.setProperty("address", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(),
 				System.getProperty("server.port", "9036")));
-		new SpringApplicationBuilder(GrpcClientTestApp.class).web(WebApplicationType.SERVLET).run(args);
+		new SpringApplicationBuilder(GrpcClientSampleApp.class).web(WebApplicationType.SERVLET).run(args);
 	}
 
 }

--- a/laokou-sample/laokou-sample-grpc/laokou-sample-grpc-server/src/main/java/org/laokou/start/GrpcServerSampleApp.java
+++ b/laokou-sample/laokou-sample-grpc/laokou-sample-grpc-server/src/main/java/org/laokou/start/GrpcServerSampleApp.java
@@ -17,34 +17,24 @@
 
 package org.laokou.start;
 
-import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import lombok.SneakyThrows;
-import org.laokou.common.core.annotation.EnableTaskExecutor;
-import org.laokou.common.netty.annotation.EnableWebSocketServer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import java.net.InetAddress;
 
 /**
- * 系统服务启动类. exposeProxy=true => 使用Cglib代理，在切面中暴露代理对象，进行方法增强
- *
  * @author laokou
  */
-@EnableTaskExecutor
-@EnableWebSocketServer
-@EnableEncryptableProperties
-@EnableConfigurationProperties
 @SpringBootApplication(scanBasePackages = { "org.laokou" })
-public class WsTestApp {
+public class GrpcServerSampleApp {
 
 	@SneakyThrows
 	public static void main(String[] args) {
 		System.setProperty("address", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(),
-				System.getProperty("server.port", "9032")));
-		new SpringApplicationBuilder(WsTestApp.class).web(WebApplicationType.SERVLET).run(args);
+				System.getProperty("server.port", "9035")));
+		new SpringApplicationBuilder(GrpcServerSampleApp.class).web(WebApplicationType.SERVLET).run(args);
 	}
 
 }

--- a/laokou-sample/laokou-sample-seata/laokou-sample-seata-server/pom.xml
+++ b/laokou-sample/laokou-sample-seata/laokou-sample-seata-server/pom.xml
@@ -257,7 +257,7 @@
         <configuration>
           <finalName>${project.artifactId}</finalName>
           <!-- main方法的地址 只需要修改这个地址-->
-          <mainClass>org.apache.seata.server.SeataServerTestApp</mainClass>
+          <mainClass>org.apache.seata.server.SeataServerSampleApp</mainClass>
         </configuration>
         <executions>
           <execution>

--- a/laokou-sample/laokou-sample-seata/laokou-sample-seata-server/src/main/java/org/apache/seata/server/SeataServerSampleApp.java
+++ b/laokou-sample/laokou-sample-seata/laokou-sample-seata-server/src/main/java/org/apache/seata/server/SeataServerSampleApp.java
@@ -27,7 +27,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  */
 @EnableEncryptableProperties
 @SpringBootApplication(scanBasePackages = { "org.apache.seata" })
-public class SeataServerTestApp {
+public class SeataServerSampleApp {
 
 	/// ```properties
 	/// -Dnacos.remote.client.rpc.tls.enable=true
@@ -42,7 +42,7 @@ public class SeataServerTestApp {
 		SslUtil.ignoreSSLTrust();
 		// 配置关闭nacos日志，因为nacos的log4j2导致本项目的日志不输出的问题
 		System.setProperty("nacos.logging.default.config.enabled", "false");
-		SpringApplication.run(SeataServerTestApp.class, args);
+		SpringApplication.run(SeataServerSampleApp.class, args);
 	}
 
 }

--- a/laokou-sample/laokou-sample-shardingsphere/src/main/java/org/laokou/start/ShardingSampleApp.java
+++ b/laokou-sample/laokou-sample-shardingsphere/src/main/java/org/laokou/start/ShardingSampleApp.java
@@ -37,7 +37,7 @@ import java.net.InetAddress;
 @EnableDiscoveryClient(autoRegister = false)
 @SpringBootApplication(scanBasePackages = { "org.laokou" })
 @MapperScan(basePackages = "org.laokou.infrastructure.gatewayimpl.database")
-public class ShardingTestApp {
+public class ShardingSampleApp {
 
 	/// ```properties
 	/// -Dnacos.remote.client.rpc.tls.enable=true
@@ -55,7 +55,7 @@ public class ShardingTestApp {
 		System.setProperty("nacos.logging.default.config.enabled", "false");
 		System.setProperty("address", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(),
 				System.getProperty("server.port", "9033")));
-		new SpringApplicationBuilder(ShardingTestApp.class).web(WebApplicationType.SERVLET).run(args);
+		new SpringApplicationBuilder(ShardingSampleApp.class).web(WebApplicationType.SERVLET).run(args);
 	}
 
 }

--- a/laokou-sample/laokou-sample-tcp/src/main/java/org/laokou/start/TcpSampleApp.java
+++ b/laokou-sample/laokou-sample-tcp/src/main/java/org/laokou/start/TcpSampleApp.java
@@ -18,23 +18,32 @@
 package org.laokou.start;
 
 import lombok.SneakyThrows;
+import org.laokou.common.core.annotation.EnableTaskExecutor;
+import org.laokou.common.netty.annotation.EnableTcpServer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import java.net.InetAddress;
 
 /**
+ * 系统服务启动类. exposeProxy=true => 使用Cglib代理，在切面中暴露代理对象，进行方法增强
+ *
  * @author laokou
  */
+@EnableTcpServer
+@EnableTaskExecutor
+@EnableConfigurationProperties
 @SpringBootApplication(scanBasePackages = { "org.laokou" })
-public class GrpcServerTestApp {
+public class TcpSampleApp {
 
 	@SneakyThrows
 	public static void main(String[] args) {
+		// 01 01 03 05
 		System.setProperty("address", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(),
-				System.getProperty("server.port", "9035")));
-		new SpringApplicationBuilder(GrpcServerTestApp.class).web(WebApplicationType.SERVLET).run(args);
+				System.getProperty("server.port", "9034")));
+		new SpringApplicationBuilder(TcpSampleApp.class).web(WebApplicationType.SERVLET).run(args);
 	}
 
 }

--- a/laokou-sample/laokou-sample-websocket/src/main/java/org/laokou/start/WsSampleApp.java
+++ b/laokou-sample/laokou-sample-websocket/src/main/java/org/laokou/start/WsSampleApp.java
@@ -17,9 +17,10 @@
 
 package org.laokou.start;
 
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import lombok.SneakyThrows;
 import org.laokou.common.core.annotation.EnableTaskExecutor;
-import org.laokou.common.netty.annotation.EnableTcpServer;
+import org.laokou.common.netty.annotation.EnableWebSocketServer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -32,18 +33,18 @@ import java.net.InetAddress;
  *
  * @author laokou
  */
-@EnableTcpServer
 @EnableTaskExecutor
+@EnableWebSocketServer
+@EnableEncryptableProperties
 @EnableConfigurationProperties
 @SpringBootApplication(scanBasePackages = { "org.laokou" })
-public class TcpTestApp {
+public class WsSampleApp {
 
 	@SneakyThrows
 	public static void main(String[] args) {
-		// 01 01 03 05
 		System.setProperty("address", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(),
-				System.getProperty("server.port", "9034")));
-		new SpringApplicationBuilder(TcpTestApp.class).web(WebApplicationType.SERVLET).run(args);
+				System.getProperty("server.port", "9032")));
+		new SpringApplicationBuilder(WsSampleApp.class).web(WebApplicationType.SERVLET).run(args);
 	}
 
 }

--- a/laokou-test/laokou-test-elasticsearch/pom.xml
+++ b/laokou-test/laokou-test-elasticsearch/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.laokou</groupId>
+    <artifactId>laokou-test</artifactId>
+    <version>3.4.1</version>
+  </parent>
+  <artifactId>laokou-test-elasticsearch</artifactId>
+  <version>3.4.1</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ulisesbocchio</groupId>
+      <artifactId>jasypt-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/EsTestApp.java
+++ b/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/EsTestApp.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.test.elasticsearch;
+
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.laokou.common.core.annotation.EnableTaskExecutor;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+@EnableTaskExecutor
+@EnableEncryptableProperties
+@EnableConfigurationProperties
+@EnableAspectJAutoProxy(exposeProxy = true)
+@SpringBootApplication(scanBasePackages = { "org.laokou" })
+public class EsTestApp {
+
+	public static void main(String[] args) throws UnknownHostException {
+		System.setProperty("address", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(),
+				System.getProperty("server.port", "8082")));
+		new SpringApplicationBuilder(EsTestApp.class).web(WebApplicationType.SERVLET).run(args);
+	}
+
+}

--- a/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Project.java
+++ b/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Project.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.test.elasticsearch.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.Data;
+import org.laokou.common.elasticsearch.annotation.Field;
+import org.laokou.common.elasticsearch.annotation.Index;
+import org.laokou.common.elasticsearch.annotation.Type;
+
+import java.io.Serializable;
+
+@Data
+@Index
+public class Project implements Serializable {
+
+	@JsonSerialize(using = ToStringSerializer.class)
+	@Field(type = Type.LONG)
+	private Long businessKey;
+
+}

--- a/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Resource.java
+++ b/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Resource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.test.elasticsearch.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.laokou.common.elasticsearch.annotation.*;
+
+import java.io.Serializable;
+
+@Data
+@Index(setting = @Setting(refreshInterval = "-1"), analysis = @Analysis(
+		filters = { @Filter(name = "pinyin_filter",
+				options = { @Option(key = "type", value = "pinyin"), @Option(key = "keep_full_pinyin", value = "false"),
+						@Option(key = "keep_joined_full_pinyin", value = "true"),
+						@Option(key = "keep_original", value = "true"),
+						@Option(key = "limit_first_letter_length", value = "16"),
+						@Option(key = "remove_duplicated_term", value = "true"),
+						@Option(key = "none_chinese_pinyin_tokenize", value = "false") }) },
+		analyzers = {
+				@Analyzer(name = "ik_pinyin", args = @Args(filter = "pinyin_filter", tokenizer = "ik_max_word")) }))
+@NoArgsConstructor
+@AllArgsConstructor
+public class Resource implements Serializable {
+
+	@Field(type = Type.TEXT, searchAnalyzer = "ik_smart", analyzer = "ik_pinyin")
+	private String name;
+
+}

--- a/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Resp.java
+++ b/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Resp.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.test.elasticsearch.entity;
+
+import lombok.Data;
+import org.laokou.common.elasticsearch.annotation.Field;
+import org.laokou.common.elasticsearch.annotation.Index;
+import org.laokou.common.elasticsearch.annotation.Type;
+
+import java.io.Serializable;
+
+@Data
+@Index
+public class Resp implements Serializable {
+
+	@Field(type = Type.KEYWORD)
+	private String key;
+
+}

--- a/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Result.java
+++ b/laokou-test/laokou-test-elasticsearch/src/main/java/org/laokou/test/elasticsearch/entity/Result.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.test.elasticsearch.entity;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class Result implements Serializable {
+
+	private String id;
+
+	private String name;
+
+}

--- a/laokou-test/laokou-test-elasticsearch/src/main/resources/application.yml
+++ b/laokou-test/laokou-test-elasticsearch/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: laokou-test-elasticsearch
+  profiles:
+    active: @PROFILE-ACTIVE@
+  elasticsearch:
+    uris:
+      - https://elasticsearch:9200
+    username: ENC(svQedUe/LhX4+kE58LA73GTbkn0xR1Nz4P9hIalcloHMkQ8BCur8LiptBZ9DI78f)
+    password: ENC(XVR9OF604T3+2BINpvvCohjr7/KM/vuP3ZgYpu+FX/h3uogFI3sh26h8wHPBE+rj)
+    connection-timeout: 30s
+    socket-timeout: 30s
+server:
+  port: 8082
+
+jasypt:
+  encryptor:
+    password: @JASYPT-ENCRYPTOR-PASSWORD@
+
+logging:
+  config: classpath:log4j2-@PROFILE-ACTIVE@.xml

--- a/laokou-test/laokou-test-elasticsearch/src/main/resources/log4j2-dev.xml
+++ b/laokou-test/laokou-test-elasticsearch/src/main/resources/log4j2-dev.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+-->
+<!--
+    OFF > FATAL > ERROR > WARN > INFO > DEBUG > TRACE > ALL
+    monitorInterval: 间隔秒数，自动检测配置文件的变更和重新配置本身
+ -->
+<Configuration status="INFO" monitorInterval="5">
+  <!-- 变量配置 -->
+  <Properties>
+    <!-- 存放目录 -->
+    <property name="LOG_PATH" value="./logs/test-elasticsearch"/>
+    <!-- 日志文件大小 -->
+    <property name="LOG_ROLL_SIZE" value="100 M"/>
+    <!-- 服务名称 -->
+    <property name="SERVICE_ID" value="laokou-test-elasticsearch"/>
+    <!-- 日志保留30天 -->
+    <property name="LOG_DAYS" value="30"/>
+    <!-- 1天滚动一次 -->
+    <property name="LOG_INTERVAL" value="1"/>
+    <!-- 环境 -->
+    <property name="PROFILE" value="dev"/>
+  </Properties>
+  <Appenders>
+    <!-- 控制台输出 -->
+    <Console name="console" target="SYSTEM_OUT">
+      <JsonLayout complete="false" compact="true" eventEol="true" properties="true" locationInfo="true" includeStacktrace="true" stacktraceAsString="false" objectMessageAsJsonObject="false">
+        <KeyValuePair key="serviceId" value="${SERVICE_ID}"/>
+        <KeyValuePair key="profile" value="${PROFILE}" />
+      </JsonLayout>
+    </Console>
+    <RollingRandomAccessFile name="file" fileName="${LOG_PATH}/${SERVICE_ID}.json"
+                             filePattern="${LOG_PATH}/%d{yyyyMMdd}/${SERVICE_ID}_%d{yyyy-MM-dd}.%i.json.gz"
+                             immediateFlush="false">
+      <Filters>
+        <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+      <JsonLayout complete="true" compact="false" eventEol="true" properties="true" locationInfo="true" includeStacktrace="true" stacktraceAsString="false" objectMessageAsJsonObject="false">
+        <KeyValuePair key="serviceId" value="${SERVICE_ID}"/>
+        <KeyValuePair key="profile" value="${PROFILE}" />
+      </JsonLayout>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="${LOG_INTERVAL}"/>
+        <SizeBasedTriggeringPolicy size="${LOG_ROLL_SIZE}"/>
+      </Policies>
+      <DefaultRolloverStrategy max="${LOG_DAYS}"/>
+    </RollingRandomAccessFile>
+    <Async name="async_file" bufferSize="2000" blocking="false">
+      <AppenderRef ref="file"/>
+    </Async>
+  </Appenders>
+  <!--
+   additivity      => 需不需要打印此logger继承的父logger，false只打印当前logger，true继续打印上一层logger，直至root
+   includeLocation => 显示文件行数，方法名等信息，true显示，false不显示，可以减少日志输出的体积，加快日志写入速度
+ -->
+  <Loggers>
+    <AsyncLogger name="org.laokou" additivity="FALSE" includeLocation="FALSE" level="INFO">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="async_file"/>
+    </AsyncLogger>
+    <AsyncRoot level="INFO" additivity="FALSE" includeLocation="FALSE">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="async_file"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/laokou-test/laokou-test-elasticsearch/src/main/resources/log4j2-prod.xml
+++ b/laokou-test/laokou-test-elasticsearch/src/main/resources/log4j2-prod.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+-->
+<!--
+    OFF > FATAL > ERROR > WARN > INFO > DEBUG > TRACE > ALL
+    monitorInterval: 间隔秒数，自动检测配置文件的变更和重新配置本身
+ -->
+<Configuration status="INFO" monitorInterval="5">
+  <!-- 变量配置 -->
+  <Properties>
+    <!-- 存放目录 -->
+    <property name="LOG_PATH" value="./logs/test-elasticsearch"/>
+    <!-- 日志文件大小 -->
+    <property name="LOG_ROLL_SIZE" value="100 M"/>
+    <!-- 服务名称 -->
+    <property name="SERVICE_ID" value="laokou-test-elasticsearch"/>
+    <!-- 日志保留30天 -->
+    <property name="LOG_DAYS" value="30"/>
+    <!-- 1天滚动一次 -->
+    <property name="LOG_INTERVAL" value="1"/>
+    <!-- 环境 -->
+    <property name="PROFILE" value="prod"/>
+  </Properties>
+  <Appenders>
+    <!-- 控制台输出 -->
+    <Console name="console" target="SYSTEM_OUT">
+      <JsonLayout complete="false" compact="true" eventEol="true" properties="true" locationInfo="false" includeStacktrace="true" stacktraceAsString="true" objectMessageAsJsonObject="true">
+        <KeyValuePair key="serviceId" value="${SERVICE_ID}"/>
+        <KeyValuePair key="profile" value="${PROFILE}" />
+      </JsonLayout>
+    </Console>
+    <RollingRandomAccessFile name="file" fileName="${LOG_PATH}/${SERVICE_ID}.json"
+                             filePattern="${LOG_PATH}/%d{yyyyMMdd}/${SERVICE_ID}_%d{yyyy-MM-dd}.%i.json.gz"
+                             immediateFlush="false">
+      <Filters>
+        <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+      <JsonLayout complete="true" compact="false" eventEol="true" properties="true" locationInfo="false" includeStacktrace="true" stacktraceAsString="true" objectMessageAsJsonObject="true">
+        <KeyValuePair key="serviceId" value="${SERVICE_ID}"/>
+        <KeyValuePair key="profile" value="${PROFILE}" />
+      </JsonLayout>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="${LOG_INTERVAL}"/>
+        <SizeBasedTriggeringPolicy size="${LOG_ROLL_SIZE}"/>
+      </Policies>
+      <DefaultRolloverStrategy max="${LOG_DAYS}"/>
+    </RollingRandomAccessFile>
+    <Async name="async_file" bufferSize="2000" blocking="false">
+      <AppenderRef ref="file"/>
+    </Async>
+  </Appenders>
+  <!--
+   additivity      => 需不需要打印此logger继承的父logger，false只打印当前logger，true继续打印上一层logger，直至root
+   includeLocation => 显示文件行数，方法名等信息，true显示，false不显示，可以减少日志输出的体积，加快日志写入速度
+ -->
+  <Loggers>
+    <AsyncLogger name="org.laokou" additivity="FALSE" includeLocation="FALSE" level="INFO">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="async_file"/>
+    </AsyncLogger>
+    <AsyncRoot level="INFO" additivity="FALSE" includeLocation="FALSE">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="async_file"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/laokou-test/laokou-test-elasticsearch/src/main/resources/log4j2-test.xml
+++ b/laokou-test/laokou-test-elasticsearch/src/main/resources/log4j2-test.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+-->
+<!--
+    OFF > FATAL > ERROR > WARN > INFO > DEBUG > TRACE > ALL
+    monitorInterval: 间隔秒数，自动检测配置文件的变更和重新配置本身
+ -->
+<Configuration status="INFO" monitorInterval="5">
+  <!-- 变量配置 -->
+  <Properties>
+    <!-- 存放目录 -->
+    <property name="LOG_PATH" value="./logs/test-elasticsearch"/>
+    <!-- 日志文件大小 -->
+    <property name="LOG_ROLL_SIZE" value="100 M"/>
+    <!-- 服务名称 -->
+    <property name="SERVICE_ID" value="laokou-test-elasticsearch"/>
+    <!-- 日志保留30天 -->
+    <property name="LOG_DAYS" value="30"/>
+    <!-- 1天滚动一次 -->
+    <property name="LOG_INTERVAL" value="1"/>
+    <!-- 环境 -->
+    <property name="PROFILE" value="test"/>
+  </Properties>
+  <Appenders>
+    <!-- 控制台输出 -->
+    <Console name="console" target="SYSTEM_OUT">
+      <JsonLayout complete="false" compact="true" eventEol="true" properties="true" locationInfo="true" includeStacktrace="true" stacktraceAsString="false" objectMessageAsJsonObject="false">
+        <KeyValuePair key="serviceId" value="${SERVICE_ID}"/>
+        <KeyValuePair key="profile" value="${PROFILE}" />
+      </JsonLayout>
+    </Console>
+    <RollingRandomAccessFile name="file" fileName="${LOG_PATH}/${SERVICE_ID}.json"
+                             filePattern="${LOG_PATH}/%d{yyyyMMdd}/${SERVICE_ID}_%d{yyyy-MM-dd}.%i.json.gz"
+                             immediateFlush="false">
+      <Filters>
+        <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+      <JsonLayout complete="true" compact="false" eventEol="true" properties="true" locationInfo="true" includeStacktrace="true" stacktraceAsString="false" objectMessageAsJsonObject="false">
+        <KeyValuePair key="serviceId" value="${SERVICE_ID}"/>
+        <KeyValuePair key="profile" value="${PROFILE}" />
+      </JsonLayout>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="${LOG_INTERVAL}"/>
+        <SizeBasedTriggeringPolicy size="${LOG_ROLL_SIZE}"/>
+      </Policies>
+      <DefaultRolloverStrategy max="${LOG_DAYS}"/>
+    </RollingRandomAccessFile>
+    <Async name="async_file" bufferSize="2000" blocking="false">
+      <AppenderRef ref="file"/>
+    </Async>
+  </Appenders>
+  <!--
+   additivity      => 需不需要打印此logger继承的父logger，false只打印当前logger，true继续打印上一层logger，直至root
+   includeLocation => 显示文件行数，方法名等信息，true显示，false不显示，可以减少日志输出的体积，加快日志写入速度
+ -->
+  <Loggers>
+    <AsyncLogger name="org.laokou" additivity="FALSE" includeLocation="FALSE" level="INFO">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="async_file"/>
+    </AsyncLogger>
+    <AsyncRoot level="INFO" additivity="FALSE" includeLocation="FALSE">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="async_file"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/laokou-test/laokou-test-elasticsearch/src/test/java/org/laokou/test/elasticsearch/Elasticsearch8ApiTest.java
+++ b/laokou-test/laokou-test-elasticsearch/src/test/java/org/laokou/test/elasticsearch/Elasticsearch8ApiTest.java
@@ -15,36 +15,31 @@
  *
  */
 
-package org.laokou.admin;
+package org.laokou.test.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.indices.IndexState;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.annotation.EnableTaskExecutor;
-import org.laokou.common.i18n.utils.JacksonUtil;
-import org.laokou.common.elasticsearch.annotation.*;
 import org.laokou.common.elasticsearch.entity.Search;
 import org.laokou.common.elasticsearch.template.ElasticsearchTemplate;
 import org.laokou.common.i18n.dto.Page;
+import org.laokou.common.i18n.utils.JacksonUtil;
+import org.laokou.test.elasticsearch.entity.Project;
+import org.laokou.test.elasticsearch.entity.Resource;
+import org.laokou.test.elasticsearch.entity.Resp;
+import org.laokou.test.elasticsearch.entity.Result;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.test.context.TestConstructor;
-import org.springframework.web.context.WebApplicationContext;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author laokou
@@ -52,8 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Slf4j
 @SpringBootTest
 @EnableTaskExecutor
+@RequiredArgsConstructor
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class Elasticsearch8ApiTest extends CommonTest {
+class Elasticsearch8ApiTest {
 
 	private final ElasticsearchClient elasticsearchClient;
 
@@ -61,20 +57,11 @@ class Elasticsearch8ApiTest extends CommonTest {
 
 	private final ElasticsearchAsyncClient elasticsearchAsyncClient;
 
-	Elasticsearch8ApiTest(WebApplicationContext webApplicationContext,
-			OAuth2AuthorizationService oAuth2AuthorizationService, ElasticsearchClient elasticsearchClient,
-			ElasticsearchTemplate elasticsearchTemplate, ElasticsearchAsyncClient elasticsearchAsyncClient) {
-		super(webApplicationContext, oAuth2AuthorizationService);
-		this.elasticsearchClient = elasticsearchClient;
-		this.elasticsearchTemplate = elasticsearchTemplate;
-		this.elasticsearchAsyncClient = elasticsearchAsyncClient;
-	}
-
 	@BeforeEach
 	void contextLoads() {
-		assertNotNull(elasticsearchClient);
-		assertNotNull(elasticsearchAsyncClient);
-		assertNotNull(elasticsearchTemplate);
+		Assertions.assertNotNull(elasticsearchClient);
+		Assertions.assertNotNull(elasticsearchAsyncClient);
+		Assertions.assertNotNull(elasticsearchTemplate);
 	}
 
 	@Test
@@ -135,56 +122,6 @@ class Elasticsearch8ApiTest extends CommonTest {
 	@Test
 	void testDeleteIndexApi() {
 		elasticsearchTemplate.deleteIndex(List.of("laokou_res_1", "laokou_pro_1", "laokou_resp_1"));
-	}
-
-	@Data
-	@Index(setting = @Setting(refreshInterval = "-1"),
-			analysis = @Analysis(
-					filters = { @Filter(name = "pinyin_filter",
-							options = { @Option(key = "type", value = "pinyin"),
-									@Option(key = "keep_full_pinyin", value = "false"),
-									@Option(key = "keep_joined_full_pinyin", value = "true"),
-									@Option(key = "keep_original", value = "true"),
-									@Option(key = "limit_first_letter_length", value = "16"),
-									@Option(key = "remove_duplicated_term", value = "true"),
-									@Option(key = "none_chinese_pinyin_tokenize", value = "false") }) },
-					analyzers = { @Analyzer(name = "ik_pinyin",
-							args = @Args(filter = "pinyin_filter", tokenizer = "ik_max_word")) }))
-	@NoArgsConstructor
-	@AllArgsConstructor
-	static class Resource implements Serializable {
-
-		@Field(type = Type.TEXT, searchAnalyzer = "ik_smart", analyzer = "ik_pinyin")
-		private String name;
-
-	}
-
-	@Data
-	@Index
-	static class Project implements Serializable {
-
-		@JsonSerialize(using = ToStringSerializer.class)
-		@Field(type = Type.LONG)
-		private Long businessKey;
-
-	}
-
-	@Data
-	@Index
-	static class Resp implements Serializable {
-
-		@Field(type = Type.KEYWORD)
-		private String key;
-
-	}
-
-	@Data
-	static class Result implements Serializable {
-
-		private String id;
-
-		private String name;
-
 	}
 
 }

--- a/laokou-test/pom.xml
+++ b/laokou-test/pom.xml
@@ -10,5 +10,11 @@
   </parent>
 
   <artifactId>laokou-test</artifactId>
+  <version>3.4.1</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>laokou-test-elasticsearch</module>
+  </modules>
 
 </project>

--- a/laokou-test/pom.xml
+++ b/laokou-test/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.laokou</groupId>
+    <artifactId>KCloud-Platform-IoT</artifactId>
+    <version>3.4.1</version>
+  </parent>
+
+  <artifactId>laokou-test</artifactId>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <module>laokou-tool</module>
     <module>laokou-cola</module>
     <module>laokou-sample</module>
+    <module>laokou-test</module>
   </modules>
   <name>KCloud-Platform-IoT</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台</description>


### PR DESCRIPTION
## Summary by Sourcery

将Elasticsearch测试迁移到新模块并移除不必要的依赖。

测试：
- 将Elasticsearch测试从`laokou-admin`迁移到新模块`laokou-test-elasticsearch`。
- 在新的测试模块中添加了测试实体`Resource`、`Project`、`Resp`和`Result`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate Elasticsearch tests to a new module and remove unnecessary dependencies.

Tests:
- Migrated Elasticsearch tests from `laokou-admin` to a new module `laokou-test-elasticsearch`.
- Added test entities `Resource`, `Project`, `Resp`, and `Result` to the new test module.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new testing module `laokou-test` to enhance project structure.
	- Added new classes for Elasticsearch integration, including `EsTestApp`, `Project`, `Resource`, `Resp`, and `Result`.
	- New logging configurations for different environments (dev, prod, test) to manage logging behavior effectively.

- **Bug Fixes**
	- Removed incorrect property definition for `httpclient` in the dependency management.

- **Refactor**
	- Updated class names for clarity and consistency across the application (e.g., `GrpcClientTestApp` to `GrpcClientSampleApp`).

- **Chores**
	- Cleaned up dependencies and exclusions in Maven configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->