### PR TITLE
Dev

### DIFF
--- a/doc/db/kcloud_platform_nacos.sql
+++ b/doc/db/kcloud_platform_nacos.sql
@@ -2560,10 +2560,6 @@ spring:
       max-file-size: -1
       max-request-size: -1
   cloud:
-    openfeign:
-      oauth2:
-        enabled: true
-        clientRegistrationId: "default"
     # sentinel
     sentinel:
       filter:
@@ -5020,10 +5016,6 @@ spring:
       max-file-size: -1
       max-request-size: -1
   cloud:
-    openfeign:
-      oauth2:
-        enabled: true
-        clientRegistrationId: "default"
     # sentinel
     sentinel:
       filter:
@@ -5307,10 +5299,6 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: "2m"
   cloud:
-    openfeign:
-      oauth2:
-        enabled: true
-        clientRegistrationId: "default"
     # sentinel
     sentinel:
       filter:
@@ -5433,10 +5421,6 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: "2m"
   cloud:
-    openfeign:
-      oauth2:
-        enabled: true
-        clientRegistrationId: "default"
     # sentinel
     sentinel:
       filter:
@@ -5559,10 +5543,6 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: "2m"
   cloud:
-    openfeign:
-      oauth2:
-        enabled: true
-        clientRegistrationId: "default"
     # sentinel
     sentinel:
       filter:
@@ -5853,10 +5833,6 @@ spring:
       max-file-size: -1
       max-request-size: -1
   cloud:
-    openfeign:
-      oauth2:
-        enabled: true
-        clientRegistrationId: "default"
     # sentinel
     sentinel:
       filter:

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncCountInterceptor.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncCountInterceptor.java
@@ -33,7 +33,9 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * 没有上过生产，请谨慎使用.
+ * <p/>
  * 没有上过生产，请谨慎使用.
+ * <p/>
  * 没有上过生产，请谨慎使用.
  *
  * @author gitkakafu

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncCountInterceptor.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncCountInterceptor.java
@@ -32,6 +32,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * 没有上过生产，请谨慎使用.
+ * 没有上过生产，请谨慎使用.
+ * 没有上过生产，请谨慎使用.
+ *
  * @author gitkakafu
  * @author laokou
  */

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncPaginationInnerInterceptor.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncPaginationInnerInterceptor.java
@@ -77,7 +77,9 @@ import java.util.stream.Collectors;
 
 /**
  * 没有上过生产，请谨慎使用.
+ * <p/>
  * 没有上过生产，请谨慎使用.
+ * <p/>
  * 没有上过生产，请谨慎使用.
  *
  * @author hubin

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncPaginationInnerInterceptor.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/AsyncPaginationInnerInterceptor.java
@@ -76,6 +76,10 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 /**
+ * 没有上过生产，请谨慎使用.
+ * 没有上过生产，请谨慎使用.
+ * 没有上过生产，请谨慎使用.
+ *
  * @author hubin
  * @author gitkakafu
  * @author laokou

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/SqlMonitorInterceptor.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/SqlMonitorInterceptor.java
@@ -58,7 +58,7 @@ public class SqlMonitorInterceptor implements Interceptor {
 
     @Override
 	public Object intercept(Invocation invocation) throws Throwable {
-		StopWatch stopWatch = new StopWatch("SQL查询");
+		StopWatch stopWatch = new StopWatch("SQL执行");
 		stopWatch.start();
 		Object obj = invocation.proceed();
 		stopWatch.stop();


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

此 pull request 增强了 MyBatis Plus 的配置，移除了 OpenFeign OAuth2 客户端注册并改进了 SQL 监控。它还移除了分页查询中每页 500 条记录的限制。

增强功能：
- 通过将 StopWatch 描述从 'SQL查询' 重命名为 'SQL执行'，改进 SQL 监控。
- 移除分页查询中每页 500 条记录的限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request enhances the MyBatis Plus configuration by removing the OpenFeign OAuth2 client registration and improving SQL monitoring. It also removes the 500-record limit for each page in pagination queries.

Enhancements:
- Improve SQL monitoring by renaming the StopWatch description from 'SQL查询' to 'SQL执行'.
- Remove the 500-record limit for each page in pagination queries.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed outdated OAuth2 client settings to simplify service integration.
- **Refactor**
	- Streamlined SQL interception by replacing asynchronous pagination with a more direct approach to enhance query execution.
- **Documentation**
	- Added and updated cautionary notices on experimental components for improved usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->