### PR TITLE
fix: 【系统管理】+【物联管理】找不到mapper

### DIFF
--- a/laokou-common/laokou-common-log/src/main/java/org/laokou/common/log/aop/OperateLogAop.java
+++ b/laokou-common/laokou-common-log/src/main/java/org/laokou/common/log/aop/OperateLogAop.java
@@ -43,7 +43,7 @@ import org.springframework.util.StopWatch;
 @Slf4j
 @Aspect
 @Component
-@MapperScan(basePackages = "org.laokou.common.log.database")
+@MapperScan(basePackages = "org.laokou.common.log.mapper")
 @RequiredArgsConstructor
 public class OperateLogAop {
 

--- a/ui/src/pages/IoT/Device/ThingModelDrawer.tsx
+++ b/ui/src/pages/IoT/Device/ThingModelDrawer.tsx
@@ -1,11 +1,11 @@
-import {DrawerForm, ProFormDigit, ProFormRadio, ProFormSelect, ProFormText} from '@ant-design/pro-components';
+import {DrawerForm, ProFormDigit, ProFormSelect, ProFormText} from '@ant-design/pro-components';
 import {Col, message, Row} from 'antd';
-import {modifyV3, saveV3} from "@/services/iot/thingModel";
-import {v7 as uuidV7} from "uuid";
 import React from "react";
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
-import {ProFormItem} from "@ant-design/pro-form";
+import {ProFormItem, ProFormTextArea} from "@ant-design/pro-form";
+import {v7 as uuidV7} from "uuid";
+import {modifyV3, saveV3} from "@/services/iot/thingModel";
 
 interface ThingModelDrawerProps {
 	modalVisit: boolean;
@@ -16,6 +16,8 @@ interface ThingModelDrawerProps {
 	onComponent: () => void;
 	value: string;
 	setValue: (value: string) => void;
+	flag: number;
+	setFlag: (flag: number) => void;
 }
 
 type TableColumns = {
@@ -33,12 +35,27 @@ type TableColumns = {
 	createTime: string | undefined;
 };
 
-export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, setModalVisit, title, readOnly, dataSource, onComponent, value, setValue }) => {
+export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, setModalVisit, title, readOnly, dataSource, onComponent, value, setValue, flag, setFlag }) => {
 
 	const onChange = React.useCallback((val: any) => {
 		dataSource.expression = val;
 		setValue(val);
 	}, []);
+
+	const getSpecs = (value: any) => {
+		switch (value.dataType) {
+			case 'integer': return {
+				min: value.min,
+				max: value.max,
+				length: value.length,
+				unit: value.unit,
+			}
+			case 'decimal': return {}
+			case 'boolean': return {}
+			case 'string': return {}
+			default: return {}
+		}
+	}
 
 	return (
 		<DrawerForm<TableColumns>
@@ -60,8 +77,10 @@ export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, 
 				}
 			}}
 			onFinish={ async (value) => {
-				console.log(value)
-/*				if (value.id === undefined) {
+				value.specs = JSON.stringify(getSpecs(value))
+				// @ts-ignore
+				value.type = value.type.join(',')
+				if (value.id === undefined) {
 					saveV3({co: value}, uuidV7()).then(res => {
 						if (res.code === 'OK') {
 							message.success("新增成功").then()
@@ -77,7 +96,7 @@ export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, 
 							onComponent()
 						}
 					})
-				}*/
+				}
 			}}>
 			<ProFormText
 				readonly={readOnly}
@@ -127,7 +146,7 @@ export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, 
 				rules={[{ required: true, message: '请输入排序' }]}
 			/>
 
-			<ProFormRadio.Group
+			<ProFormSelect
 				name="expressionFlag"
 				label="是否使用表达式"
 				readonly={readOnly}
@@ -136,20 +155,23 @@ export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, 
 					{label:"是",value: 1 },
 					{label:"否",value: 0 }
 				]}
+				onChange={setFlag}
 			/>
 
-			<ProFormItem
-				label="表达式"
-				tooltip={"JS脚本，参数【inputMap】"}
-			>
-				<CodeMirror
-					readOnly={readOnly}
-					value={value}
-					height="400px"
-					extensions={[javascript({ jsx: true, typescript: true })]}
-					onChange={onChange}
-				/>
-			</ProFormItem>
+			{flag === 1 && (
+				<ProFormItem
+					label="表达式"
+					tooltip={"JS脚本，参数【inputMap】"}
+				>
+					<CodeMirror
+						readOnly={readOnly}
+						value={value}
+						height="400px"
+						extensions={[javascript({ jsx: true, typescript: true })]}
+						onChange={onChange}
+					/>
+				</ProFormItem>
+			)}
 
 			<ProFormSelect
 				name="dataType"
@@ -170,33 +192,35 @@ export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({ modalVisit, 
 						readonly={readOnly}
 						name="min"
 						label="最小值"
-						rules={[{ required: true, message: '请输入最小值' }]}
-					/>
+						rules={[{ required: true, message: '请输入最小值' }]}/>
 				</Col>
 				<Col span={12}>
 					<ProFormText
 						readonly={readOnly}
 						name="max"
 						label="最大值"
-						rules={[{ required: true, message: '请输入最大值' }]}
-					/>
+						rules={[{ required: true, message: '请输入最大值' }]}/>
 				</Col>
 				<Col span={12}>
 					<ProFormText
 						readonly={readOnly}
 						name="length"
 						label="长度"
-						rules={[{ required: true, message: '请输入长度' }]}
-					/>
+						rules={[{ required: true, message: '请输入长度' }]}/>
 				</Col>
 				<Col span={12}>
 					<ProFormText
 						readonly={readOnly}
 						name="unit"
-						label="单位"
-					/>
+						label="单位"/>
 				</Col>
 			</Row>
+
+			<ProFormTextArea
+				readonly={readOnly}
+				name="remark"
+				label="备注"
+			/>
 
 		</DrawerForm>
 	);

--- a/ui/src/pages/IoT/Device/thingModel.tsx
+++ b/ui/src/pages/IoT/Device/thingModel.tsx
@@ -17,6 +17,7 @@ export default () => {
 	const [readOnly, setReadOnly] = useState(false)
 	const [value, setValue] = useState("");
 	const [ids, setIds] = useState<any>([])
+	const [flag, setFlag] = useState(0)
 
 	type TableColumns = {
 		id: number;
@@ -156,6 +157,8 @@ export default () => {
 				}}
 				value={value}
 				setValue={setValue}
+				flag={flag}
+				setFlag={setFlag}
 			/>
 
 			<ProTable<TableColumns>
@@ -188,6 +191,14 @@ export default () => {
 							setTitle('新增物模型')
 							setReadOnly(false)
 							setModalVisit(true)
+							setFlag(0)
+							setDataSource({
+								id: undefined,
+								sort: 1,
+								expressionFlag: 0,
+								dataType: 'integer',
+								category: 1,
+							})
 						}}>
 							新增
 						</Button>,


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复 mapper 扫描问题并增强 IoT 管理系统中的 Thing Model Drawer 组件

**新特性:**

- 在 Thing Model Drawer 中引入了一个新的备注文本区域
- 增加了对基于标志的表达式输入进行条件渲染的支持

**Bug 修复:**

- 更正了 `OperateLogAop` 类中的 mapper 扫描包路径，以解决找不到 mapper 的问题
- 修复了 Thing Model Drawer，使其能够正确处理表单提交和数据规范

**增强:**

- 更新了 Thing Model Drawer，以支持基于数据类型的动态规范生成
- 在 IoT 设备管理界面中增加了更灵活的表单处理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix mapper scanning and enhance the Thing Model Drawer component in the IoT management system

New Features:
- Introduced a new remark text area in the Thing Model Drawer
- Added support for conditional rendering of expression input based on a flag

Bug Fixes:
- Corrected the mapper scanning package path in the OperateLogAop class to resolve mapper not found issue
- Fixed the Thing Model Drawer to properly handle form submissions and data specifications

Enhancements:
- Updated the Thing Model Drawer to support dynamic specification generation based on data type
- Added more flexible form handling in the IoT Device management interface

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the device model configuration interface by introducing interactive controls, including a new dropdown for expression selection that conditionally displays additional input fields.
  - Added a remarks field to capture extra details and improved state management to streamline form interactions and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->