### PR TITLE
feat: 提交okhttp【开启ssl验证】

### DIFF
--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -158,6 +158,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.freefair.okhttp-spring-boot</groupId>
+        <artifactId>okhttp4-spring-boot-starter</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.laokou</groupId>
         <artifactId>laokou-logstash-client</artifactId>
         <version>${laokou.version}</version>

--- a/laokou-common/laokou-common-core/pom.xml
+++ b/laokou-common/laokou-common-core/pom.xml
@@ -127,6 +127,10 @@
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.freefair.okhttp-spring-boot</groupId>
+      <artifactId>okhttp4-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
       <scope>test</scope>

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/RestClientConfig.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/RestClientConfig.java
@@ -38,7 +38,7 @@ public class RestClientConfig {
 	public RestClient restClient() {
 		log.info("{} => Initializing Default RestClient", Thread.currentThread().getName());
 		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-		factory.setHttpClient(getHttpClient(true));
+		factory.setHttpClient(getHttpClient());
 		return RestClient.builder().requestFactory(factory).build();
 	}
 

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/utils/OkHttpUtil.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/utils/OkHttpUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.core.utils;
+
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.laokou.common.i18n.utils.ObjectUtil;
+import org.laokou.common.i18n.utils.SslUtil;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.laokou.common.i18n.common.constant.StringConstant.EMPTY;
+
+/**
+ * @author laokou
+ */
+@Slf4j
+public final class OkHttpUtil {
+
+	private static final OkHttpClient CLIENT = getOkHttpClient();
+
+	private OkHttpUtil() {
+	}
+
+	public static String doFormDataPost(String url, Map<String, String> params, Map<String, String> headers) {
+		FormBody.Builder builder = new FormBody.Builder();
+		if (MapUtil.isNotEmpty(params)) {
+			params.forEach(builder::add);
+		}
+		Request request = new Request.Builder().url(url).headers(Headers.of(headers)).post(builder.build()).build();
+		try (Response response = CLIENT.newCall(request).execute()) {
+			ResponseBody body = response.body();
+			return ObjectUtil.isNotNull(body) ? body.string() : EMPTY;
+		}
+		catch (IOException e) {
+			log.error("调用失败，错误信息：{}", e.getMessage());
+		}
+		return EMPTY;
+	}
+
+	private static OkHttpClient getOkHttpClient() {
+		return new OkHttpClient.Builder()
+			.sslSocketFactory(SslUtil.sslContext().getSocketFactory(), SslUtil.DisableValidationTrustManager.INSTANCE)
+			.hostnameVerifier((hostname, session) -> true)
+			.connectTimeout(Duration.ofSeconds(10))
+			.readTimeout(Duration.ofSeconds(10))
+			.writeTimeout(Duration.ofSeconds(10))
+			.pingInterval(Duration.ZERO)
+			.connectionPool(new ConnectionPool(5, Duration.ofMinutes(5).toNanos(), TimeUnit.NANOSECONDS))
+			.build();
+	}
+
+	@PreDestroy
+	public void destroy() {
+		CLIENT.connectionPool().evictAll();
+	}
+
+}

--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/utils/JacksonUtil.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/utils/JacksonUtil.java
@@ -50,12 +50,16 @@ public final class JacksonUtil {
 	/**
 	 * 映射器配置.
 	 */
-	private static final ObjectMapper MAPPER = new ObjectMapper()
-		// 没有的属性不报错
-		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-		.registerModule(new JavaTimeModule());
+	private static final ObjectMapper MAPPER = getMapper();
 
 	private JacksonUtil() {
+	}
+
+	private static ObjectMapper getMapper() {
+		return new ObjectMapper()
+			// 没有的属性不报错
+			.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+			.registerModule(new JavaTimeModule());
 	}
 
 	/**

--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/utils/SslUtil.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/utils/SslUtil.java
@@ -60,7 +60,9 @@ public final class SslUtil {
 		HttpsURLConnection.setDefaultHostnameVerifier((hostname, sslSession) -> true);
 	}
 
-	private static class DisableValidationTrustManager implements X509TrustManager {
+	public static class DisableValidationTrustManager implements X509TrustManager {
+
+		public static final X509TrustManager INSTANCE = new DisableValidationTrustManager();
 
 		public DisableValidationTrustManager() {
 		}

--- a/laokou-common/laokou-common-sms/src/main/java/org/laokou/common/sms/service/impl/GYYSmsServiceImpl.java
+++ b/laokou-common/laokou-common-sms/src/main/java/org/laokou/common/sms/service/impl/GYYSmsServiceImpl.java
@@ -92,7 +92,7 @@ public class GYYSmsServiceImpl extends AbstractSmsServiceImpl {
 		Map<String, String> params = Map.of("mobile", mobile, "param", paramValue, "smsSignId", signId, "templateId",
 			templateId);
 		String paramString = JacksonUtil.toJsonStr(Map.of("mobile", SensitiveUtil.formatMobile(mobile,3, 6), "content", TemplateUtil.getContent(TEMPLATES.get(templateId), param)));
-		String json = HttpUtil.doFormDataPost(URL, params, headers, true);
+		String json = HttpUtil.doFormDataPost(URL, params, headers);
 		JsonNode jsonNode = JacksonUtil.readTree(json);
 		int code = jsonNode.get("code").asInt();
 		if (code != SendStatus.OK.getCode()) {

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -26,10 +26,7 @@ import org.laokou.auth.dto.CaptchaSendCmd;
 import org.laokou.auth.dto.TokenRemoveCmd;
 import org.laokou.auth.dto.clientobject.CaptchaCO;
 import org.laokou.common.core.annotation.EnableTaskExecutor;
-import org.laokou.common.core.utils.HttpUtil;
-import org.laokou.common.core.utils.IdGenerator;
-import org.laokou.common.core.utils.MDCUtil;
-import org.laokou.common.core.utils.ThreadUtil;
+import org.laokou.common.core.utils.*;
 import org.laokou.common.crypto.utils.RSAUtil;
 import org.laokou.common.i18n.utils.DateUtil;
 import org.laokou.common.i18n.utils.JacksonUtil;
@@ -259,7 +256,7 @@ class OAuth2ApiTest {
 					"urn:ietf:params:oauth:grant-type:device_code");
 			Map<String, String> headers = Collections.singletonMap("Authorization",
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = HttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("设备授权码认证模式，返回信息：{}", json);
 			String accessToken = JacksonUtil.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtil.readTree(json).get("refresh_token").asText();
@@ -277,7 +274,7 @@ class OAuth2ApiTest {
 			Map<String, String> params = Map.of("grant_type", "client_credentials");
 			Map<String, String> headers = Collections.singletonMap("Authorization",
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = HttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("客户端认证模式，返回信息：{}", json);
 			String accessToken = JacksonUtil.readTree(json).get("access_token").asText();
 			Assert.isTrue(StringUtil.isNotEmpty(accessToken), "access token is empty");
@@ -295,7 +292,7 @@ class OAuth2ApiTest {
 					"authorization_code");
 			Map<String, String> headers = Collections.singletonMap("Authorization",
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = HttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("授权码认证模式，返回信息：{}", json);
 			String accessToken = JacksonUtil.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtil.readTree(json).get("refresh_token").asText();
@@ -321,7 +318,7 @@ class OAuth2ApiTest {
 			Map<String, String> headers = Map.of("Authorization",
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=", "User-Agent",
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = HttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("手机号认证，返回信息：{}", json);
 			String accessToken = JacksonUtil.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtil.readTree(json).get("refresh_token").asText();
@@ -341,7 +338,7 @@ class OAuth2ApiTest {
 			Map<String, String> headers = Map.of("Authorization",
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=", "User-Agent",
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = HttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("邮箱认证，返回信息：{}", json);
 			String accessToken = JacksonUtil.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtil.readTree(json).get("refresh_token").asText();
@@ -363,7 +360,7 @@ class OAuth2ApiTest {
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=", "trace-id",
 					String.valueOf(IdGenerator.defaultSnowflakeId()), "User-Agent",
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = OkHttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("用户名密码认证模式，返回信息：{}", json);
 			String accessToken = JacksonUtil.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtil.readTree(json).get("refresh_token").asText();
@@ -381,7 +378,7 @@ class OAuth2ApiTest {
 			Map<String, String> params = Map.of("refresh_token", refreshToken, "grant_type", "refresh_token");
 			Map<String, String> headers = Collections.singletonMap("Authorization",
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=");
-			String json = HttpUtil.doFormDataPost(apiUrl, params, headers, disabledSsl());
+			String json = HttpUtil.doFormDataPost(apiUrl, params, headers);
 			log.info("刷新令牌模式，返回信息；{}", json);
 			return JacksonUtil.readTree(json).get("access_token").asText();
 		}


### PR DESCRIPTION
## Summary by Sourcery

启用 OkHttp 请求的 SSL 验证。

新功能：
- 引入新的 OkHttpUtil 类用于发起 HTTP 请求。

增强：
- 使用 OkHttp 替代 HttpClient 进行 HTTP 请求。

测试：
- 更新测试以使用 OkHttpUtil。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable SSL verification for OkHttp requests.

New Features:
- Introduce a new OkHttpUtil class for making HTTP requests.

Enhancements:
- Use OkHttp for HTTP requests instead of HttpClient.

Tests:
- Update tests to use OkHttpUtil.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated advanced HTTP support with OkHttp, enabling robust form-data POST operations across services.

- **Refactor**
  - Consolidated HTTP client management with simplified request configurations and enhanced resource cleanup.
  - Updated SMS and authentication workflows by removing legacy SSL configuration flags.

- **Chores**
  - Updated project dependencies to support improved HTTP operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->