### PR TITLE
fix: github ci报错

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install UI
-        run: pnpm install --prefix ./ui
+        run: pnpm install --prefix ./ui/pnpm-lock.yaml
       - name: Build UI
-        run: pnpm build --prefix ./ui
+        run: pnpm build --prefix ./ui/pnpm-lock.yaml
       - name: Build the Docker image
         run: |
           # 登录阿里云镜像仓库


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 更正了 pnpm install 和 build 命令中使用的前缀路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Correct the prefix path used in the pnpm install and build commands.

</details>