### PR TITLE
test: 【core组件】提交测试用例

### DIFF
--- a/archive/docs/01.指南/05.后端指南/00.COLA代码规范.md
+++ b/archive/docs/01.指南/05.后端指南/00.COLA代码规范.md
@@ -54,9 +54,9 @@ validateUserCredentials() </span> 或 <span style="color: #00dd00;"> eliminateDu
 | Adapter层    | web         | 处理页面请求Controller          | 否  |
 | Adapter层    | wireless    | 处理无线端适配                   | 否  |
 | Adapter层    | wap         | 处理wap端的适配                 | 否  |
+| Adapter层    | consumer    | 处理外部message               | 否  |
 |             |             |                           |    |
 | App层        | executor    | 处理request，包括command和query | 是  |
-| App层        | consumer    | 处理外部message               | 否  |
 | App层        | scheduler   | 处理定时任务                    | 否  |
 |             |             |                           |    |
 | Domain层     | model       | 领域模型                      | 否  |

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/PropertyUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/PropertyUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.core;
+
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.core.config.SpringDisruptorProperties;
+import org.laokou.common.core.util.PropertyUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.io.IOException;
+
+/**
+ * @author laokou
+ */
+@SpringBootTest
+@RequiredArgsConstructor
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class PropertyUtilsTest {
+
+	@Test
+	void test() throws IOException {
+		SpringDisruptorProperties properties = PropertyUtils.bindOrCreate("spring.disruptor", SpringDisruptorProperties.class, "application.yml", "yaml");
+		Assertions.assertNotNull(properties);
+		Assertions.assertEquals(1024, properties.getBufferSize());
+	}
+
+}

--- a/laokou-common/laokou-common-core/src/test/resources/application.yml
+++ b/laokou-common/laokou-common-core/src/test/resources/application.yml
@@ -6,3 +6,5 @@ spring:
     name: laokou-common-core
   profiles:
     active: test
+  disruptor:
+    buffer-size: 1024

--- a/laokou-common/laokou-common-mqtt-client/laokou-common-hivemq-mqtt-client/src/main/java/org/laokou/common/mqtt/config/HivemqMqttClient.java
+++ b/laokou-common/laokou-common-mqtt-client/laokou-common-hivemq-mqtt-client/src/main/java/org/laokou/common/mqtt/config/HivemqMqttClient.java
@@ -219,9 +219,7 @@ public class HivemqMqttClient extends AbstractMqttClient {
 			.requestResponseInformation(mqttClientProperties.isRequestResponseInformation())
 			.applyRestrictions()
 			.applyConnect()
-			.doOnSuccess(ack -> {
-				log.info("【Hivemq】 => MQTT连接成功，客户端ID：{}", clientId);
-			})
+			.doOnSuccess(ack -> log.info("【Hivemq】 => MQTT连接成功，客户端ID：{}", clientId))
 			.doOnError(e -> log.error("【Hivemq】 => MQTT连接失败，错误信息：{}", e.getMessage(), e))
 			.subscribeOn(Schedulers.from(ThreadUtils.newVirtualTaskExecutor()))
 			.subscribe(ack -> {


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加属性绑定的测试用例并简化 MQTT 客户端连接日志

新特性：
- 在 test application.yml 中引入 Disruptor 缓冲区大小的配置。

增强：
- 简化 HivemqMqttClient 连接方法中的日志记录 lambda 表达式。

测试：
- 添加 PropertyUtils 的测试用例，以验证从配置文件绑定 SpringDisruptorProperties。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add test case for property binding and simplify MQTT client connection logging

New Features:
- Introduce configuration for Disruptor buffer size in test application.yml

Enhancements:
- Simplify logging lambda in HivemqMqttClient connection method

Tests:
- Add a test case for PropertyUtils to verify binding of SpringDisruptorProperties from configuration file

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated package naming conventions in the backend guidelines to clarify the placement of the "consumer" package under the Adapter layer and remove it from the App layer.

- **Tests**
  - Added a new test to verify property binding for Spring Disruptor configuration.
  - Introduced a sample configuration in the test resources for Disruptor buffer size.

- **Style**
  - Simplified the logging syntax in the MQTT client connection success handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->