### PR TITLE
feat: token无感刷新

### DIFF
--- a/doc/db/kcloud_platform_nacos.sql
+++ b/doc/db/kcloud_platform_nacos.sql
@@ -2264,7 +2264,7 @@ spring:
             token:
               authorization-code-time-to-live: 5m
               access-token-time-to-live: 5m
-              refresh-token-time-to-live: 6h
+              refresh-token-time-to-live: 1h
               device-code-time-to-live: 5m
             registration:
               id: 95TxSsTPFA3tF12TBSMmUVK0da
@@ -2443,7 +2443,7 @@ spring:
             token:
               authorization-code-time-to-live: 5m
               access-token-time-to-live: 5m
-              refresh-token-time-to-live: 6h
+              refresh-token-time-to-live: 1h
               device-code-time-to-live: 5m
             registration:
               id: 95TxSsTPFA3tF12TBSMmUVK0da
@@ -3431,7 +3431,7 @@ spring:
             token:
               authorization-code-time-to-live: 5m
               access-token-time-to-live: 5m
-              refresh-token-time-to-live: 6h
+              refresh-token-time-to-live: 1h
               device-code-time-to-live: 5m
             registration:
               id: 95TxSsTPFA3tF12TBSMmUVK0da

--- a/laokou-cloud/laokou-nacos/src/main/java/com/alibaba/nacos/NacosApp.java
+++ b/laokou-cloud/laokou-nacos/src/main/java/com/alibaba/nacos/NacosApp.java
@@ -40,6 +40,8 @@ public class NacosApp {
 		// @formatter:off
 		// -Dnacos.home => Nacos的根目录
 		// Nacos控制台 => 【http/https】://【ip:8848】/nacos
+		// -Dnacos.standalone=true
+		// -Dnacos.home=./logs/nacos
 		// -Dnacos.remote.server.rpc.tls.enableTls=true
 		// -Dnacos.remote.server.rpc.tls.mutualAuthEnable=true
 		// -Dnacos.remote.server.rpc.tls.compatibility=false

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/GlobalOpaqueTokenIntrospector.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/GlobalOpaqueTokenIntrospector.java
@@ -21,7 +21,6 @@ import io.micrometer.common.lang.NonNullApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.i18n.common.exception.GlobalException;
-import org.laokou.common.i18n.utils.DateUtil;
 import org.laokou.common.i18n.utils.ObjectUtil;
 import org.laokou.common.security.handler.OAuth2ExceptionHandler;
 import org.laokou.common.security.utils.UserDetail;
@@ -29,10 +28,12 @@ import org.laokou.common.tenant.annotation.Master;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+import org.springframework.util.Assert;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -62,15 +63,20 @@ public class GlobalOpaqueTokenIntrospector implements OpaqueTokenIntrospector, W
 		if (ObjectUtil.isNull(authorization)) {
 			throw OAuth2ExceptionHandler.getException(UNAUTHORIZED);
 		}
+		OAuth2Authorization.Token<OAuth2RefreshToken> refreshToken = authorization.getRefreshToken();
 		OAuth2Authorization.Token<OAuth2AccessToken> accessToken = authorization.getAccessToken();
-		long expireTime = DateUtil.betweenSeconds(DateUtil.nowInstant(), accessToken.getToken().getExpiresAt());
-		if (expireTime > 0) {
+		Assert.notNull(accessToken, "accessToken is null");
+		Assert.notNull(refreshToken, "refreshToken is null");
+		if (accessToken.isActive()) {
             Object obj = authorization.getAttribute(Principal.class.getName());
             if (ObjectUtil.isNotNull(obj)) {
                 UserDetail userDetail = (UserDetail) ((UsernamePasswordAuthenticationToken) obj).getPrincipal();
                 // 解密
                 return decryptInfo(userDetail);
             }
+		}
+		if (!refreshToken.isActive()) {
+			oAuth2AuthorizationService.remove(authorization);
 		}
 		throw OAuth2ExceptionHandler.getException(UNAUTHORIZED);
 	}


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

实现了静默令牌刷新功能。 这包括 UI 上的更改，以处理令牌过期和刷新，以及后端的更改，以验证和刷新令牌。

新功能：
- 增加了令牌刷新功能，可以自动更新用户会话，而无需手动登录。

增强功能：
- 在 UI 中实现了静默令牌刷新功能，通过在令牌过期时自动刷新令牌来改善用户体验。
- 更新了后端以验证和刷新令牌，确保授权用户可以持续访问。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implements silent token refresh functionality. This includes changes to the UI to handle token expiration and refresh, as well as backend changes to validate and refresh tokens.

New Features:
- Adds token refresh functionality to automatically renew user sessions without requiring manual login.

Enhancements:
- Implements silent token refresh functionality in the UI to improve user experience by automatically refreshing tokens when they expire.
- Updates the backend to validate and refresh tokens, ensuring continued access for authorized users.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced token refresh flow with clearer error handling and user notifications upon a successful token renewal.
  
- **Refactor**
  - Streamlined token validation logic to ensure consistent handling of both access and refresh tokens.
  
- **Chores**
  - Updated configuration settings to reduce refresh token lifetime, improving overall session management.
  - Added guidance for optional standalone operation and log directory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->