### PR TITLE
Test环境SSL 异常对应

### DIFF
--- a/laokou-cloud/laokou-nacos/pom.xml
+++ b/laokou-cloud/laokou-nacos/pom.xml
@@ -48,6 +48,10 @@
     <hessian.version>3.5.5</hessian.version>
     <!--commons-lang3版本-->
     <commons-lang3.version>3.17.0</commons-lang3.version>
+    <!-- bcprov-jdk18on版本 -->
+    <bcprov.version>1.80</bcprov.version>
+    <!-- bcpkix-jdk18on版本 -->
+    <bcpkix.version>1.80</bcpkix.version>
   </properties>
 
   <dependencies>
@@ -282,6 +286,16 @@
       <groupId>com.alipay.sofa</groupId>
       <artifactId>hessian</artifactId>
       <version>${hessian.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bcprov.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bcpkix.version}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -152,6 +152,10 @@
     <annotations-api.version>6.0.53</annotations-api.version>
     <!--influxdb-client-java版本-->
     <influxdb-client-java.version>7.2.0</influxdb-client-java.version>
+    <!-- bcprov-jdk18on版本 -->
+    <bcprov.version>1.80</bcprov.version>
+    <!-- bcpkix-jdk18on版本 -->
+    <bcpkix.version>1.80</bcpkix.version>
   </properties>
 
   <!-- 定义全局jar版本,模块使用需要再次引入但不用写版本号 -->
@@ -1054,6 +1058,16 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         <version>${spring-boot-starter-oauth2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bcprov.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bcpkix.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/laokou-common/laokou-common-nacos/pom.xml
+++ b/laokou-common/laokou-common-nacos/pom.xml
@@ -137,6 +137,14 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Test环境SSL 异常对应
name 'grpcSdkServer': Invocation of init method failed; nested exception is java.lang.IllegalArgumentException: Input stream does not contain valid private key.
或者
com.alibaba.nacos.common.remote.client.grpc.GrpcClient : [3d43cfd0-773f-4047-91c3-76fa01ca49fc_config-0]Fail to connect to server!,error=java.lang.RuntimeException: Unable to build SslContext

## Summary by Sourcery

Bug 修复：
- 解决测试环境中的 SSL 异常，处理诸如"初始化方法调用失败；嵌套异常是 java.lang.IllegalArgumentException: 输入流不包含有效的私钥"和"无法构建 SslContext"等问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve SSL exceptions in the test environment, addressing issues like "Invocation of init method failed; nested exception is java.lang.IllegalArgumentException: Input stream does not contain valid private key" and "Unable to build SslContext".

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced encryption and security measures have been integrated to provide improved data protection and more robust safeguarding of user information.
	- Added support for Bouncy Castle cryptography libraries to enhance cryptographic functionalities across projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->