### PR TITLE
fix: github ci报错

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+          cache: 'npm'
           cache-dependency-path: "./ui/pnpm-lock.yaml"
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 使用 npm 缓存依赖项，而不是 pnpm。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Use npm for caching dependencies instead of pnpm.

</details>