### PR TITLE
test: 【nacos】测试用例补充完毕

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -138,7 +138,7 @@ image::doc/image/老寇IoT云平台架构图.png[架构图,align=center]
 |Spring Cloud Alibaba        |2023.0.3.2
 |Spring Boot Admin           |3.4.5
 |Spring Authorization Server |1.5.0
-|Mybatis Plus                |3.5.10.1
+|Mybatis Plus                |3.5.11
 |Nacos                       |2.5.0
 |Sentinel                    |1.8.8
 |Redis                       |7.4.2

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的I
 |    Spring Cloud Alibaba     |  2023.0.3.2   |
 |      Spring Boot Admin      |     3.4.5     |
 | Spring Authorization Server |     1.5.0     |
-|        Mybatis Plus         |   3.5.10.1    |
+|        Mybatis Plus         |    3.5.11     |
 |            Nacos            |     2.5.0     |
 |          Sentinel           |     1.8.8     |
 |            Redis            |     7.4.2     |

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
@@ -23,6 +23,9 @@ import com.alibaba.cloud.nacos.util.InetIPv6Utils;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.selector.NamingSelector;
+import com.alibaba.nacos.client.naming.selector.NamingSelectorFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -36,6 +39,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestConstructor;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author laokou
@@ -91,18 +97,219 @@ class NamingUtilsTest {
 	@Test
 	void testGetAllInstances() throws NacosException, InterruptedException {
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service").isEmpty());
+
 		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service").isEmpty());
 
 		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service").isEmpty());
+		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty());
+
+		Instance instance = new Instance();
+		instance.setIp("127.0.0.1");
+		instance.setPort(8080);
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", instance));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", instance));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils.getAllInstances("test-service", false).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
+		Thread.sleep(1000);
+		Assertions.assertTrue(
+				namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1",
+				8080, nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(
+				namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false)
+					.isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1",
+				8080, nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils
+			.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false)
+			.isEmpty());
+
+		Assertions
+			.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils
+			.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false)
+			.isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils
+			.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false)
+			.isEmpty());
+	}
+
+	@Test
+	void testSelectInstances() throws NacosException, InterruptedException {
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", true, false).isEmpty());
+
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true, false).isEmpty());
+		Assertions.assertFalse(
+				namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true)
+					.isEmpty());
+		Assertions
+			.assertFalse(namingUtils
+				.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()),
+						true, false)
+				.isEmpty());
+		Assertions.assertFalse(namingUtils
+			.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true, false)
+			.isEmpty());
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty());
+		Assertions.assertFalse(namingUtils
+			.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true)
+			.isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils
+			.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false)
+			.isEmpty());
+	}
+
+	@Test
+	void testSelectOneHealthyInstance() throws NacosException, InterruptedException {
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service"));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP"));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", false));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service",
+				List.of(nacosDiscoveryProperties.getClusterName())));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP",
+				List.of(nacosDiscoveryProperties.getClusterName())));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service",
+				List.of(nacosDiscoveryProperties.getClusterName()), false));
+		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP",
+				List.of(nacosDiscoveryProperties.getClusterName()), false));
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+	}
+
+	@Test
+	void testSubscribeService() throws NacosException, InterruptedException {
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP",
+				List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP",
+				List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service",
+				List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service",
+				List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+
+		// 只选择订阅ip为`127.0`开头的实例。
+		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
+		Assertions
+			.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080,
+				nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+	}
+
+	@Test
+	void testGetServicesOfServer() throws NacosException, InterruptedException {
+		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1",
+				8080, nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+
+		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0);
+		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10).getCount() > 0);
+
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		Assertions.assertFalse(namingUtils.getSubscribeServices().isEmpty());
+
+		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1",
+				8080, nacosDiscoveryProperties.getClusterName()));
+		Thread.sleep(1000);
+		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+	}
+
+	@Test
+	void testBatchRegisterInstance() throws NacosException, InterruptedException {
+		Instance instance = new Instance();
+		instance.setIp("127.0.0.1");
+		instance.setPort(8080);
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		Thread.sleep(1000);
+		Assertions.assertNotEquals(2, namingUtils.selectInstances("test-service", true).size());
+
+		Assertions.assertDoesNotThrow(
+				() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		Thread.sleep(1000);
+		Assertions.assertEquals(0, namingUtils.selectInstances("test-service", false).size());
 	}
 
 	@Test
 	void testNacosServiceShutDown() throws InterruptedException {
-		Thread.sleep(4000);
+		Thread.sleep(1000);
 		Assertions.assertDoesNotThrow(namingUtils::nacosServiceShutDown);
 	}
 

--- a/laokou-common/laokou-common-nacos/src/test/resources/bootstrap.yml
+++ b/laokou-common/laokou-common-nacos/src/test/resources/bootstrap.yml
@@ -24,5 +24,6 @@ spring:
         password: nacos
         group: DEFAULT_GROUP
         enabled: true
+        cluster-name: laokou-cluster
       username: nacos
       password: nacos


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

测试：
- 在 NamingUtils 中，为 getAllInstances, selectInstances, selectOneHealthyInstance, subscribeService, getServicesOfServer 和 batchRegisterInstance 方法添加了测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Adds test cases for getAllInstances, selectInstances, selectOneHealthyInstance, subscribeService, getServicesOfServer and batchRegisterInstance methods in NamingUtils.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated version references for a core backend component to 3.5.11.
- **Tests**
  - Enhanced test scenarios for improved reliability in service instance management and faster shutdown processes.
- **Chores**
  - Added a configuration setting for specifying the service discovery cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->