### PR TITLE
fix: github ci报错

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,14 +23,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: "./ui/package-lock.json"
-      - name: Cache Clean UI
-        run: npm cache clean --force
+          cache: 'pnpm'
+          cache-dependency-path: "./ui/pnpm-lock.yaml"
+      - name: Install pnpm
+        run: npm install -g pnpm
       - name: Install UI
-        run: npm install --prefix ./ui
+        run: pnpm install --prefix ./ui
       - name: Build UI
-        run: npm run build --prefix ./ui
+        run: pnpm build --prefix ./ui
       - name: Build the Docker image
         run: |
           # 登录阿里云镜像仓库


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 在 GitHub CI 工作流程中，使用 pnpm 替代 npm 来安装、构建和缓存 UI 依赖项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Use pnpm instead of npm for installing, building, and caching UI dependencies in the GitHub CI workflow.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use pnpm as the package manager
	- Modified CI configuration to install and use pnpm for dependency management and building

<!-- end of auto-generated comment: release notes by coderabbit.ai -->