### PR TITLE
feat: 【物联管理】校验信息增加前缀

### DIFF
--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/CollectionUtils.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/CollectionUtils.java
@@ -81,4 +81,16 @@ public final class CollectionUtils {
 		return Splitter.on(on).trimResults().splitToList(str);
 	}
 
+	public static <E> boolean contains(Collection<E> collections, E element) {
+		return collections.contains(element);
+	}
+
+	public static <E> boolean anyMatch(Collection<E> collections, Collection<E> allCollections) {
+		return collections.stream().anyMatch(allCollections::contains);
+	}
+
+	public static <E> boolean containsAll(Collection<E> collections, Collection<E> allCollections) {
+		return allCollections.containsAll(collections);
+	}
+
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/extensionpoint/extension/DeptParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/extensionpoint/extension/DeptParamValidator.java
@@ -36,7 +36,7 @@ public final class DeptParamValidator {
 	public static ParamValidator.Validate validateParentId(DeptE deptE) {
 		Long pid = deptE.getPid();
 		if (ObjectUtils.isNull(pid)) {
-			return invalidate("父级ID不能为空");
+			return invalidate("部门父级ID不能为空");
 		}
 		return validate();
 	}
@@ -44,10 +44,10 @@ public final class DeptParamValidator {
 	public static ParamValidator.Validate validateSort(DeptE deptE) {
 		Integer sort = deptE.getSort();
 		if (ObjectUtils.isNull(sort)) {
-			return invalidate("排序不能为空");
+			return invalidate("部门排序不能为空");
 		}
 		if (sort < 1 || sort > 99999) {
-			return invalidate("排序范围1-99999");
+			return invalidate("部门排序范围1-99999");
 		}
 		return validate();
 	}
@@ -55,7 +55,7 @@ public final class DeptParamValidator {
 	public static ParamValidator.Validate validateId(DeptE deptE) {
 		Long id = deptE.getId();
 		if (ObjectUtils.isNull(id)) {
-			return invalidate("ID不能为空");
+			return invalidate("部门ID不能为空");
 		}
 		return validate();
 	}
@@ -63,7 +63,7 @@ public final class DeptParamValidator {
 	public static ParamValidator.Validate validateName(DeptE deptE) {
 		String name = deptE.getName();
 		if (StringUtils.isEmpty(name)) {
-			return invalidate("名称不能为空");
+			return invalidate("部门名称不能为空");
 		}
 		return validate();
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/extensionpoint/extension/MenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/extensionpoint/extension/MenuParamValidator.java
@@ -42,16 +42,16 @@ public final class MenuParamValidator {
 		String permission = menuE.getPermission();
 		if (MenuTypeEnum.BUTTON.getCode() == type) {
 			if (StringUtils.isEmpty(permission)) {
-				return invalidate("权限标识不能为空");
+				return invalidate("菜单权限标识不能为空");
 			}
 			if (isSave && menuMapper
 				.selectCount(Wrappers.lambdaQuery(MenuDO.class).eq(MenuDO::getPermission, permission)) > 0) {
-				return invalidate("权限标识已存在");
+				return invalidate("菜单权限标识已存在");
 			}
 			if (!isSave && menuMapper.selectCount(Wrappers.lambdaQuery(MenuDO.class)
 				.eq(MenuDO::getPermission, permission)
 				.ne(MenuDO::getId, menuE.getId())) > 0) {
-				return invalidate("权限标识已存在");
+				return invalidate("菜单权限标识已存在");
 			}
 		}
 		return validate();
@@ -60,7 +60,7 @@ public final class MenuParamValidator {
 	public static ParamValidator.Validate validateParentId(MenuE menuE) {
 		Long pid = menuE.getPid();
 		if (ObjectUtils.isNull(pid)) {
-			return invalidate("父级ID不能为空");
+			return invalidate("菜单父级ID不能为空");
 		}
 		return validate();
 	}
@@ -68,7 +68,7 @@ public final class MenuParamValidator {
 	public static ParamValidator.Validate validateType(MenuE menuE) {
 		Integer type = menuE.getType();
 		if (ObjectUtils.isNull(type)) {
-			return invalidate("类型不能为空");
+			return invalidate("菜单类型不能为空");
 		}
 		return validate();
 	}
@@ -78,15 +78,15 @@ public final class MenuParamValidator {
 		String path = menuE.getPath();
 		if (MenuTypeEnum.MENU.getCode() == type) {
 			if (StringUtils.isEmpty(path)) {
-				return invalidate("路径不能为空");
+				return invalidate("菜单路径不能为空");
 			}
 			if (isSave && menuMapper.selectCount(Wrappers.lambdaQuery(MenuDO.class).eq(MenuDO::getPath, path)) > 0) {
-				return invalidate("路径已存在");
+				return invalidate("菜单路径已存在");
 			}
 			if (!isSave && menuMapper.selectCount(Wrappers.lambdaQuery(MenuDO.class)
 				.eq(MenuDO::getPath, path)
 				.ne(MenuDO::getId, menuE.getId())) > 0) {
-				return invalidate("路径已存在");
+				return invalidate("菜单路径已存在");
 			}
 		}
 		return validate();
@@ -95,10 +95,10 @@ public final class MenuParamValidator {
 	public static ParamValidator.Validate validateSort(MenuE menuE) {
 		Integer sort = menuE.getSort();
 		if (ObjectUtils.isNull(sort)) {
-			return invalidate("排序不能为空");
+			return invalidate("菜单排序不能为空");
 		}
 		if (sort < 1 || sort > 99999) {
-			return invalidate("排序范围1-99999");
+			return invalidate("菜单排序范围1-99999");
 		}
 		return validate();
 	}
@@ -107,7 +107,7 @@ public final class MenuParamValidator {
 		Integer type = menuE.getType();
 		Integer status = menuE.getStatus();
 		if (MenuTypeEnum.MENU.getCode() == type && ObjectUtils.isNull(status)) {
-			return invalidate("状态不能为空");
+			return invalidate("菜单状态不能为空");
 		}
 		return validate();
 	}
@@ -115,7 +115,7 @@ public final class MenuParamValidator {
 	public static ParamValidator.Validate validateId(MenuE menuE) {
 		Long id = menuE.getId();
 		if (ObjectUtils.isNull(id)) {
-			return invalidate("ID不能为空");
+			return invalidate("菜单ID不能为空");
 		}
 		return validate();
 	}
@@ -124,16 +124,16 @@ public final class MenuParamValidator {
 		String name = menuE.getName();
 		Integer type = menuE.getType();
 		if (StringUtils.isEmpty(name)) {
-			return invalidate("名称不能为空");
+			return invalidate("菜单名称不能为空");
 		}
 		if (MenuTypeEnum.MENU.getCode() == type) {
 			if (isSave && menuMapper.selectCount(Wrappers.lambdaQuery(MenuDO.class).eq(MenuDO::getName, name)) > 0) {
-				return invalidate("名称已存在");
+				return invalidate("菜单名称已存在");
 			}
 			if (!isSave && menuMapper.selectCount(Wrappers.lambdaQuery(MenuDO.class)
 				.eq(MenuDO::getName, name)
 				.ne(MenuDO::getId, menuE.getId())) > 0) {
-				return invalidate("名称已存在");
+				return invalidate("菜单名称已存在");
 			}
 		}
 		return validate();

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/extensionpoint/extension/RoleParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/extensionpoint/extension/RoleParamValidator.java
@@ -43,10 +43,10 @@ public final class RoleParamValidator {
 	public static ParamValidator.Validate validateSort(RoleE roleE) {
 		Integer sort = roleE.getSort();
 		if (ObjectUtils.isNull(sort)) {
-			return invalidate("排序不能为空");
+			return invalidate("角色排序不能为空");
 		}
 		if (sort < 1 || sort > 99999) {
-			return invalidate("排序范围1-99999");
+			return invalidate("角色排序范围1-99999");
 		}
 		return validate();
 	}
@@ -54,7 +54,7 @@ public final class RoleParamValidator {
 	public static ParamValidator.Validate validateId(RoleE roleE) {
 		Long id = roleE.getId();
 		if (ObjectUtils.isNull(id)) {
-			return invalidate("ID不能为空");
+			return invalidate("角色ID不能为空");
 		}
 		return validate();
 	}
@@ -62,7 +62,7 @@ public final class RoleParamValidator {
 	public static ParamValidator.Validate validateDataScope(RoleE roleE) {
 		String dataScope = roleE.getDataScope();
 		if (StringUtils.isEmpty(dataScope)) {
-			return invalidate("数据范围不能为空");
+			return invalidate("角色数据范围不能为空");
 		}
 		return validate();
 	}
@@ -70,7 +70,7 @@ public final class RoleParamValidator {
 	public static ParamValidator.Validate validateMenuIds(RoleE roleE) {
 		List<String> menuIds = roleE.getMenuIds();
 		if (CollectionUtils.isEmpty(menuIds)) {
-			return invalidate("菜单IDS不能为空");
+			return invalidate("角色菜单IDS不能为空");
 		}
 		return validate();
 	}
@@ -78,7 +78,7 @@ public final class RoleParamValidator {
 	public static ParamValidator.Validate validateDeptIds(RoleE roleE) {
 		List<String> deptIds = roleE.getDeptIds();
 		if (ObjectUtils.equals(roleE.getDataScope(), DataScope.CUSTOM.getCode()) && CollectionUtils.isEmpty(deptIds)) {
-			return invalidate("部门IDS不能为空");
+			return invalidate("角色部门IDS不能为空");
 		}
 		return validate();
 	}
@@ -87,14 +87,14 @@ public final class RoleParamValidator {
 		Long id = roleE.getId();
 		String name = roleE.getName();
 		if (StringUtils.isEmpty(name)) {
-			return invalidate("名称不能为空");
+			return invalidate("角色名称不能为空");
 		}
 		if (isSave && roleMapper.selectCount(Wrappers.lambdaQuery(RoleDO.class).eq(RoleDO::getName, name)) > 0) {
-			return invalidate("名称已存在");
+			return invalidate("角色名称已存在");
 		}
 		if (!isSave && roleMapper
 			.selectCount(Wrappers.lambdaQuery(RoleDO.class).eq(RoleDO::getName, name).ne(RoleDO::getId, id)) > 0) {
-			return invalidate("名称已存在");
+			return invalidate("角色名称已存在");
 		}
 		return validate();
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/extensionpoint/extension/UserParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/extensionpoint/extension/UserParamValidator.java
@@ -45,7 +45,7 @@ public final class UserParamValidator {
 	public static ParamValidator.Validate validateId(UserE userE) {
 		Long id = userE.getId();
 		if (ObjectUtils.isNull(id)) {
-			return invalidate("ID不能为空");
+			return invalidate("用户ID不能为空");
 		}
 		return validate();
 	}
@@ -54,17 +54,17 @@ public final class UserParamValidator {
 			UserMapper userMapper) {
 		String password = userE.getPassword();
 		if (StringUtils.isEmpty(password)) {
-			return invalidate("密码不能为空");
+			return invalidate("用户密码不能为空");
 		}
 		if (password.length() < 6 || password.length() > 30) {
-			return invalidate("密码长度为6-30个字符");
+			return invalidate("用户密码长度为6-30个字符");
 		}
 		UserDO userDO = userMapper.selectById(userE.getId());
 		if (ObjectUtils.isNull(userDO)) {
 			return invalidate("用户不存在");
 		}
 		if (passwordEncoder.matches(password, userDO.getPassword())) {
-			return invalidate("新密码不能与旧密码相同");
+			return invalidate("用户新密码不能与旧密码相同");
 		}
 		return validate();
 	}
@@ -100,20 +100,20 @@ public final class UserParamValidator {
 		String mail = userE.getMail();
 		if (StringUtils.isNotEmpty(mail)) {
 			if (!RegexUtils.mailRegex(mail)) {
-				return invalidate("邮箱错误");
+				return invalidate("用户邮箱错误");
 			}
 			if (mail.length() > 30) {
-				return invalidate("邮箱不能超过30个字符");
+				return invalidate("用户邮箱不能超过30个字符");
 			}
 			Long id = userE.getId();
 			String encryptMail = AESUtils.encrypt(mail);
 			if (isSave && userMapper
 				.selectCount(Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getMail, encryptMail)) > 0) {
-				return invalidate("邮箱已存在");
+				return invalidate("用户邮箱已存在");
 			}
 			if (!isSave && userMapper.selectCount(
 					Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getMail, encryptMail).ne(UserDO::getId, id)) > 0) {
-				return invalidate("邮箱已存在");
+				return invalidate("用户邮箱已存在");
 			}
 		}
 		return validate();
@@ -124,18 +124,18 @@ public final class UserParamValidator {
 		String mobile = userE.getMobile();
 		if (StringUtils.isNotEmpty(mobile)) {
 			if (!RegexUtils.mobileRegex(mobile)) {
-				return invalidate("手机号错误");
+				return invalidate("用户手机号错误");
 			}
 			Long id = userE.getId();
 			String encryptMobile = AESUtils.encrypt(mobile);
 			if (isSave && userMapper
 				.selectCount(Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getMobile, encryptMobile)) > 0) {
-				return invalidate("手机号已存在");
+				return invalidate("用户手机号已存在");
 			}
 			if (!isSave && userMapper.selectCount(Wrappers.lambdaQuery(UserDO.class)
 				.eq(UserDO::getMobile, encryptMobile)
 				.ne(UserDO::getId, id)) > 0) {
-				return invalidate("手机号已存在");
+				return invalidate("用户手机号已存在");
 			}
 		}
 		return validate();
@@ -144,7 +144,7 @@ public final class UserParamValidator {
 	public static ParamValidator.Validate validateRoleIds(UserE userE) {
 		List<String> roleIds = userE.getRoleIds();
 		if (CollectionUtils.isEmpty(roleIds)) {
-			return invalidate("角色IDS不能为空");
+			return invalidate("用户角色IDS不能为空");
 		}
 		return validate();
 	}
@@ -152,7 +152,7 @@ public final class UserParamValidator {
 	public static ParamValidator.Validate validateDeptIds(UserE userE) {
 		List<String> deptIds = userE.getDeptIds();
 		if (CollectionUtils.isEmpty(deptIds)) {
-			return invalidate("部门IDS不能为空");
+			return invalidate("用户部门IDS不能为空");
 		}
 		return validate();
 	}

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/extensionpoint/extension/ThingModelParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/extensionpoint/extension/ThingModelParamValidator.java
@@ -19,6 +19,7 @@ package org.laokou.iot.thingModel.service.extensionpoint.extension;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.laokou.common.core.util.CollectionUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.laokou.iot.thingModel.gatewayimpl.database.ThingModelMapper;
@@ -46,7 +47,7 @@ public final class ThingModelParamValidator {
 	public static ParamValidator.Validate validateId(ThingModelE thingModelE) {
 		Long id = thingModelE.getId();
 		if (ObjectUtils.isNull(id)) {
-			return invalidate("ID不能为空");
+			return invalidate("物模型ID不能为空");
 		}
 		return validate();
 	}
@@ -56,18 +57,18 @@ public final class ThingModelParamValidator {
 		String code = thingModelE.getCode();
 		String name = thingModelE.getName();
 		if (ObjectUtils.isNull(name) || ObjectUtils.isNull(code)) {
-			return invalidate("编码和名称不能为空");
+			return invalidate("物模型编码和名称不能为空");
 		}
 		if (isSave && thingModelMapper.selectCount(Wrappers.lambdaQuery(ThingModelDO.class)
 			.eq(ThingModelDO::getCode, code)
 			.eq(ThingModelDO::getName, name)) > 0) {
-			return invalidate("编码和名称已存在");
+			return invalidate("物模型编码和名称已存在");
 		}
 		if (!isSave && thingModelMapper.selectCount(Wrappers.lambdaQuery(ThingModelDO.class)
 			.eq(ThingModelDO::getCode, code)
 			.eq(ThingModelDO::getName, name)
 			.ne(ThingModelDO::getId, thingModelE.getId())) > 0) {
-			return invalidate("编码和名称已存在");
+			return invalidate("物模型编码和名称已存在");
 		}
 		return validate();
 	}
@@ -75,7 +76,7 @@ public final class ThingModelParamValidator {
 	public static ParamValidator.Validate validateSpecs(ThingModelE thingModelE) throws JsonProcessingException {
 		String specs = thingModelE.getSpecs();
 		if (ObjectUtils.isNull(specs)) {
-			return invalidate("规格不能为空");
+			return invalidate("物模型规格不能为空");
 		}
 		DataTypeEnum dataTypeEnum = DataTypeEnum.getByCode(thingModelE.getDataType());
 		return dataTypeEnum.validate(specs);
@@ -84,10 +85,10 @@ public final class ThingModelParamValidator {
 	public static ParamValidator.Validate validateSort(ThingModelE thingModelE) {
 		Integer sort = thingModelE.getSort();
 		if (ObjectUtils.isNull(sort)) {
-			return invalidate("排序不能为空");
+			return invalidate("物模型排序不能为空");
 		}
 		if (sort < 1 || sort > 99999) {
-			return invalidate("排序范围1-99999");
+			return invalidate("物模型排序范围1-99999");
 		}
 		return validate();
 	}
@@ -95,12 +96,12 @@ public final class ThingModelParamValidator {
 	public static ParamValidator.Validate validateType(ThingModelE thingModelE) {
 		String type = thingModelE.getType();
 		if (ObjectUtils.isNull(type)) {
-			return invalidate("模型类型不能为空");
+			return invalidate("物模型类型不能为空");
 		}
-		boolean isExist = Arrays.stream(type.split(COMMA))
-			.anyMatch(Arrays.stream(TypeEnum.values()).map(TypeEnum::getCode).toList()::contains);
+		boolean isExist = CollectionUtils.containsAll(Arrays.stream(type.split(COMMA)).toList(),
+				Arrays.stream(TypeEnum.values()).map(TypeEnum::getCode).toList());
 		if (!isExist) {
-			return invalidate("模型类型不存在");
+			return invalidate("物模型类型不存在");
 		}
 		return validate();
 	}
@@ -108,10 +109,11 @@ public final class ThingModelParamValidator {
 	public static ParamValidator.Validate validateCategory(ThingModelE thingModelE) {
 		Integer category = thingModelE.getCategory();
 		if (ObjectUtils.isNull(category)) {
-			return invalidate("模型类别不能为空");
+			return invalidate("物模型类别不能为空");
 		}
-		if (!Arrays.stream(CategoryEnum.values()).map(CategoryEnum::getCode).toList().contains(category)) {
-			return invalidate("模型类别不存在");
+		if (!CollectionUtils.contains(Arrays.stream(CategoryEnum.values()).map(CategoryEnum::getCode).toList(),
+				category)) {
+			return invalidate("物模型类别不存在");
 		}
 		return validate();
 	}
@@ -119,10 +121,10 @@ public final class ThingModelParamValidator {
 	public static ParamValidator.Validate validateDataType(ThingModelE thingModelE) {
 		String dataType = thingModelE.getDataType();
 		if (ObjectUtils.isNull(dataType)) {
-			return invalidate("数据类型不能为空");
+			return invalidate("物模型数据类型不能为空");
 		}
 		if (!Arrays.stream(DataTypeEnum.values()).map(DataTypeEnum::getCode).toList().contains(dataType)) {
-			return invalidate("数据类型不存在");
+			return invalidate("物模型数据类型不存在");
 		}
 		return validate();
 	}


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在多个服务参数验证器中，为验证错误消息添加前缀，以提高错误消息的清晰度

增强功能：
- 更新了验证错误消息，使其包含特定的域前缀（例如，“用户”、“菜单”、“角色”、“部门”、“事物模型”），以便在错误消息中提供更多上下文

杂项：
- 在 `CollectionUtils` 中添加了实用方法，以支持集合操作
- 重构了验证错误消息，使其更具描述性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add prefixes to validation error messages across multiple service parameter validators to improve error message clarity

Enhancements:
- Updated validation error messages to include specific domain prefixes (e.g., 'User', 'Menu', 'Role', 'Department', 'Thing Model') to provide more context in error messages

Chores:
- Added utility methods to CollectionUtils to support collection operations
- Refactored validation error messages to be more descriptive

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced support for collection operations, offering efficient checks for specific elements and groups.
  
- **Bug Fixes**
  - Refined validation error messages across departments, menus, roles, users, and IoT sections to provide clearer, context-specific guidance during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->