### PR TITLE
test: 【openfeign组件】提交测试用例

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,6 +41,7 @@ jobs:
             ./laokou-common/laokou-common-nacos/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-shardingsphere/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-elasticsearch/target/site/jacoco/jacoco.xml,
+            ./laokou-common/laokou-common-openfeign/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-graalvm-js/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-mybatis-plus/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-mqtt-client/laokou-common-hivemq-mqtt-client/target/site/jacoco/jacoco.xml,


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 Maven CI 工作流中的 OpenFeign 组件添加代码覆盖率报告

CI：
- 更新了 Maven 工作流，以跟踪 OpenFeign 组件的测试覆盖率

测试：
- 在 CI 测试覆盖率集合中包含 laokou-common-openfeign 模块的 jacoco.xml 覆盖率报告

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add code coverage reporting for the OpenFeign component in the Maven CI workflow

CI:
- Updated Maven workflow to track test coverage for the OpenFeign component

Tests:
- Include jacoco.xml coverage report for the laokou-common-openfeign module in the CI test coverage collection

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated coverage reporting in the build workflow to include an additional module, ensuring more comprehensive test coverage data is uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->