### PR TITLE
feat: 修改前端项目启动【dev环境】文档

### DIFF
--- a/archive/docs/01.指南/04.前端指南/00.前端启动.md
+++ b/archive/docs/01.指南/04.前端指南/00.前端启动.md
@@ -56,6 +56,9 @@ pnpm build
 
 ### 后端联调
 
+注意：<font color="red">dev环境，请使用http://</font>
+注意：<font color="red">test/prod环境，请使用https://</font>
+
 <img src="/img/前端启动/img_2.png"/>
 
 我是老寇，我们下次再见啦！

--- a/doc/deploy/docker-compose/docker-compose-dev.yml
+++ b/doc/deploy/docker-compose/docker-compose-dev.yml
@@ -89,6 +89,25 @@ services:
       - laokou_network
     depends_on:
       - rocketmq-namesrv
+  # 账号密码 admin/admin
+  rocketmq-dashboard:
+    image: apacherocketmq/rocketmq-dashboard:1.0.0
+    container_name: rocketmq-dashboard
+    # 保持容器在没有守护程序的情况下运行
+    tty: true
+    restart: always
+    privileged: true
+    ports:
+      - "8089:8080"
+    environment:
+      - JAVA_OPTS=-Xmx256M -Xms256M -Xmn128M -Drocketmq.namesrv.addr=rocketmq-namesrv:9876
+      - TZ=Asia/Shanghai
+      # 开启登录认证
+      - ROCKETMQ_CONFIG_LOGIN_REQUIRED=true
+    networks:
+      - laokou_network
+    depends_on:
+      - rocketmq-namesrv
 networks:
   laokou_network:
     driver: bridge

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2ResourceServerConfig.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2ResourceServerConfig.java
@@ -33,7 +33,6 @@ import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.session.security.SpringSessionBackedSessionRegistry;
 
 import static org.laokou.common.security.config.OAuth2ResourceServerConfig.customizer;
-import static org.springframework.security.config.http.SessionCreationPolicy.IF_REQUIRED;
 
 /**
  * 资源服务器配置.
@@ -66,13 +65,13 @@ class OAuth2ResourceServerConfig {
 	) throws Exception {
 		return http
 			// 只会在需要时创建 HttpSession【默认配置】
-			.sessionManagement(config -> config
-				.sessionCreationPolicy(IF_REQUIRED)
-				.invalidSessionStrategy(sessionInvalidStrategy)
-				// 最大会话1
-				.maximumSessions(1)
-				.sessionRegistry(springSessionBackedSessionRegistry)
-				.expiredSessionStrategy(sessionExpiredStrategy))
+			//  .sessionManagement(config -> config
+			// 	.sessionCreationPolicy(IF_REQUIRED)
+			// 	.invalidSessionStrategy(sessionInvalidStrategy)
+			// 	// 最大会话1
+			// 	.maximumSessions(1)
+			// 	.sessionRegistry(springSessionBackedSessionRegistry)
+			// 	.expiredSessionStrategy(sessionExpiredStrategy))
 			.headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
 				.httpStrictTransportSecurity(hsts -> hsts
 					.includeSubDomains(true)


### PR DESCRIPTION
## Summary by Sourcery

将 RocketMQ 仪表板添加到开发环境，并更新 OAuth2 资源服务器配置以移除会话管理。

增强：
- 在 OAuth2 资源服务器配置中移除会话管理。

部署：
- 在开发环境的 docker-compose 配置中添加 RocketMQ 仪表板服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add RocketMQ Dashboard to the development environment and update the OAuth2 resource server configuration to remove session management.

Enhancements:
- Remove session management in OAuth2 resource server configuration.

Deployment:
- Add RocketMQ Dashboard service to docker-compose configuration for development environment.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added notes about using `http://` in development and `https://` in test and production environments

- **Configuration**
  - Added RocketMQ Dashboard service to Docker Compose development configuration
    - Exposed port 8089
    - Configured with specific environment settings
    - Enabled login authentication

- **Security**
  - Disabled session management configuration in OAuth2 resource server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->