### PR TITLE
feat: logstash支持loki，基于type切换【elk和loki】

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -138,7 +138,7 @@ image::doc/image/老寇IoT云平台架构图.png[架构图,align=center]
 - 高亮搜索：Elasticsearch
 - 链路跟踪：Jaeger
 - 任务调度：Snail Job
-- 日志分析：EFK
+- 日志分析：EFK & Loki
 - 缓存&分布式锁：Redis & Redisson
 - 统计报表：MongoDB
 - 对象存储：Amazon S3

--- a/doc/deploy/docker-compose/promtail/config/promtail-config.yaml
+++ b/doc/deploy/docker-compose/promtail/config/promtail-config.yaml
@@ -8,21 +8,12 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# https://grafana.org.cn/docs/loki/latest/send-data/promtail/configuration/#example-push-config
 scrape_configs:
-  - job_name: trace-log
-    static_configs:
-      - targets:
-          - localhost
-    pipeline_stages:
-      - match:
-          selector: '{job="trace-log"}'
-          stages:
-            - labels:
-                id:
-                serviceId:
-                traceId:
-                spanId:
-            - timestamp:
-                format: "2006/01/02 15:04:05"
-                source: instant  # 正则提取的字段
-                location: Asia/Shanghai
+  - job_name: trace-log-push
+    loki_push_api:
+      server:
+        http_listen_port: 3500
+        grpc_listen_port: 3600
+      labels:
+        pushserver: trace-log-push

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/RestClientConfig.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/RestClientConfig.java
@@ -49,7 +49,7 @@ public class RestClientConfig {
 		return RestClient.builder().requestFactory(factory).build();
 	}
 
-	@Bean(bootstrap = Bean.Bootstrap.BACKGROUND)
+	@Bean
 	public RestClient restClient() {
 		log.info("{} => Initializing Default RestClient", Thread.currentThread().getName());
 		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();

--- a/laokou-service/laokou-logstash/laokou-logstash-app/src/main/java/org/laokou/logstash/command/TraceLogSaveCmdExe.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-app/src/main/java/org/laokou/logstash/command/TraceLogSaveCmdExe.java
@@ -15,39 +15,24 @@
  *
  */
 
-package org.laokou.logstash.consumer;
+package org.laokou.logstash.command;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.laokou.logstash.api.TraceLogServiceI;
+import org.laokou.logstash.ability.DomainService;
 import org.laokou.logstash.dto.TraceLogSaveCmd;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 /**
  * @author laokou
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class TraceLogConsumer {
+public class TraceLogSaveCmdExe {
 
-	private final TraceLogServiceI traceLogServiceI;
+	private final DomainService domainService;
 
-	@KafkaListener(topics = "laokou_trace_topic", groupId = "laokou_trace_consumer_group")
-	public void kafkaConsumer(List<String> messages, Acknowledgment ack) {
-		try {
-			traceLogServiceI.save(new TraceLogSaveCmd(messages));
-		}
-		catch (Exception e) {
-			log.error("分布式链路写入失败，错误信息：{}", e.getMessage());
-		}
-		finally {
-			ack.acknowledge();
-		}
+	public void executeVoid(TraceLogSaveCmd cmd) {
+		domainService.create(cmd.getMessages());
 	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-app/src/main/java/org/laokou/logstash/service/TraceLogServiceImpl.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-app/src/main/java/org/laokou/logstash/service/TraceLogServiceImpl.java
@@ -15,39 +15,26 @@
  *
  */
 
-package org.laokou.logstash.consumer;
+package org.laokou.logstash.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.laokou.logstash.api.TraceLogServiceI;
+import org.laokou.logstash.command.TraceLogSaveCmdExe;
 import org.laokou.logstash.dto.TraceLogSaveCmd;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.stereotype.Component;
-
-import java.util.List;
+import org.springframework.stereotype.Service;
 
 /**
  * @author laokou
  */
-@Slf4j
-@Component
+@Service
 @RequiredArgsConstructor
-public class TraceLogConsumer {
+public class TraceLogServiceImpl implements TraceLogServiceI {
 
-	private final TraceLogServiceI traceLogServiceI;
+	private final TraceLogSaveCmdExe traceLogSaveCmdExe;
 
-	@KafkaListener(topics = "laokou_trace_topic", groupId = "laokou_trace_consumer_group")
-	public void kafkaConsumer(List<String> messages, Acknowledgment ack) {
-		try {
-			traceLogServiceI.save(new TraceLogSaveCmd(messages));
-		}
-		catch (Exception e) {
-			log.error("分布式链路写入失败，错误信息：{}", e.getMessage());
-		}
-		finally {
-			ack.acknowledge();
-		}
+	@Override
+	public void save(TraceLogSaveCmd cmd) {
+		traceLogSaveCmdExe.executeVoid(cmd);
 	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-client/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -16,6 +16,10 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-i18n</artifactId>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-logstash/laokou-logstash-client/src/main/java/org/laokou/logstash/api/TraceLogServiceI.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/src/main/java/org/laokou/logstash/api/TraceLogServiceI.java
@@ -15,12 +15,15 @@
  *
  */
 
-package org.laokou.logstash.common.support;
+package org.laokou.logstash.api;
 
-import java.util.List;
+import org.laokou.logstash.dto.TraceLogSaveCmd;
 
-public interface TraceLogStorage {
+/**
+ * @author laokou
+ */
+public interface TraceLogServiceI {
 
-	void batchSave(List<String> messages);
+	void save(TraceLogSaveCmd cmd);
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-client/src/main/java/org/laokou/logstash/dto/TraceLogSaveCmd.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/src/main/java/org/laokou/logstash/dto/TraceLogSaveCmd.java
@@ -15,12 +15,23 @@
  *
  */
 
-package org.laokou.logstash.common.support;
+package org.laokou.logstash.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.laokou.common.i18n.dto.CommonCommand;
 
 import java.util.List;
 
-public interface TraceLogStorage {
+/**
+ * @author laokou
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TraceLogSaveCmd extends CommonCommand {
 
-	void batchSave(List<String> messages);
+	private List<String> messages;
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-client/src/main/java/org/laokou/logstash/dto/clientobject/LokiPushDTO.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/src/main/java/org/laokou/logstash/dto/clientobject/LokiPushDTO.java
@@ -15,12 +15,51 @@
  *
  */
 
-package org.laokou.logstash.common.support;
+package org.laokou.logstash.dto.clientobject;
+
+import lombok.Data;
+import org.laokou.common.i18n.dto.ClientObject;
 
 import java.util.List;
 
-public interface TraceLogStorage {
+/**
+ * @author laokou
+ */
+@Data
+public class LokiPushDTO extends ClientObject {
 
-	void batchSave(List<String> messages);
+	private List<Stream> streams;
+
+	@Data
+	public static class Label {
+
+		private String id;
+
+		private String serviceId;
+
+		private String profile;
+
+		private String traceId;
+
+		private String spanId;
+
+		private String address;
+
+		private String level;
+
+		private String threadName;
+
+		private String packageName;
+
+	}
+
+	@Data
+	public static class Stream {
+
+		private Label stream;
+
+		private List<List<String>> values;
+
+	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-domain/src/main/java/org/laokou/logstash/ability/DomainService.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-domain/src/main/java/org/laokou/logstash/ability/DomainService.java
@@ -15,14 +15,10 @@
  *
  */
 
-package org.laokou.logstash.consumer;
+package org.laokou.logstash.ability;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.laokou.logstash.api.TraceLogServiceI;
-import org.laokou.logstash.dto.TraceLogSaveCmd;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
+import org.laokou.logstash.gateway.TraceLogGateway;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -30,24 +26,14 @@ import java.util.List;
 /**
  * @author laokou
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class TraceLogConsumer {
+public class DomainService {
 
-	private final TraceLogServiceI traceLogServiceI;
+	private final TraceLogGateway traceLogGateway;
 
-	@KafkaListener(topics = "laokou_trace_topic", groupId = "laokou_trace_consumer_group")
-	public void kafkaConsumer(List<String> messages, Acknowledgment ack) {
-		try {
-			traceLogServiceI.save(new TraceLogSaveCmd(messages));
-		}
-		catch (Exception e) {
-			log.error("分布式链路写入失败，错误信息：{}", e.getMessage());
-		}
-		finally {
-			ack.acknowledge();
-		}
+	public void create(List<String> messages) {
+		traceLogGateway.create(messages);
 	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-domain/src/main/java/org/laokou/logstash/gateway/TraceLogGateway.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-domain/src/main/java/org/laokou/logstash/gateway/TraceLogGateway.java
@@ -15,12 +15,15 @@
  *
  */
 
-package org.laokou.logstash.common.support;
+package org.laokou.logstash.gateway;
 
 import java.util.List;
 
-public interface TraceLogStorage {
+/**
+ * @author laokou
+ */
+public interface TraceLogGateway {
 
-	void batchSave(List<String> messages);
+	void create(List<String> messages);
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/common/config/StorageConfig.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/common/config/StorageConfig.java
@@ -24,6 +24,7 @@ import org.laokou.logstash.common.support.TraceLogStorage;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 
 /**
  * @author laokou
@@ -39,8 +40,8 @@ public class StorageConfig {
 
 	@Bean("traceLogStorage")
 	@ConditionalOnProperty(prefix = "storage", matchIfMissing = true, name = "type", havingValue = "LOKI")
-	public TraceLogStorage traceLogLokiStorage() {
-		return new TraceLogLokiStorage();
+	public TraceLogStorage traceLogLokiStorage(RestClient restClient, LokiProperties lokiProperties) {
+		return new TraceLogLokiStorage(restClient, lokiProperties);
 	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/common/support/AbstractTraceLogStorage.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/common/support/AbstractTraceLogStorage.java
@@ -23,7 +23,7 @@ import org.laokou.common.i18n.common.constant.StringConstant;
 import org.laokou.common.i18n.utils.DateUtil;
 import org.laokou.common.i18n.utils.JacksonUtil;
 import org.laokou.common.i18n.utils.StringUtil;
-import org.laokou.logstash.gateway.database.dataobject.TraceLogIndex;
+import org.laokou.logstash.gatewayimpl.database.dataobject.TraceLogIndex;
 
 @Slf4j
 public abstract class AbstractTraceLogStorage implements TraceLogStorage {

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/convertor/TraceLogConvertor.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/convertor/TraceLogConvertor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022-2024 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.logstash.convertor;
+
+import org.laokou.common.i18n.utils.DateUtil;
+import org.laokou.logstash.dto.clientobject.LokiPushDTO;
+import org.laokou.logstash.gatewayimpl.database.dataobject.TraceLogIndex;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author laokou
+ */
+public final class TraceLogConvertor {
+
+	private TraceLogConvertor() {
+	}
+
+	public static LokiPushDTO toDTO(List<TraceLogIndex> traceLogIndexList) {
+		LokiPushDTO lokiPushDTO = new LokiPushDTO();
+		List<LokiPushDTO.Stream> streams = traceLogIndexList.stream().map(TraceLogConvertor::toDTO).toList();
+		lokiPushDTO.setStreams(streams);
+		return lokiPushDTO;
+	}
+
+	private static LokiPushDTO.Stream toDTO(TraceLogIndex traceLogIndex) {
+		Instant instant = DateUtil.parsInstant(traceLogIndex.getDateTime(), DateUtil.YYYY_B_MM_B_DD_HH_R_MM_R_SS_D_SSS);
+		// 毫秒转纳秒
+		String lokiTimestamp = String.valueOf(instant.toEpochMilli() * 1000000);
+		LokiPushDTO.Label label = new LokiPushDTO.Label();
+		label.setServiceId(traceLogIndex.getServiceId());
+		label.setProfile(traceLogIndex.getProfile());
+		label.setTraceId(traceLogIndex.getTraceId());
+		label.setSpanId(traceLogIndex.getSpanId());
+		label.setAddress(traceLogIndex.getAddress());
+		label.setLevel(traceLogIndex.getLevel());
+		label.setThreadName(traceLogIndex.getThreadName());
+		label.setPackageName(traceLogIndex.getPackageName());
+		LokiPushDTO.Stream stream = new LokiPushDTO.Stream();
+		List<List<String>> values = new ArrayList<>(2);
+		List<String> message = List.of(lokiTimestamp, traceLogIndex.getMessage());
+		List<String> stacktrace = List.of(lokiTimestamp, traceLogIndex.getStacktrace());
+		values.add(message);
+		values.add(stacktrace);
+		stream.setStream(label);
+		stream.setValues(values);
+		return stream;
+	}
+
+}

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/gatewayimpl/TraceLogGatewayImpl.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/gatewayimpl/TraceLogGatewayImpl.java
@@ -15,14 +15,11 @@
  *
  */
 
-package org.laokou.logstash.consumer;
+package org.laokou.logstash.gatewayimpl;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.laokou.logstash.api.TraceLogServiceI;
-import org.laokou.logstash.dto.TraceLogSaveCmd;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
+import org.laokou.logstash.common.support.TraceLogStorage;
+import org.laokou.logstash.gateway.TraceLogGateway;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -30,24 +27,15 @@ import java.util.List;
 /**
  * @author laokou
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class TraceLogConsumer {
+public class TraceLogGatewayImpl implements TraceLogGateway {
 
-	private final TraceLogServiceI traceLogServiceI;
+	private final TraceLogStorage traceLogStorage;
 
-	@KafkaListener(topics = "laokou_trace_topic", groupId = "laokou_trace_consumer_group")
-	public void kafkaConsumer(List<String> messages, Acknowledgment ack) {
-		try {
-			traceLogServiceI.save(new TraceLogSaveCmd(messages));
-		}
-		catch (Exception e) {
-			log.error("分布式链路写入失败，错误信息：{}", e.getMessage());
-		}
-		finally {
-			ack.acknowledge();
-		}
+	@Override
+	public void create(List<String> messages) {
+		traceLogStorage.batchSave(messages);
 	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/gatewayimpl/database/dataobject/TraceLogIndex.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/gatewayimpl/database/dataobject/TraceLogIndex.java
@@ -15,7 +15,7 @@
  *
  */
 
-package org.laokou.logstash.gateway.database.dataobject;
+package org.laokou.logstash.gatewayimpl.database.dataobject;
 
 import lombok.Data;
 import org.laokou.common.elasticsearch.annotation.Field;

--- a/laokou-service/laokou-logstash/laokou-logstash-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-logstash/laokou-logstash-start/src/main/resources/application.yml
@@ -56,3 +56,6 @@ logging:
 
 storage:
   type: elasticsearch
+
+loki:
+  url: http://loki:3100/loki/api/v1/push

--- a/laokou-service/laokou-logstash/laokou-logstash-start/src/test/java/org/laokou/logstash/KafkaTest.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-start/src/test/java/org/laokou/logstash/KafkaTest.java
@@ -20,7 +20,10 @@ package org.laokou.logstash;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.laokou.common.i18n.utils.DateUtil;
+import org.laokou.common.i18n.utils.JacksonUtil;
 import org.laokou.common.kafka.template.DefaultKafkaTemplate;
+import org.laokou.logstash.gatewayimpl.database.dataobject.TraceLogIndex;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
 
@@ -37,7 +40,20 @@ class KafkaTest {
 
 	@Test
 	void kafkaSenderTest() {
-		defaultKafkaTemplate.send("laokou_trace_topic", "测试数据");
+		TraceLogIndex index = new TraceLogIndex();
+		index.setId("1");
+		index.setServiceId("laokou-logstash");
+		index.setProfile("dev");
+		index.setDateTime(DateUtil.format(DateUtil.nowInstant(), DateUtil.YYYY_B_MM_B_DD_HH_R_MM_R_SS_D_SSS));
+		index.setTraceId("1");
+		index.setSpanId("1");
+		index.setAddress("127.0.0.1");
+		index.setLevel("INFO");
+		index.setThreadName("main");
+		index.setPackageName("org.laokou.logstash");
+		index.setMessage("{\"testValue\": \"123456\"}");
+		index.setStacktrace("");
+		defaultKafkaTemplate.send("laokou_trace_topic", JacksonUtil.toJsonStr(index));
 	}
 
 }


### PR DESCRIPTION
## Summary by Sourcery

添加对 Loki 作为日志后端的支持，并根据配置在 Elasticsearch 和 Loki 之间实现切换。

新特性：
- 添加对 Loki 作为日志后端的支持。

测试：
- 更新 Kafka 测试以包含更全面的测试数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Loki as a logging backend and implement switching between Elasticsearch and Loki based on configuration.

New Features:
- Added support for Loki as a logging backend.

Tests:
- Updated Kafka test to include more comprehensive test data.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced logging infrastructure with Loki integration
  - Added support for structured trace log management
  - Implemented new log storage and conversion mechanisms

- **Infrastructure Changes**
  - Updated Promtail configuration for log pushing
  - Modified log storage and processing workflows
  - Introduced new service layers for trace log handling

- **Configuration Updates**
  - Added Loki URL configuration for log pushing
  - Updated dependency management for logging components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->