### PR TITLE
feat: 提取重置密码模态，使其代码可维护

### DIFF
--- a/ui/src/pages/Sys/Permission/ResetPwdDrawer.tsx
+++ b/ui/src/pages/Sys/Permission/ResetPwdDrawer.tsx
@@ -1,0 +1,59 @@
+import { DrawerForm, ProFormText } from '@ant-design/pro-components';
+import { message } from 'antd';
+import { resetPwdV3 } from '@/services/admin/user';
+
+interface ResetPwdDrawerProps {
+	visible: boolean;
+	setVisible: (visible: boolean) => void;
+	primaryKey: number | undefined;
+}
+
+export const ResetPwdDrawer: React.FC<ResetPwdDrawerProps> = ({ visible, setVisible, primaryKey }) => {
+	const handleFinish = async (values: any) => {
+		const { password, confirmPassword } = values;
+		if (password !== confirmPassword) {
+			message.error("两次密码不一致");
+			return false;
+		}
+		resetPwdV3({ id: primaryKey, password }).then(res => {
+			if (res.code === 'OK') {
+				message.success("密码重置成功");
+				setVisible(false);
+				return true;
+			}
+		});
+		return false;
+	};
+
+	return (
+		<DrawerForm
+			open={visible}
+			title="重置密码"
+			drawerProps={{
+				destroyOnClose: true,
+				closable: true,
+				maskClosable: true,
+			}}
+			onOpenChange={setVisible}
+			onFinish={handleFinish}
+		>
+			<ProFormText name="id" label="ID" hidden />
+			<ProFormText.Password
+				name="password"
+				label="密码"
+				tooltip="默认密码：laokou123"
+				placeholder="请输入密码"
+				fieldProps={{ autoComplete: 'new-password' }}
+				rules={[{ required: true, message: '请输入密码' }]}
+			/>
+			<ProFormText.Password
+				name="confirmPassword"
+				label="确认密码"
+				tooltip="默认密码：laokou123"
+				placeholder="请输入确认密码"
+				fieldProps={{ autoComplete: 'new-password' }}
+				rules={[{ required: true, message: '请输入确认密码' }]}
+			/>
+		</DrawerForm>
+	);
+};

--- a/ui/src/pages/Sys/Permission/user.tsx
+++ b/ui/src/pages/Sys/Permission/user.tsx
@@ -4,15 +4,16 @@ import {
 	ProFormText, ProFormTreeSelect,
 } from '@ant-design/pro-components';
 import {ProTable} from '@ant-design/pro-components';
-import { pageV3, removeV3, saveV3, getByIdV3, modifyV3, resetPwdV3 } from '@/services/admin/user';
+import { pageV3, removeV3, saveV3, getByIdV3, modifyV3 } from '@/services/admin/user';
 import {useEffect, useRef, useState} from "react";
 import {TableRowSelection} from "antd/es/table/interface";
 import {Button, message, Modal, Space, Switch, Tag} from 'antd';
-import { DeleteOutlined, PlusOutlined, UserOutlined } from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import {v7 as uuidV7} from 'uuid';
 import {trim} from "@/utils/format";
 import {treeListV3} from "@/services/admin/dept";
 import {pageV3 as rolePageV3} from "@/services/admin/role";
+import { ResetPwdDrawer } from '@/pages/Sys/Permission/ResetPwdDrawer';
 
 export default () => {
 
@@ -29,12 +30,6 @@ export default () => {
 		deptIds: string[];
 		roleIds: string[];
 	};
-
-	type TableRestPwdColumns = {
-		id: number;
-		password: string | undefined;
-		confirmPassword: string | undefined;
-	}
 
 	const [readOnly, setReadOnly] = useState(false)
 	const [modalVisit, setModalVisit] = useState(false);
@@ -241,65 +236,11 @@ export default () => {
 
 	return (
 		<>
-			<DrawerForm<TableRestPwdColumns>
-				open={modalRestPwdVisit}
-				title={'重置密码'}
-				drawerProps={{
-					destroyOnClose: true,
-					closable: true,
-					maskClosable: true
-				}}
-				onOpenChange={setModalRestPwdVisit}
-				submitter={{
-					submitButtonProps: {
-						style: {
-							display: readOnly ? 'none' : 'inline-block',
-						},
-					}
-				}}
-				onFinish={ async (value) => {
-					const password = value?.password
-					const confirmPassword = value?.confirmPassword
-					if (password !== confirmPassword) {
-						message.error("两次密码不一致").then()
-						return
-					}
-					resetPwdV3({id: primaryKey, password: password}).then(res => {
-						if (res.code === 'OK') {
-							message.success("重置成功").then()
-							setModalRestPwdVisit(false)
-						}
-					})
-				}}>
 
-				<ProFormText
-					name="id"
-					label="ID"
-					hidden={true}
-				/>
-
-				<ProFormText.Password
-					name="password"
-					label="密码"
-					tooltip={"默认密码：laokou123"}
-					placeholder={'请输入密码'}
-					fieldProps={{
-						autoComplete: 'new-password',
-					}}
-					rules={[{ required: true, message: '请输入密码' }]}
-				/>
-
-				<ProFormText.Password
-					name="confirmPassword"
-					label="确认密码"
-					tooltip={"默认密码：laokou123"}
-					placeholder={'请输入确认密码'}
-					fieldProps={{
-						autoComplete: 'new-password',
-					}}
-					rules={[{ required: true, message: '请输入确认密码' }]}
-				/>
-			</DrawerForm>
+			<ResetPwdDrawer visible={modalRestPwdVisit}
+				setVisible={setModalRestPwdVisit}
+				primaryKey={primaryKey}
+			/>
 
 			<DrawerForm<TableColumns>
 				open={modalVisit}
@@ -438,6 +379,7 @@ export default () => {
 				/>
 
 			</DrawerForm>
+
 			<ProTable<TableColumns>
 				actionRef={actionRef}
 				columns={columns}


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强功能：
- 将重置密码的模态框重构为一个独立的 `ResetPwdDrawer` 组件，以提高代码的可维护性和可重用性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refactor the reset password modal into a separate `ResetPwdDrawer` component to improve code maintainability and reusability.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new sliding drawer-based password reset interface that validates matching passwords and provides immediate success or error feedback.
  
- **Refactor**
  - Replaced the previous inline password reset form with the new, dedicated interface to streamline the reset process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->