### PR TITLE
fix: github ci报错

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,12 +25,12 @@ jobs:
           node-version: 18.x
           cache: 'npm'
           cache-dependency-path: "./ui/pnpm-lock.yaml"
-      - name: Clean cache pnpm
-        run: pnpm store prune
+      - name: Install pnpm
+        run: npm install -g pnpm
       - name: Install UI
-        run: pnpm install --prefix ./ui
+        run: pnpm install
       - name: Build UI
-        run: pnpm run build --prefix ./ui
+        run: pnpm build
       - name: Build the Docker image
         run: |
           # 登录阿里云镜像仓库

--- a/ui/README.adoc
+++ b/ui/README.adoc
@@ -11,12 +11,12 @@ pnpm add moment
 
 [source,shell]
 ----
-pnpm run dev
+pnpm dev
 ----
 
 === 部署项目
 
 [source,shell]
 ----
-pnpm run build
+pnpm build
 ----


### PR DESCRIPTION
## Summary by Sourcery

更新 GitHub CI 工作流以全局安装 pnpm 并移除缓存清理步骤。

增强：
- 更新 UI 构建命令以使用全局 pnpm。

持续集成（CI）：
- 在 CI 工作流中全局安装 pnpm。
- 从 CI 工作流中移除 pnpm 缓存清理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub CI workflow to install pnpm globally and remove cache cleaning step.

Enhancements:
- Update UI build commands to use global pnpm.

CI:
- Install pnpm globally in the CI workflow.
- Remove the pnpm cache cleaning step from the CI workflow.

</details>