### PR TITLE
feat: 增加oss服务【基于openfeign https调用】

### DIFF
--- a/doc/db/kcloud_platform.sql
+++ b/doc/db/kcloud_platform.sql
@@ -792,7 +792,7 @@ INSERT INTO "public"."boot_sys_menu" ("id", "creator", "editor", "create_time", 
 INSERT INTO "public"."boot_sys_menu" ("id", "creator", "editor", "create_time", "update_time", "del_flag", "version", "tenant_id", "pid", "permission", "type", "name", "path", "icon", "sort", "status") VALUES (60, 1, 1, '2025-03-02 17:52:49.303296', '2025-03-02 17:54:03.34208', 0, 2, 0, 33, 'sys:operate-log:page', 1, '分页查询操作日志', NULL, NULL, 50, 0);
 INSERT INTO "public"."boot_sys_menu" ("id", "creator", "editor", "create_time", "update_time", "del_flag", "version", "tenant_id", "pid", "permission", "type", "name", "path", "icon", "sort", "status") VALUES (61, 1, 1, '2025-03-02 18:06:30.782409', '2025-03-02 18:07:31.180306', 0, 1, 0, 33, 'sys:operate-log:export', 1, '导出全部操作日志', NULL, NULL, 40, 0);
 INSERT INTO "public"."boot_sys_menu" ("id", "creator", "editor", "create_time", "update_time", "del_flag", "version", "tenant_id", "pid", "permission", "type", "name", "path", "icon", "sort", "status") VALUES (62, 1, 1, '2025-03-02 18:09:02.472121', '2025-03-02 18:09:02.472121', 0, 0, 0, 33, 'sys:operate-log:detail', 1, '查看操作日志', NULL, NULL, 30, 0);
-
+INSERT INTO "public"."boot_sys_menu" ("id", "creator", "editor", "create_time", "update_time", "del_flag", "version", "tenant_id", "pid", "permission", "type", "name", "path", "icon", "sort", "status") VALUES (63, 1, 1, '2025-03-15 12:15:37.277552', '2025-03-15 12:15:37.278549', 0, 0, 0, 37, 'sys:oss:upload', 1, '上传文件', NULL, NULL, 5, 0);
 -- ----------------------------
 -- Table structure for boot_sys_menu_package
 -- ----------------------------

--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -159,8 +159,8 @@
     <bcpkix.version>1.80</bcpkix.version>
     <!--reactor-kafka版本-->
     <reactor-kafka.version>1.3.23</reactor-kafka.version>
-    <!--okhttp4-spring-boot-starter版本-->
-    <okhttp4-spring-boot-starter.version>3.4.2</okhttp4-spring-boot-starter.version>
+    <!--okhttp3版本-->
+    <okhttp3.version>3.14.9</okhttp3.version>
     <!--spring-ai-openai-spring-boot-starter版本-->
     <spring-ai-openai-spring-boot-starter.version>1.0.0-M6</spring-ai-openai-spring-boot-starter.version>
     <!--flink-connector-kafka版本-->
@@ -291,9 +291,9 @@
         <version>${spring-ai-openai-spring-boot-starter.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.freefair.okhttp-spring-boot</groupId>
-        <artifactId>okhttp4-spring-boot-starter</artifactId>
-        <version>${okhttp4-spring-boot-starter.version}</version>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp3.version}</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor.kafka</groupId>

--- a/laokou-common/laokou-common-core/pom.xml
+++ b/laokou-common/laokou-common-core/pom.xml
@@ -123,10 +123,6 @@
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.freefair.okhttp-spring-boot</groupId>
-      <artifactId>okhttp4-spring-boot-starter</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.alibaba</groupId>
       <artifactId>transmittable-thread-local</artifactId>
     </dependency>
@@ -139,6 +135,10 @@
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/utils/FileUtil.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/utils/FileUtil.java
@@ -20,14 +20,16 @@ package org.laokou.common.core.utils;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.i18n.common.exception.SystemException;
 import org.laokou.common.i18n.utils.StringUtil;
-
 import java.io.*;
 import java.net.URI;
 import java.net.URLConnection;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -108,6 +110,17 @@ public final class FileUtil {
 
 	public static void write(Path path, byte[] buff) throws IOException {
 		Files.write(path, buff);
+	}
+
+	public static void write(Path path, InputStream inputStream, long size) throws NoSuchAlgorithmException {
+		try (FileOutputStream fos = new FileOutputStream(path.toFile());
+				FileChannel outChannel = fos.getChannel();
+				ReadableByteChannel inChannel = Channels.newChannel(inputStream);) {
+			outChannel.transferFrom(inChannel, 0, size);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	public static void chunkWrite(File file, InputStream in, long start, long end, long size) {

--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/utils/SslUtil.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/utils/SslUtil.java
@@ -50,7 +50,7 @@ public final class SslUtil {
 		// 怎么选择加密协议，请看 ProtocolVersion
 		// 为什么能找到对应的加密协议 请查看 SSLContextSpi
 		SSLContext sslContext = SSLContext.getInstance(TLS_PROTOCOL_VERSION);
-		sslContext.init(null, trustManagers, null);
+		sslContext.init(null, trustManagers, new java.security.SecureRandom());
 		return sslContext;
 	}
 

--- a/laokou-common/laokou-common-openapi-doc/src/main/java/org/laokou/common/openapi/doc/config/OpenApiDocAutoConfig.java
+++ b/laokou-common/laokou-common-openapi-doc/src/main/java/org/laokou/common/openapi/doc/config/OpenApiDocAutoConfig.java
@@ -56,8 +56,8 @@ public class OpenApiDocAutoConfig {
 						// .flows(new OAuthFlows().authorizationCode(new OAuthFlow()
 						// .authorizationUrl(oAuth2ResourceServerProperties.getAuthorizationUrl())
 						// .tokenUrl(oAuth2ResourceServerProperties.getTokenUrl())
-						// .scopes(new Scopes().addString("read", "读").addString("write",
-						// "写"))))
+						// .scopes(new
+						// Scopes().addString("read","读").addString("write","写"))))
 						.in(SecurityScheme.In.HEADER)
 						.scheme("Bearer")
 						.bearerFormat("JWT")));

--- a/laokou-common/laokou-common-openfeign/src/main/java/org/laokou/common/openfeign/config/OpenFeignAutoConfig.java
+++ b/laokou-common/laokou-common-openfeign/src/main/java/org/laokou/common/openfeign/config/OpenFeignAutoConfig.java
@@ -17,7 +17,6 @@
 
 package org.laokou.common.openfeign.config;
 
-import com.alibaba.cloud.sentinel.feign.SentinelFeignAutoConfiguration;
 import feign.*;
 import feign.codec.ErrorDecoder;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,12 +24,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.utils.RequestUtil;
 import org.laokou.common.idempotent.utils.IdempotentUtil;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.cloud.openfeign.FeignClientsConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-
 import java.util.Map;
 
 import static org.laokou.common.i18n.common.constant.StringConstant.UNDER;
@@ -49,8 +45,6 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @RequiredArgsConstructor
-@Import({ FeignClientsConfiguration.class })
-@AutoConfiguration(before = SentinelFeignAutoConfiguration.class)
 public class OpenFeignAutoConfig extends ErrorDecoder.Default implements RequestInterceptor {
 
 	private final IdempotentUtil idempotentUtil;

--- a/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/config/StorageAutoConfig.java
+++ b/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/config/StorageAutoConfig.java
@@ -21,8 +21,6 @@ import org.laokou.common.oss.template.StorageTemplate;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
-import java.util.concurrent.ExecutorService;
-
 /**
  * @author laokou
  */
@@ -30,8 +28,8 @@ import java.util.concurrent.ExecutorService;
 public class StorageAutoConfig {
 
 	@Bean
-	public StorageTemplate storageTemplate(ExecutorService virtualThreadExecutor) {
-		return new StorageTemplate(virtualThreadExecutor);
+	public StorageTemplate storageTemplate() {
+		return new StorageTemplate();
 	}
 
 }

--- a/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/entity/FileInfo.java
+++ b/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/entity/FileInfo.java
@@ -19,9 +19,7 @@ package org.laokou.common.oss.entity;
 
 import lombok.Data;
 import org.laokou.common.core.utils.FileUtil;
-import org.springframework.util.DigestUtils;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.io.*;
 import java.util.UUID;
 
@@ -31,35 +29,22 @@ import java.util.UUID;
 @Data
 public class FileInfo implements Serializable {
 
-	private final ByteArrayOutputStream cachedOutputStream;
-
 	protected final long size;
 
 	protected final String name;
 
-	protected final String md5;
+	protected InputStream inputStream;
 
 	protected final String contentType;
 
 	protected final long chunkSize;
 
 	public FileInfo(MultipartFile file) throws IOException {
-		this.cachedOutputStream = getCachedOutputStream(file.getInputStream());
+		this.inputStream = file.getInputStream();
 		this.size = file.getSize();
 		this.name = UUID.randomUUID() + FileUtil.getFileExt(file.getOriginalFilename());
-		this.md5 = DigestUtils.md5DigestAsHex(new ByteArrayInputStream(cachedOutputStream.toByteArray()));
 		this.contentType = file.getContentType();
-		this.chunkSize = this.size / 10;
-	}
-
-	public InputStream getInputStream() {
-		return new ByteArrayInputStream(cachedOutputStream.toByteArray());
-	}
-
-	private ByteArrayOutputStream getCachedOutputStream(InputStream in) throws IOException {
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		bos.write(in.readAllBytes());
-		return bos;
+		this.chunkSize = Math.max(this.size / 100, 8192);
 	}
 
 }

--- a/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/entity/OssInfo.java
+++ b/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/entity/OssInfo.java
@@ -36,6 +36,11 @@ public class OssInfo {
 	private String directory;
 
 	/**
+	 * OSS的路径【本地】.
+	 */
+	private String path;
+
+	/**
 	 * OSS的域名【本地】.
 	 */
 	private String domain;

--- a/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/template/AbstractStorage.java
+++ b/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/template/AbstractStorage.java
@@ -21,7 +21,7 @@ import org.laokou.common.oss.entity.FileInfo;
 import org.laokou.common.oss.entity.OssInfo;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * @author laokou
@@ -32,16 +32,13 @@ public abstract class AbstractStorage<O> implements Storage {
 
 	protected final OssInfo ossInfo;
 
-	protected final ExecutorService virtualThreadExecutor;
-
-	protected AbstractStorage(FileInfo fileInfo, OssInfo ossInfo, ExecutorService virtualThreadExecutor) {
+	protected AbstractStorage(FileInfo fileInfo, OssInfo ossInfo) {
 		this.fileInfo = fileInfo;
 		this.ossInfo = ossInfo;
-		this.virtualThreadExecutor = virtualThreadExecutor;
 	}
 
 	@Override
-	public String upload() throws IOException {
+	public String upload() throws IOException, NoSuchAlgorithmException {
 		O obj = getObj();
 		createBucket(obj);
 		upload(obj);
@@ -52,7 +49,7 @@ public abstract class AbstractStorage<O> implements Storage {
 
 	protected abstract void createBucket(O obj);
 
-	protected abstract void upload(O obj) throws IOException;
+	protected abstract void upload(O obj) throws IOException, NoSuchAlgorithmException;
 
 	protected abstract String getUrl(O obj);
 

--- a/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/template/AmazonS3Storage.java
+++ b/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/template/AmazonS3Storage.java
@@ -29,18 +29,15 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.laokou.common.oss.entity.FileInfo;
 import org.laokou.common.oss.entity.OssInfo;
-
-import java.io.ByteArrayInputStream;
 import java.net.URL;
-import java.util.concurrent.ExecutorService;
 
 /**
  * @author laokou
  */
 public class AmazonS3Storage extends AbstractStorage<AmazonS3> {
 
-	public AmazonS3Storage(FileInfo fileInfo, OssInfo ossInfo, ExecutorService virtualThreadExecutor) {
-		super(fileInfo, ossInfo, virtualThreadExecutor);
+	public AmazonS3Storage(FileInfo fileInfo, OssInfo ossInfo) {
+		super(fileInfo, ossInfo);
 	}
 
 	@Override
@@ -79,7 +76,7 @@ public class AmazonS3Storage extends AbstractStorage<AmazonS3> {
 		objectMetadata.setContentLength(fileInfo.getSize());
 		objectMetadata.setContentType(fileInfo.getContentType());
 		PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, fileInfo.getName(),
-				new ByteArrayInputStream(fileInfo.getCachedOutputStream().toByteArray()), objectMetadata);
+				fileInfo.getInputStream(), objectMetadata);
 		putObjectRequest.getRequestClientOptions().setReadLimit((int) (fileInfo.getSize() + 1));
 		obj.putObject(putObjectRequest);
 	}

--- a/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/template/LocalStorage.java
+++ b/laokou-common/laokou-common-oss/src/main/java/org/laokou/common/oss/template/LocalStorage.java
@@ -23,15 +23,15 @@ import org.laokou.common.oss.entity.OssInfo;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.ExecutorService;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * @author laokou
  */
 public class LocalStorage extends AbstractStorage<Path> {
 
-	public LocalStorage(FileInfo fileInfo, OssInfo ossInfo, ExecutorService virtualThreadExecutor) {
-		super(fileInfo, ossInfo, virtualThreadExecutor);
+	public LocalStorage(FileInfo fileInfo, OssInfo ossInfo) {
+		super(fileInfo, ossInfo);
 	}
 
 	@Override
@@ -44,14 +44,13 @@ public class LocalStorage extends AbstractStorage<Path> {
 	}
 
 	@Override
-	protected void upload(Path obj) throws IOException {
-		FileUtil.write(obj.toFile(), fileInfo.getInputStream(), fileInfo.getSize(), fileInfo.getChunkSize(),
-				virtualThreadExecutor);
+	protected void upload(Path obj) throws NoSuchAlgorithmException {
+		FileUtil.write(obj, fileInfo.getInputStream(), fileInfo.getSize());
 	}
 
 	@Override
 	protected String getUrl(Path obj) {
-		return ossInfo.getDomain() + obj.toString();
+		return ossInfo.getDomain() + ossInfo.getPath() + fileInfo.getName();
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-adapter/src/main/java/org/laokou/admin/web/OssControllerV3.java
+++ b/laokou-service/laokou-admin/laokou-admin-adapter/src/main/java/org/laokou/admin/web/OssControllerV3.java
@@ -104,4 +104,12 @@ public class OssControllerV3 {
 		return ossServiceI.getById(new OssGetQry(id));
 	}
 
+	@TraceLog
+	@PostMapping(value = "upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PreAuthorize("hasAuthority('sys:oss:upload')")
+	@Operation(summary = "OSS上传文件", description = "OSS上传文件")
+	public Result<String> uploadV3(@RequestPart("file") MultipartFile file) {
+		return ossServiceI.upload(new OssUploadCmd(file));
+	}
+
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/oss/command/OssUploadCmdExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/oss/command/OssUploadCmdExe.java
@@ -15,16 +15,25 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.admin.oss.command;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
+import lombok.RequiredArgsConstructor;
+import org.laokou.admin.oss.dto.OssUploadCmd;
+import org.laokou.admin.oss.gatewayimpl.rpc.OssFeignClient;
+import org.laokou.common.i18n.dto.Result;
+import org.springframework.stereotype.Component;
 
 /**
  * @author laokou
  */
-public interface Storage {
+@Component
+@RequiredArgsConstructor
+public class OssUploadCmdExe {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	private final OssFeignClient ossFeignClient;
+
+	public Result<String> execute(OssUploadCmd cmd) {
+		return ossFeignClient.uploadV3(cmd.getFile());
+	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/oss/service/OssServiceImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/oss/service/OssServiceImpl.java
@@ -51,6 +51,8 @@ public class OssServiceImpl implements OssServiceI {
 
 	private final OssGetQryExe ossGetQryExe;
 
+	private final OssUploadCmdExe ossUploadCmdExe;
+
 	@Override
 	public void save(OssSaveCmd cmd) {
 		ossSaveCmdExe.executeVoid(cmd);
@@ -84,6 +86,11 @@ public class OssServiceImpl implements OssServiceI {
 	@Override
 	public Result<OssCO> getById(OssGetQry qry) {
 		return ossGetQryExe.execute(qry);
+	}
+
+	@Override
+	public Result<String> upload(OssUploadCmd cmd) {
+		return ossUploadCmdExe.execute(cmd);
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/oss/api/OssServiceI.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/oss/api/OssServiceI.java
@@ -71,4 +71,10 @@ public interface OssServiceI {
 	 */
 	Result<OssCO> getById(OssGetQry qry);
 
+	/**
+	 * 上传文件.
+	 * @param cmd 上传命令
+	 */
+	Result<String> upload(OssUploadCmd cmd);
+
 }

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/oss/dto/OssUploadCmd.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/oss/dto/OssUploadCmd.java
@@ -15,16 +15,22 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.admin.oss.dto;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.laokou.common.i18n.dto.CommonCommand;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * @author laokou
  */
-public interface Storage {
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OssUploadCmd extends CommonCommand {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	private MultipartFile file;
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/common/constant/ServiceConstant.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/common/constant/ServiceConstant.java
@@ -15,16 +15,16 @@
  *
  */
 
-package org.laokou.common.oss.template;
-
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
+package org.laokou.admin.common.constant;
 
 /**
  * @author laokou
  */
-public interface Storage {
+public final class ServiceConstant {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	private ServiceConstant() {
+	}
+
+	public static final String OSS = "laokou-oss";
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/oss/gatewayimpl/rpc/OssFeignClient.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/oss/gatewayimpl/rpc/OssFeignClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.admin.oss.gatewayimpl.rpc;
+
+import org.laokou.admin.oss.gatewayimpl.rpc.factory.OssFeignClientFallbackFactory;
+import org.laokou.common.i18n.dto.Result;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.laokou.admin.common.constant.ServiceConstant.OSS;
+
+/**
+ * @author laokou
+ */
+@FeignClient(value = OSS, contextId = "laokou-oss-consumer", path = "v3/oss",
+		fallbackFactory = OssFeignClientFallbackFactory.class)
+public interface OssFeignClient {
+
+	@PostMapping(value = "upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	Result<String> uploadV3(@RequestPart("file") MultipartFile file);
+
+}

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/oss/gatewayimpl/rpc/factory/OssFeignClientFallbackFactory.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/oss/gatewayimpl/rpc/factory/OssFeignClientFallbackFactory.java
@@ -15,16 +15,21 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.admin.oss.gatewayimpl.rpc.factory;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
+import org.laokou.admin.oss.gatewayimpl.rpc.fallback.OssFeignClientFallback;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
 
 /**
  * @author laokou
  */
-public interface Storage {
+@Component
+public class OssFeignClientFallbackFactory implements FallbackFactory<OssFeignClientFallback> {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	@Override
+	public OssFeignClientFallback create(Throwable cause) {
+		return new OssFeignClientFallback(cause);
+	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/oss/gatewayimpl/rpc/fallback/OssFeignClientFallback.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/oss/gatewayimpl/rpc/fallback/OssFeignClientFallback.java
@@ -15,16 +15,29 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.admin.oss.gatewayimpl.rpc.fallback;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
+import lombok.extern.slf4j.Slf4j;
+import org.laokou.admin.oss.gatewayimpl.rpc.OssFeignClient;
+import org.laokou.common.i18n.dto.Result;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * @author laokou
  */
-public interface Storage {
+@Slf4j
+public class OssFeignClientFallback implements OssFeignClient {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	private final Throwable cause;
+
+	public OssFeignClientFallback(Throwable cause) {
+		this.cause = cause;
+	}
+
+	@Override
+	public Result<String> uploadV3(MultipartFile file) {
+		log.error("文件上传失败，错误信息：{}", cause.getMessage(), cause);
+		return Result.fail("S_Oss_UploadFailed", "文件上传失败，服务正在维护，请联系管理员");
+	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application.yml
@@ -162,6 +162,32 @@ spring:
     loadbalancer:
       nacos:
         enabled: true
+    # 解决集成sentinel，openfeign启动报错，官方下个版本修复
+    openfeign:
+      http2client:
+        enabled: false
+      compression:
+        response:
+          enabled: false
+        request:
+          enabled: false
+      # FeignAutoConfiguration、OkHttpFeignLoadBalancerConfiguration、OkHttpClient#getClient、FeignClientProperties、OptionsFactoryBean#getObject
+      # 在BeanFactory调用getBean()时，不是调用getBean，而是调用getObject(),因此，getObject()相当于代理了getBean(),而且getObject()对Options初始化，是直接从openfeign.default获取配置值的
+      okhttp:
+        enabled: true
+      circuitbreaker:
+        enabled: true
+      httpclient:
+        hc5:
+          enabled: false
+        disable-ssl-validation: true
+      client:
+        config:
+          default:
+            connectTimeout: 120000 #连接超时
+            readTimeout: 120000 #读取超时
+            logger-level: none
+      lazy-attributes-resolution: true
     inetutils:
       ignored-interfaces:
         - docker0
@@ -246,3 +272,17 @@ rocketmq:
   name-server: rocketmq-namesrv:9876
   consumer:
     pull-batch-size: 32
+
+  # feign
+feign:
+  sentinel:
+    enabled: true
+    default-rule: default
+    rules:
+      # https://sentinelguard.io/zh-cn/docs/circuit-breaking.html
+      default:
+        - grade: 2 # 异常数策略
+          count: 1 # 异常数模式下为对应的阈值
+          timeWindow: 30 # 熔断时长，单位为 s（经过熔断时长后熔断器会进入探测恢复状态（HALF-OPEN 状态），若接下来的一个请求成功完成（没有错误）则结束熔断，否则会再次被熔断。ERROR_COUNT）
+          statIntervalMs: 1000 # 统计时长（单位为 ms），如 60*1000 代表分钟级（1.8.0 引入）
+          minRequestAmount: 5 # 熔断触发的最小请求数，请求数小于该值时即使异常比率超出阈值也不会熔断

--- a/laokou-service/laokou-oss/laokou-oss-adapter/src/main/java/org/laokou/oss/web/OssControllerV3.java
+++ b/laokou-service/laokou-oss/laokou-oss-adapter/src/main/java/org/laokou/oss/web/OssControllerV3.java
@@ -17,15 +17,36 @@
 
 package org.laokou.oss.web;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.laokou.common.i18n.dto.Result;
+import org.laokou.common.trace.annotation.TraceLog;
+import org.laokou.oss.api.OssServiceI;
+import org.laokou.oss.dto.OssUploadCmd;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("v3/oss")
 @Tag(name = "OSS管理", description = "OSS管理")
 public class OssControllerV3 {
+
+	private final OssServiceI ossServiceI;
+
+	@TraceLog
+	@PostMapping(value = "upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PreAuthorize("hasAuthority('sys:oss:upload')")
+	@Operation(summary = "OSS上传文件", description = "OSS上传文件")
+	public Result<String> uploadV3(@RequestPart("file") MultipartFile file)
+			throws IOException, NoSuchAlgorithmException {
+		return ossServiceI.upload(new OssUploadCmd(file));
+	}
 
 }

--- a/laokou-service/laokou-oss/laokou-oss-app/src/main/java/org/laokou/oss/command/OssUploadCmdExe.java
+++ b/laokou-service/laokou-oss/laokou-oss-app/src/main/java/org/laokou/oss/command/OssUploadCmdExe.java
@@ -15,26 +15,44 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.oss.command;
 
 import lombok.RequiredArgsConstructor;
 import org.laokou.common.i18n.dto.Result;
-import org.laokou.common.oss.entity.FileInfo;
 import org.laokou.common.oss.entity.OssInfo;
+import org.laokou.common.oss.entity.Type;
+import org.laokou.common.oss.template.StorageTemplate;
+import org.laokou.oss.dto.OssUploadCmd;
+import org.laokou.oss.model.OssE;
+import org.springframework.stereotype.Component;
+
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 
 /**
  * @author laokou
  */
+@Component
 @RequiredArgsConstructor
-public class StorageTemplate {
+public class OssUploadCmdExe {
 
-	public Result<String> upload(FileInfo fileInfo, OssInfo ossInfo) throws IOException, NoSuchAlgorithmException {
-		return switch (ossInfo.getType()) {
-			case LOCAL -> Result.ok(new LocalStorage(fileInfo, ossInfo).upload());
-			case CLOUD -> Result.ok(new AmazonS3Storage(fileInfo, ossInfo).upload());
-		};
+	private final StorageTemplate storageTemplate;
+
+	public Result<String> execute(OssUploadCmd cmd) throws IOException, NoSuchAlgorithmException {
+		OssE ossE = new OssE(cmd.getFile());
+		// 校验文件大小
+		ossE.checkSize();
+		return storageTemplate.upload(ossE, getInfo());
+	}
+
+	// TODO 从数据库获取配置，根据系统设置进行负载均衡
+	private OssInfo getInfo() {
+		OssInfo ossInfo = new OssInfo();
+		ossInfo.setType(Type.LOCAL);
+		ossInfo.setDomain("http://localhost:82");
+		ossInfo.setDirectory("D:\\laokou\\temp");
+		ossInfo.setPath("/temp/");
+		return ossInfo;
 	}
 
 }

--- a/laokou-service/laokou-oss/laokou-oss-app/src/main/java/org/laokou/oss/service/OssServiceImpl.java
+++ b/laokou-service/laokou-oss/laokou-oss-app/src/main/java/org/laokou/oss/service/OssServiceImpl.java
@@ -15,7 +15,14 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.oss.service;
+
+import lombok.RequiredArgsConstructor;
+import org.laokou.common.i18n.dto.Result;
+import org.laokou.oss.api.OssServiceI;
+import org.laokou.oss.command.OssUploadCmdExe;
+import org.laokou.oss.dto.OssUploadCmd;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
@@ -23,8 +30,15 @@ import java.security.NoSuchAlgorithmException;
 /**
  * @author laokou
  */
-public interface Storage {
+@Service
+@RequiredArgsConstructor
+public class OssServiceImpl implements OssServiceI {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	private final OssUploadCmdExe ossUploadCmdExe;
+
+	@Override
+	public Result<String> upload(OssUploadCmd cmd) throws IOException, NoSuchAlgorithmException {
+		return ossUploadCmdExe.execute(cmd);
+	}
 
 }

--- a/laokou-service/laokou-oss/laokou-oss-client/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-client/pom.xml
@@ -14,10 +14,6 @@
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-excel</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.laokou</groupId>
-      <artifactId>laokou-common-core</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/laokou-service/laokou-oss/laokou-oss-client/src/main/java/org/laokou/oss/api/OssServiceI.java
+++ b/laokou-service/laokou-oss/laokou-oss-client/src/main/java/org/laokou/oss/api/OssServiceI.java
@@ -15,7 +15,10 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.oss.api;
+
+import org.laokou.common.i18n.dto.Result;
+import org.laokou.oss.dto.OssUploadCmd;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
@@ -23,8 +26,8 @@ import java.security.NoSuchAlgorithmException;
 /**
  * @author laokou
  */
-public interface Storage {
+public interface OssServiceI {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	Result<String> upload(OssUploadCmd cmd) throws IOException, NoSuchAlgorithmException;
 
 }

--- a/laokou-service/laokou-oss/laokou-oss-client/src/main/java/org/laokou/oss/dto/OssUploadCmd.java
+++ b/laokou-service/laokou-oss/laokou-oss-client/src/main/java/org/laokou/oss/dto/OssUploadCmd.java
@@ -15,16 +15,22 @@
  *
  */
 
-package org.laokou.common.oss.template;
+package org.laokou.oss.dto;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.laokou.common.i18n.dto.CommonCommand;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * @author laokou
  */
-public interface Storage {
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OssUploadCmd extends CommonCommand {
 
-	String upload() throws IOException, NoSuchAlgorithmException;
+	private MultipartFile file;
 
 }

--- a/laokou-service/laokou-oss/laokou-oss-domain/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-domain/pom.xml
@@ -11,8 +11,12 @@
 
   <dependencies>
     <dependency>
-        <groupId>org.laokou</groupId>
-        <artifactId>laokou-common-oss</artifactId>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-oss-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-oss</artifactId>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-oss/laokou-oss-domain/src/main/java/org/laokou/oss/model/OssE.java
+++ b/laokou-service/laokou-oss/laokou-oss-domain/src/main/java/org/laokou/oss/model/OssE.java
@@ -17,10 +17,14 @@
 
 package org.laokou.oss.model;
 
+import org.laokou.common.i18n.common.exception.BizException;
 import org.laokou.common.oss.entity.FileInfo;
+import org.springframework.util.DigestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * @author laokou
@@ -29,6 +33,18 @@ public class OssE extends FileInfo {
 
 	public OssE(MultipartFile file) throws IOException {
 		super(file);
+	}
+
+	public void checkSize() {
+		if (super.size > 1024 * 1024 * 100) {
+			throw new BizException("B_Oss_SizeExceeding100M", "文件大小不能超过100M");
+		}
+	}
+
+	public String getMd5() throws IOException {
+		ByteBuffer buffer = ByteBuffer.wrap(super.inputStream.readAllBytes());
+		super.inputStream = new ByteArrayInputStream(buffer.array());
+		return DigestUtils.md5DigestAsHex(buffer.array());
 	}
 
 }

--- a/laokou-service/laokou-oss/laokou-oss-infrastructure/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-infrastructure/pom.xml
@@ -16,10 +16,6 @@
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
-      <artifactId>laokou-oss-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.laokou</groupId>
       <artifactId>laokou-common-security</artifactId>
     </dependency>
     <dependency>

--- a/laokou-service/laokou-oss/laokou-oss-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-oss/laokou-oss-start/src/main/resources/application.yml
@@ -24,6 +24,11 @@ server:
 spring:
   application:
     name: ${SERVICE_ID:laokou-oss}
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: -1
+      max-request-size: -1
   profiles:
     active: @PROFILE-ACTIVE@
   lifecycle:
@@ -32,6 +37,29 @@ spring:
   threads:
     virtual:
       enabled: true
+  task-execution:
+    pool:
+      core-pool-size: 32
+      max-pool-size: 64
+      keep-alive: 60s
+      thread-priority: 10
+      allow-core-thread-timeout: false
+      queue-capacity: 500
+  # security
+  security:
+    oauth2:
+      resource-server:
+        enabled: true
+        request-matcher:
+          ignore-patterns:
+            GET:
+              - /v3/api-docs/**=laokou-oss
+              - /swagger-ui.html=laokou-oss
+              - /swagger-ui/**=laokou-oss
+              - /actuator/**=laokou-oss
+              - /error=laokou-oss
+              - /doc.html=laokou-oss
+              - /webjars/**=laokou-oss
   datasource:
     dynamic:
       # 默认false,建议线上关闭


### PR DESCRIPTION
好的，这是将提供的拉取请求摘要翻译成中文的结果：

## Sourcery 总结

添加使用 OpenFeign 通过 HTTPS 调用 OSS（对象存储服务）功能。这包括配置、领域模型更改以及用于将文件上传到 OSS 的控制器端点。

新功能：
- 引入具有本地存储能力的 OSS 服务。
- 向 OSS 服务添加文件上传功能。
- 与 Sentinel 集成，实现熔断和容错。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds OSS (Object Storage Service) functionality using OpenFeign for HTTPS calls. This includes configuration, domain model changes, and controller endpoints for uploading files to OSS.

New Features:
- Introduces OSS service with local storage capability.
- Adds file upload functionality to the OSS service.
- Integrates with Sentinel for circuit breaking and fault tolerance.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new file upload option to the system menu for easier access.
	- Introduced upgraded file upload endpoints with enhanced validations (including a 100 MB file size limit) and improved error handling.
	- Updated service configurations to boost performance and reliability during file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->