### PR TITLE
feat: 提交部分AssertJ

### DIFF
--- a/archive/docs/01.指南/00.开发手册/27.组件【nacos】.md
+++ b/archive/docs/01.指南/00.开发手册/27.组件【nacos】.md
@@ -997,69 +997,69 @@ class NamingUtilsTest {
 	void testGetAllInstances() throws NacosException, InterruptedException {
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service").isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service").isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty());
 
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", instance));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", instance));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 	}
 
 	@Test
 	void testSelectInstances() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true, false).isEmpty());
 
@@ -1070,14 +1070,14 @@ class NamingUtilsTest {
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty());
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 	}
 
 	@Test
 	void testSelectOneHealthyInstance() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
@@ -1090,55 +1090,55 @@ class NamingUtilsTest {
 		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false));
 		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 	}
 
 	@Test
 	void testSubscribeService() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
+		(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
 
 		// 只选择订阅ip为`127.0`开头的实例。
 		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
+		(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 	}
 
 	@Test
 	void testGetServicesOfServer() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
 		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0);
 		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10).getCount() > 0);
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
 		Assertions.assertFalse(namingUtils.getSubscribeServices().isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 	}
@@ -1148,11 +1148,11 @@ class NamingUtilsTest {
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
-		Assertions.assertDoesNotThrow(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
 		Assertions.assertNotEquals(2, namingUtils.selectInstances("test-service", true).size());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
 		Assertions.assertEquals(0, namingUtils.selectInstances("test-service", false).size());
 	}
@@ -1160,7 +1160,7 @@ class NamingUtilsTest {
 	@Test
 	void testNacosServiceShutDown() throws InterruptedException {
 		Thread.sleep(1000);
-		Assertions.assertDoesNotThrow(namingUtils::nacosServiceShutDown);
+		(namingUtils::nacosServiceShutDown);
 	}
 
 }

--- a/archive/docs/01.指南/08.文章/00.物联网之对接MQTT最佳实践.md
+++ b/archive/docs/01.指南/08.文章/00.物联网之对接MQTT最佳实践.md
@@ -1423,11 +1423,11 @@ class VertxMqttClientTest {
        properties.setClientId("test-client-1");
        properties.setTopics(Map.of("/test-topic-1/#", 1));
        VertxMqttClient vertxMqttClient = new VertxMqttClient(vertx, properties, messageHandlers);
-       Assertions.assertDoesNotThrow(vertxMqttClient::open);
+       assertThatNoException().isThrownBy(vertxMqttClient::open);
        Thread.sleep(500);
-       Assertions.assertDoesNotThrow(() -> vertxMqttClient.publish("/test-topic-1/test", 1, "test", false, false));
+       (() -> vertxMqttClient.publish("/test-topic-1/test", 1, "test", false, false));
        Thread.sleep(500);
-       Assertions.assertDoesNotThrow(vertxMqttClient::close);
+       (vertxMqttClient::close);
        Thread.sleep(500);
     }
 

--- a/archive/docs/01.指南/08.文章/05.物联网之使用Vertx实现UDP最佳实践【响应式】.md
+++ b/archive/docs/01.指南/08.文章/05.物联网之使用Vertx实现UDP最佳实践【响应式】.md
@@ -184,7 +184,7 @@ class UdpTest {
              }
           });
           Thread.sleep(2000);
-          Assertions.assertDoesNotThrow(datagramSocket::close);
+          assertThatNoException().isThrownBy(datagramSocket::close);
        }
     }
 

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CollectionUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CollectionUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.laokou.common.core;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.CollectionUtils;
 
@@ -25,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -36,46 +36,28 @@ class CollectionUtilsTest {
 
 	@Test
 	void testIsNotEmpty() {
-		List<String> list = Arrays.asList("1", "2", "3");
-		Assertions.assertTrue(CollectionUtils.isNotEmpty(list));
-
-		List<String> emptyList = new ArrayList<>();
-		assertFalse(CollectionUtils.isNotEmpty(emptyList));
-
-		assertFalse(CollectionUtils.isNotEmpty(null));
+		assertThat(CollectionUtils.isNotEmpty(Arrays.asList("1", "2", "3"))).isTrue();
+		assertThat(CollectionUtils.isNotEmpty(new ArrayList<>())).isFalse();
+		assertThat(CollectionUtils.isNotEmpty(null)).isFalse();
 	}
 
 	@Test
 	void testIsEmpty() {
-		List<String> list = Arrays.asList("1", "2", "3");
-		assertFalse(CollectionUtils.isEmpty(list));
-
-		List<String> emptyList = new ArrayList<>();
-		assertTrue(CollectionUtils.isEmpty(emptyList));
-
-		assertTrue(CollectionUtils.isEmpty(null));
+		assertThat(CollectionUtils.isEmpty(Arrays.asList("1", "2", "3"))).isFalse();
+		assertThat(CollectionUtils.isEmpty(new ArrayList<>())).isTrue();
+		assertThat(CollectionUtils.isEmpty(null)).isTrue();
 	}
 
 	@Test
 	void testToStr() {
-		List<String> list = Arrays.asList("a", "b", "c");
-		assertEquals("a,b,c", CollectionUtils.toStr(list, ","));
-
-		// 测试空列表
-		List<String> emptyList = new ArrayList<>();
-		assertEquals("", CollectionUtils.toStr(emptyList, ","));
-
-		// 测试包含null值的列表
-		List<String> listWithNull = Arrays.asList("a", null, "c");
-		assertEquals("a,c", CollectionUtils.toStr(listWithNull, ","));
+		assertThat(CollectionUtils.toStr(Arrays.asList("a", "b", "c"), ",")).isEqualTo("a,b,c");
+		assertThat(CollectionUtils.toStr(new ArrayList<>(), ",")).isEqualTo("");
+		assertThat(CollectionUtils.toStr(Arrays.asList("a", null, "c"), ",")).isEqualTo("a,c");
 	}
 
 	@Test
 	void testToList() {
-		String str = "a,b,c";
-		List<String> expected = Arrays.asList("a", "b", "c");
-		assertEquals(expected, CollectionUtils.toList(str, ","));
-
+		assertEquals(Arrays.asList("a", "b", "c"), CollectionUtils.toList("a,b,c", ","));
 		// 测试空字符串
 		assertTrue(CollectionUtils.toList("", ",").isEmpty());
 

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/GsonUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/GsonUtilsTest.java
@@ -18,10 +18,11 @@
 package org.laokou.common.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.GsonUtils;
 import org.laokou.common.i18n.util.JacksonUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -32,14 +33,14 @@ class GsonUtilsTest {
 	void test() throws JsonProcessingException {
 		TestUser user = new TestUser(1L, "laokou");
 		String json = GsonUtils.toPrettyFormat(user);
-		Assertions.assertEquals("""
+		assertThat(json).isEqualTo("""
 				{
 				  "id": 1,
 				  "name": "laokou"
-				}""", json);
+				}""");
 		TestUser testUser = JacksonUtils.toBean(json, TestUser.class);
-		Assertions.assertEquals(1L, testUser.getId());
-		Assertions.assertEquals("laokou", testUser.getName());
+		assertThat(testUser.getId()).isEqualTo(1L);
+		assertThat(testUser.getName()).isEqualTo("laokou");
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/HttpUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/HttpUtilsTest.java
@@ -33,6 +33,8 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -56,7 +58,7 @@ class HttpUtilsTest {
 				new HashMap<>(0), new HashMap<>(0));
 		Assertions.assertEquals("hello wiremock", resultJson);
 		Assertions.assertNotNull(HttpUtils.getHttpClient());
-		Assertions.assertDoesNotThrow(HttpUtils::destroy);
+		assertThatNoException().isThrownBy(HttpUtils::destroy);
 	}
 
 	@AfterEach

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/MDCUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/MDCUtilsTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.MDCUtils;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -31,7 +33,7 @@ class MDCUtilsTest {
 		MDCUtils.put("111", "222");
 		Assertions.assertNotNull(MDCUtils.getTraceId());
 		Assertions.assertNotNull(MDCUtils.getSpanId());
-		Assertions.assertDoesNotThrow(MDCUtils::clear);
+		assertThatNoException().isThrownBy(MDCUtils::clear);
 		Assertions.assertNull(MDCUtils.getTraceId());
 		Assertions.assertNull(MDCUtils.getSpanId());
 	}

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/OkHttpUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/OkHttpUtilsTest.java
@@ -31,6 +31,8 @@ import org.springframework.test.context.TestConstructor;
 
 import java.util.HashMap;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -53,7 +55,7 @@ class OkHttpUtilsTest {
 		String resultJson = OkHttpUtils.doFormDataPost("http://localhost:" + wireMockServer.port() + "/test",
 				new HashMap<>(0), new HashMap<>(0));
 		Assertions.assertEquals("hello wiremock", resultJson);
-		Assertions.assertDoesNotThrow(OkHttpUtils::destroy);
+		assertThatNoException().isThrownBy(OkHttpUtils::destroy);
 	}
 
 	@AfterEach

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/ResponseUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/ResponseUtilsTest.java
@@ -28,6 +28,8 @@ import org.springframework.test.context.TestConstructor;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -41,8 +43,8 @@ class ResponseUtilsTest {
 	void testResponse() throws IOException {
 		HttpServletResponse response = ResponseUtils.getHttpServletResponse();
 		Assertions.assertNotNull(response);
-		Assertions.assertDoesNotThrow(() -> ResponseUtils.responseOk(response, "ok"));
-		Assertions.assertDoesNotThrow(() -> ResponseUtils.responseOk(response, "ok", "text/plain"));
+		assertThatNoException().isThrownBy(() -> ResponseUtils.responseOk(response, "ok"));
+		assertThatNoException().isThrownBy(() -> ResponseUtils.responseOk(response, "ok", "text/plain"));
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/SpringContextUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/SpringContextUtilsTest.java
@@ -27,6 +27,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestConstructor;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -51,15 +53,15 @@ class SpringContextUtilsTest {
 		Assertions.assertTrue(beanFactory.containsBeanDefinition("testEventListener"));
 		Assertions.assertFalse(beanFactory.containsBeanDefinition("testEventListener1"));
 		Assertions.assertFalse(beanFactory.containsBean("testEventListener1"));
-		Assertions.assertDoesNotThrow(() -> beanFactory.removeBeanDefinition("testEventListener"));
+		assertThatNoException().isThrownBy(() -> beanFactory.removeBeanDefinition("testEventListener"));
 		Assertions.assertFalse(beanFactory.containsBeanDefinition("testEventListener"));
 		Assertions
 			.assertDoesNotThrow(() -> SpringContextUtils.registerBean("testEventListener", TestEventListener.class));
 		Assertions.assertTrue(beanFactory.containsBeanDefinition("testEventListener"));
-		Assertions.assertDoesNotThrow(() -> SpringContextUtils.removeBean("testEventListener"));
+		assertThatNoException().isThrownBy(() -> SpringContextUtils.removeBean("testEventListener"));
 		Assertions.assertFalse(beanFactory.containsBeanDefinition("testEventListener"));
 		Assertions.assertEquals("laokou-common-core", SpringContextUtils.getServiceId());
-		Assertions.assertDoesNotThrow(() -> beanFactory.registerBeanDefinition("testEventListener",
+		assertThatNoException().isThrownBy(() -> beanFactory.registerBeanDefinition("testEventListener",
 				BeanDefinitionBuilder.genericBeanDefinition(TestEventListener.class).getBeanDefinition()));
 		Assertions.assertEquals(SpringContextUtils.getBean("testEventListener"),
 				SpringContextUtils.getBean(TestEventListener.class));

--- a/laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java
+++ b/laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java
@@ -27,6 +27,8 @@ import org.springframework.boot.system.SystemProperties;
 import java.io.File;
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -44,9 +46,9 @@ class CsvUtilsTest {
 		String fileName = "test.csv";
 		String[] arr = { "1", "2", "3" };
 		File file = new File(testPath, fileName);
-		Assertions.assertDoesNotThrow(() -> CsvUtils.execute(file, csvWriter -> csvWriter.writeNext(arr), false));
+		assertThatNoException().isThrownBy(() -> CsvUtils.execute(file, csvWriter -> csvWriter.writeNext(arr), false));
 		Assertions.assertEquals("\"1\",\"2\",\"3\"", FileUtils.readFileToString(file, "UTF-8").trim());
-		Assertions.assertDoesNotThrow(() -> FileUtils.forceDeleteOnExit(file));
+		assertThatNoException().isThrownBy(() -> FileUtils.forceDeleteOnExit(file));
 	}
 
 }

--- a/laokou-common/laokou-common-elasticsearch/src/test/java/org/laokou/common/elasticsearch/Elasticsearch8ApiTest.java
+++ b/laokou-common/laokou-common-elasticsearch/src/test/java/org/laokou/common/elasticsearch/Elasticsearch8ApiTest.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -65,18 +67,18 @@ class Elasticsearch8ApiTest {
 			.assertDoesNotThrow(() -> elasticsearchTemplate.createIndex("iot_res_1", "iot_res", TestResource.class));
 		Assertions
 			.assertDoesNotThrow(() -> elasticsearchTemplate.createIndex("iot_pro_1", "iot_pro", TestProject.class));
-		Assertions.assertDoesNotThrow(() -> elasticsearchTemplate.asyncCreateIndex("iot_resp_1", "iot_resp",
+		assertThatNoException().isThrownBy(() -> elasticsearchTemplate.asyncCreateIndex("iot_resp_1", "iot_resp",
 				TestResp.class, Executors.newSingleThreadExecutor()));
-		Assertions.assertDoesNotThrow(
+		assertThatNoException().isThrownBy(
 				() -> elasticsearchTemplate.asyncCreateDocument("iot_res_1", "222", new TestResource("8888")).join());
-		Assertions.assertDoesNotThrow(
+		assertThatNoException().isThrownBy(
 				() -> elasticsearchTemplate
 					.asyncBulkCreateDocument("iot_res_1", Map.of("555", new TestResource("6666")),
 							Executors.newSingleThreadExecutor())
 					.join());
-		Assertions.assertDoesNotThrow(
-				() -> elasticsearchTemplate.createDocument("iot_res_1", "444", new TestResource("3333")));
-		Assertions.assertDoesNotThrow(
+		assertThatNoException()
+			.isThrownBy(() -> elasticsearchTemplate.createDocument("iot_res_1", "444", new TestResource("3333")));
+		assertThatNoException().isThrownBy(
 				() -> elasticsearchTemplate.bulkCreateDocument("iot_res_1", Map.of("333", new TestResource("5555"))));
 		Search.Highlight highlight = new Search.Highlight();
 		highlight.setFields(List.of(new Search.HighlightField("name", 0, 0)));
@@ -91,7 +93,7 @@ class Elasticsearch8ApiTest {
 		log.info("索引信息：{}", JacksonUtils.toJsonStr(result));
 		Assertions.assertNotNull(result);
 		Assertions.assertFalse(result.isEmpty());
-		Assertions.assertDoesNotThrow(
+		assertThatNoException().isThrownBy(
 				() -> elasticsearchTemplate.deleteIndex(List.of("laokou_res_1", "laokou_pro_1", "laokou_resp_1")));
 	}
 

--- a/laokou-common/laokou-common-excel/src/test/java/org/laokou/common/excel/ExcelTest.java
+++ b/laokou-common/laokou-common-excel/src/test/java/org/laokou/common/excel/ExcelTest.java
@@ -33,6 +33,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.laokou.common.i18n.common.constant.StringConstants.EMPTY;
 
 /**
@@ -54,24 +55,25 @@ class ExcelTest {
 		List<TestUserDO> list = testUserMapper.selectList(Wrappers.emptyWrapper());
 		Assertions.assertEquals(1, list.size());
 		Assertions.assertTrue(list.stream().map(TestUserDO::getName).toList().contains("老寇"));
-		Assertions.assertDoesNotThrow(() -> ExcelUtils.doImport(EMPTY, TestUserExcel.class, TestUserConvertor.INSTANCE,
-				ResourceUtils.getResource("classpath:test3.xlsx").getInputStream(), TestUserMapper.class,
-				TestUserMapper::insert, mybatisUtils));
-		Assertions.assertDoesNotThrow(() -> ExcelUtils.doImport("test", TestUserExcel.class, TestUserConvertor.INSTANCE,
-				ResourceUtils.getResource("classpath:test2.xlsx").getInputStream(), TestUserMapper.class,
-				TestUserMapper::insert, mybatisUtils));
-		Assertions.assertDoesNotThrow(() -> ExcelUtils.doImport("test2", TestUserExcel.class,
+		assertThatNoException().isThrownBy(() -> ExcelUtils.doImport(EMPTY, TestUserExcel.class,
+				TestUserConvertor.INSTANCE, ResourceUtils.getResource("classpath:test3.xlsx").getInputStream(),
+				TestUserMapper.class, TestUserMapper::insert, mybatisUtils));
+		assertThatNoException().isThrownBy(() -> ExcelUtils.doImport("test", TestUserExcel.class,
 				TestUserConvertor.INSTANCE, ResourceUtils.getResource("classpath:test2.xlsx").getInputStream(),
 				TestUserMapper.class, TestUserMapper::insert, mybatisUtils));
-		Assertions.assertDoesNotThrow(() -> ExcelUtils.doImport("test3", TestUserExcel.class,
+		assertThatNoException().isThrownBy(() -> ExcelUtils.doImport("test2", TestUserExcel.class,
+				TestUserConvertor.INSTANCE, ResourceUtils.getResource("classpath:test2.xlsx").getInputStream(),
+				TestUserMapper.class, TestUserMapper::insert, mybatisUtils));
+		assertThatNoException().isThrownBy(() -> ExcelUtils.doImport("test3", TestUserExcel.class,
 				TestUserConvertor.INSTANCE, ResourceUtils.getResource("classpath:test2.xlsx").getInputStream(),
 				TestUserMapper.class, TestUserMapper::insert, mybatisUtils));
 		long count = testUserMapper.selectObjectCount(new PageQuery());
 		Assertions.assertEquals(7, count);
-		Assertions.assertDoesNotThrow(() -> ExcelUtils.doExport("测试用户Sheet页", 1000, new FileOutputStream("test.xlsx"),
-				new PageQuery(), testUserMapper, TestUserExcel.class, TestUserConvertor.INSTANCE));
-		Assertions.assertDoesNotThrow(() -> FileUtils.deleteIfExists(Path.of("test.xlsx")));
-		Assertions.assertDoesNotThrow(() -> testUserMapper.deleteUser(List.of(2L, 3L, 4L, 5L, 6L, 7L)));
+		assertThatNoException()
+			.isThrownBy(() -> ExcelUtils.doExport("测试用户Sheet页", 1000, new FileOutputStream("test.xlsx"),
+					new PageQuery(), testUserMapper, TestUserExcel.class, TestUserConvertor.INSTANCE));
+		assertThatNoException().isThrownBy(() -> FileUtils.deleteIfExists(Path.of("test.xlsx")));
+		assertThatNoException().isThrownBy(() -> testUserMapper.deleteUser(List.of(2L, 3L, 4L, 5L, 6L, 7L)));
 		count = testUserMapper.selectObjectCount(new PageQuery());
 		Assertions.assertEquals(1, count);
 	}

--- a/laokou-common/laokou-common-ftp/src/test/java/org/laokou/common/ftp/FtpTest.java
+++ b/laokou-common/laokou-common-ftp/src/test/java/org/laokou/common/ftp/FtpTest.java
@@ -30,6 +30,8 @@ import org.springframework.test.context.TestConstructor;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -46,12 +48,12 @@ class FtpTest {
 
 	@Test
 	void test() throws IOException {
-		Assertions.assertDoesNotThrow(() -> ftpTemplate.upload(ftpProperties.getDirectory(), "测试中文文本.txt",
+		assertThatNoException().isThrownBy(() -> ftpTemplate.upload(ftpProperties.getDirectory(), "测试中文文本.txt",
 				ResourceUtils.getResource("classpath:测试中文文本.txt").getInputStream()));
 		InputStream inputStream = ftpTemplate.download(ftpProperties.getDirectory(), "测试中文文本.txt");
 		Assertions.assertNotNull(inputStream);
 		Assertions.assertEquals("123", new String(inputStream.readAllBytes()).trim());
-		Assertions.assertDoesNotThrow(() -> ftpTemplate.delete(ftpProperties.getDirectory(), "测试中文文本.txt"));
+		assertThatNoException().isThrownBy(() -> ftpTemplate.delete(ftpProperties.getDirectory(), "测试中文文本.txt"));
 		Assertions.assertNull(ftpTemplate.download(ftpProperties.getDirectory(), "测试中文文本.txt"));
 	}
 

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
@@ -32,6 +32,8 @@ import org.springframework.test.context.TestConstructor;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -57,27 +59,27 @@ class MybatisUtilsTest {
 	void test() {
 		Assertions.assertNotNull(testUserMapper);
 		Assertions.assertNotNull(mybatisUtils);
-		Assertions.assertDoesNotThrow(
+		assertThatNoException().isThrownBy(
 				() -> mybatisUtils.batch(List.of(getTestUserDO()), TestUserMapper.class, TestUserMapper::insert));
 		List<TestUserDO> list = testUserMapper.selectList(Wrappers.emptyWrapper());
 		Assertions.assertEquals(2, list.size());
 		Assertions.assertTrue(list.stream().map(TestUserDO::getName).anyMatch("张三"::equals));
-		Assertions.assertDoesNotThrow(() -> testUserMapper.deleteTestUser(List.of(8L)));
+		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
 		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
-		Assertions.assertDoesNotThrow(() -> mybatisUtils.batch(List.of(getTestUserDO()), TestUserMapper.class, "master",
-				TestUserMapper::insert));
+		assertThatNoException().isThrownBy(() -> mybatisUtils.batch(List.of(getTestUserDO()), TestUserMapper.class,
+				"master", TestUserMapper::insert));
 		Assertions.assertEquals(2, testUserMapper.selectObjectCount(new PageQuery()));
-		Assertions.assertDoesNotThrow(() -> testUserMapper.deleteTestUser(List.of(8L)));
+		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
 		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
-		Assertions.assertDoesNotThrow(() -> mybatisUtils.batch(List.of(getTestUserDO()), 1000, 100, 180,
+		assertThatNoException().isThrownBy(() -> mybatisUtils.batch(List.of(getTestUserDO()), 1000, 100, 180,
 				TestUserMapper.class, "master", TestUserMapper::insert));
 		Assertions.assertEquals(2, testUserMapper.selectObjectCount(new PageQuery()));
-		Assertions.assertDoesNotThrow(() -> testUserMapper.deleteTestUser(List.of(8L)));
+		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
 		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
-		Assertions.assertDoesNotThrow(() -> mybatisUtils.batch(List.of(getTestUserDO()), 1000, 100, 180,
+		assertThatNoException().isThrownBy(() -> mybatisUtils.batch(List.of(getTestUserDO()), 1000, 100, 180,
 				TestUserMapper.class, TestUserMapper::insert));
 		Assertions.assertEquals(2, testUserMapper.selectObjectCount(new PageQuery()));
-		Assertions.assertDoesNotThrow(() -> testUserMapper.deleteTestUser(List.of(8L)));
+		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
 		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
 	}
 

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TransactionalUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TransactionalUtilsTest.java
@@ -30,6 +30,8 @@ import org.springframework.transaction.TransactionDefinition;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -45,32 +47,33 @@ class TransactionalUtilsTest {
 
 	@Test
 	void testWithoutResult() {
-		Assertions.assertDoesNotThrow(
-				() -> transactionalUtils.executeInTransaction(() -> testUserMapper.insert(getTestUserDO())));
+		assertThatNoException()
+			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.insert(getTestUserDO())));
 		Assertions.assertEquals(1,
 				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
-		Assertions.assertDoesNotThrow(
-				() -> transactionalUtils.executeInTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
-						TransactionDefinition.ISOLATION_READ_COMMITTED, false));
+		assertThatNoException()
+			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
+					TransactionDefinition.ISOLATION_READ_COMMITTED, false));
 		Assertions.assertEquals(0,
 				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
-		Assertions.assertDoesNotThrow(
-				() -> transactionalUtils.executeInNewTransaction(() -> testUserMapper.insert(getTestUserDO())));
+		assertThatNoException()
+			.isThrownBy(() -> transactionalUtils.executeInNewTransaction(() -> testUserMapper.insert(getTestUserDO())));
 		Assertions.assertEquals(1,
 				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
-		Assertions.assertDoesNotThrow(
+		assertThatNoException().isThrownBy(
 				() -> transactionalUtils.executeInNewTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
 						TransactionDefinition.ISOLATION_READ_COMMITTED, false));
 		Assertions.assertEquals(0,
 				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
-		Assertions.assertDoesNotThrow(() -> transactionalUtils.executeInTransaction(
-				() -> testUserMapper.insert(getTestUserDO()), TransactionDefinition.PROPAGATION_REQUIRED,
-				TransactionDefinition.ISOLATION_READ_COMMITTED, false));
+		assertThatNoException()
+			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.insert(getTestUserDO()),
+					TransactionDefinition.PROPAGATION_REQUIRED, TransactionDefinition.ISOLATION_READ_COMMITTED, false));
 		Assertions.assertEquals(1,
 				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
-		Assertions.assertDoesNotThrow(() -> transactionalUtils.executeInTransaction(
-				() -> testUserMapper.deleteTestUser(List.of(9L)), TransactionDefinition.PROPAGATION_REQUIRES_NEW,
-				TransactionDefinition.ISOLATION_READ_COMMITTED, false));
+		assertThatNoException()
+			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
+					TransactionDefinition.PROPAGATION_REQUIRES_NEW, TransactionDefinition.ISOLATION_READ_COMMITTED,
+					false));
 		Assertions.assertEquals(0,
 				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
 	}

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java
@@ -31,6 +31,8 @@ import org.springframework.util.DigestUtils;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author laokou
  */
@@ -112,8 +114,8 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				Assertions.assertNotNull(s);
-				Assertions.assertTrue(s.contains("test"));
+				assertThat(s).isNotBlank();
+				assertThat(s.contains("test")).isTrue();
 			}
 		});
 	}

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
@@ -42,6 +42,8 @@ import org.springframework.test.context.TestConstructor;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 /**
  * @author laokou
  */
@@ -97,69 +99,69 @@ class NamingUtilsTest {
 	void testGetAllInstances() throws NacosException, InterruptedException {
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service").isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service").isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty());
 
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", instance));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", instance));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 	}
 
 	@Test
 	void testSelectInstances() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true, false).isEmpty());
 
@@ -170,14 +172,14 @@ class NamingUtilsTest {
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty());
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
 	}
 
 	@Test
 	void testSelectOneHealthyInstance() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
@@ -190,55 +192,55 @@ class NamingUtilsTest {
 		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false));
 		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 	}
 
 	@Test
 	void testSubscribeService() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
 
 		// 只选择订阅ip为`127.0`开头的实例。
 		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
-		Assertions.assertDoesNotThrow(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 	}
 
 	@Test
 	void testGetServicesOfServer() throws NacosException, InterruptedException {
-		Assertions.assertDoesNotThrow(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
 
 		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0);
 		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10).getCount() > 0);
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
 		Assertions.assertFalse(namingUtils.getSubscribeServices().isEmpty());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
 		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
 	}
@@ -248,11 +250,11 @@ class NamingUtilsTest {
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
-		Assertions.assertDoesNotThrow(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		assertThatNoException().isThrownBy(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
 		Assertions.assertNotEquals(2, namingUtils.selectInstances("test-service", true).size());
 
-		Assertions.assertDoesNotThrow(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		assertThatNoException().isThrownBy(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
 		Assertions.assertEquals(0, namingUtils.selectInstances("test-service", false).size());
 	}
@@ -260,7 +262,7 @@ class NamingUtilsTest {
 	@Test
 	void testNacosServiceShutDown() throws InterruptedException {
 		Thread.sleep(1000);
-		Assertions.assertDoesNotThrow(namingUtils::nacosServiceShutDown);
+		assertThatNoException().isThrownBy(namingUtils::nacosServiceShutDown);
 	}
 
 }

--- a/laokou-common/laokou-common-network/laokou-common-network-mqtt-client/src/test/java/org/laokou/common/network/mqtt/client/VertxMqttClient2Test.java
+++ b/laokou-common/laokou-common-network/laokou-common-network-mqtt-client/src/test/java/org/laokou/common/network/mqtt/client/VertxMqttClient2Test.java
@@ -19,7 +19,6 @@ package org.laokou.common.network.mqtt.client;
 
 import io.vertx.core.Vertx;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.network.mqtt.client.config.SpringMqttClientProperties;
 import org.laokou.common.network.mqtt.client.config.VertxMqttClient;
@@ -28,6 +27,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author laokou
@@ -67,12 +68,12 @@ class VertxMqttClient2Test {
 			properties.setClientId("test-client-" + i);
 			VertxMqttClient vertxMqttClient = new VertxMqttClient(vertx, virtualThreadExecutor, properties,
 					mqttMessageHandlers);
-			Assertions.assertDoesNotThrow(vertxMqttClient::open);
+			assertThatNoException().isThrownBy(vertxMqttClient::open);
 			Thread.sleep(1000);
-			Assertions.assertDoesNotThrow(() -> vertxMqttClient.publish("/1/2/up/property/report", qos,
+			assertThatNoException().isThrownBy(() -> vertxMqttClient.publish("/1/2/up/property/report", qos,
 					"{\"id\":\"1\",\"name\":\"test\",\"value\":\"test\"}", false, false));
 			Thread.sleep(1000);
-			Assertions.assertDoesNotThrow(vertxMqttClient::close);
+			assertThatNoException().isThrownBy(vertxMqttClient::close);
 		}
 	}
 

--- a/laokou-common/laokou-common-network/laokou-common-network-mqtt-client/src/test/java/org/laokou/common/network/mqtt/client/VertxMqttClientTest.java
+++ b/laokou-common/laokou-common-network/laokou-common-network-mqtt-client/src/test/java/org/laokou/common/network/mqtt/client/VertxMqttClientTest.java
@@ -19,7 +19,6 @@ package org.laokou.common.network.mqtt.client;
 
 import io.vertx.core.Vertx;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.network.mqtt.client.config.SpringMqttClientProperties;
 import org.laokou.common.network.mqtt.client.config.VertxMqttClient;
@@ -29,6 +28,8 @@ import org.springframework.test.context.TestConstructor;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author laokou
@@ -55,11 +56,12 @@ class VertxMqttClientTest {
 		properties.setTopics(Map.of("$share/test-topic-1/#", 1));
 		VertxMqttClient vertxMqttClient = new VertxMqttClient(vertx, virtualThreadExecutor, properties,
 				mqttMessageHandlers);
-		Assertions.assertDoesNotThrow(vertxMqttClient::open);
+		assertThatNoException().isThrownBy(vertxMqttClient::open);
 		Thread.sleep(500);
-		Assertions.assertDoesNotThrow(() -> vertxMqttClient.publish("/test-topic-1/test", 1, "test", false, false));
+		assertThatNoException()
+			.isThrownBy(() -> vertxMqttClient.publish("/test-topic-1/test", 1, "test", false, false));
 		Thread.sleep(500);
-		Assertions.assertDoesNotThrow(vertxMqttClient::close);
+		assertThatNoException().isThrownBy(vertxMqttClient::close);
 		Thread.sleep(500);
 	}
 

--- a/laokou-common/laokou-common-vertx/src/test/java/org/laokou/common/vertx/HttpTest.java
+++ b/laokou-common/laokou-common-vertx/src/test/java/org/laokou/common/vertx/HttpTest.java
@@ -23,7 +23,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.util.JacksonUtils;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,6 +31,8 @@ import org.springframework.test.context.TestConstructor;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author laokou
@@ -64,7 +65,7 @@ class HttpTest {
 				}
 			});
 			Thread.sleep(2000);
-			Assertions.assertDoesNotThrow(webSocketClient::close);
+			assertThatNoException().isThrownBy(webSocketClient::close);
 		}
 	}
 
@@ -94,7 +95,7 @@ class HttpTest {
 				request.end();
 			});
 			Thread.sleep(1000);
-			Assertions.assertDoesNotThrow(httpClient::close);
+			assertThatNoException().isThrownBy(httpClient::close);
 		}
 	}
 

--- a/laokou-common/laokou-common-vertx/src/test/java/org/laokou/common/vertx/TcpTest.java
+++ b/laokou-common/laokou-common-vertx/src/test/java/org/laokou/common/vertx/TcpTest.java
@@ -23,10 +23,11 @@ import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author laokou
@@ -51,14 +52,14 @@ class TcpTest {
 			netClient.connect(connectOptions).onComplete(res -> {
 				if (res.succeeded()) {
 					log.info("【Vertx-TCP-Client】 => 连接成功，端口：{}", finalI);
-					Assertions.assertDoesNotThrow(() -> res.result().write("发送数据，" + finalI + " ---> 123"));
+					assertThatNoException().isThrownBy(() -> res.result().write("发送数据，" + finalI + " ---> 123"));
 				}
 				else {
 					log.info("【Vertx-TCP-Client】 => 连接失败，端口：{}", finalI);
 				}
 			});
 			Thread.sleep(2000);
-			Assertions.assertDoesNotThrow(netClient::close);
+			assertThatNoException().isThrownBy(netClient::close);
 		}
 	}
 

--- a/laokou-common/laokou-common-vertx/src/test/java/org/laokou/common/vertx/UdpTest.java
+++ b/laokou-common/laokou-common-vertx/src/test/java/org/laokou/common/vertx/UdpTest.java
@@ -21,10 +21,11 @@ import io.vertx.core.Vertx;
 import io.vertx.core.datagram.DatagramSocket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author laokou
@@ -52,7 +53,7 @@ class UdpTest {
 				}
 			});
 			Thread.sleep(2000);
-			Assertions.assertDoesNotThrow(datagramSocket::close);
+			assertThatNoException().isThrownBy(datagramSocket::close);
 		}
 	}
 

--- a/laokou-common/laokou-common-xss/src/test/java/org/laokou/common/xss/XssTest.java
+++ b/laokou-common/laokou-common-xss/src/test/java/org/laokou/common/xss/XssTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.xss.util.XssUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author laokou
  */
@@ -64,10 +66,10 @@ class XssTest {
 	void testHtmlScriptJsonString() {
 		String json = "{\"s\": \"" + xssAttackVectors[3] + "\"}";
 		String cleaned = XssUtils.clearHtml(json);
-		Assertions.assertEquals(
-				"{\"s\": \"/*-/*`/*\\`/*'/*\"/**/(/* */onerror=alert(1) )//%0D%0A%0d%0a//\\x3csVg/\\x3e\"}", cleaned);
-		Assertions.assertTrue(cleaned.startsWith("{") && cleaned.endsWith("}"));
-		Assertions.assertFalse(cleaned.contains("javascript:"));
+		assertThat(cleaned)
+			.isEqualTo("{\"s\": \"/*-/*`/*\\`/*'/*\"/**/(/* */onerror=alert(1) )//%0D%0A%0d%0a//\\x3csVg/\\x3e\"}");
+		assertThat(cleaned.startsWith("{") && cleaned.endsWith("}")).isTrue();
+		assertThat(cleaned.contains("javascript:")).isFalse();
 	}
 
 	@Test

--- a/laokou-service/laokou-admin/laokou-admin-start/src/test/java/org/laokou/admin/CommonTest.java
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/test/java/org/laokou/admin/CommonTest.java
@@ -19,7 +19,6 @@ package org.laokou.admin;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.laokou.common.core.util.OkHttpUtils;
 import org.laokou.common.i18n.util.JacksonUtils;
@@ -34,6 +33,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.security.Principal;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.laokou.common.security.config.GlobalOpaqueTokenIntrospector.FULL;
 
 /**
@@ -54,7 +55,7 @@ class CommonTest {
 	void setUp() throws JsonProcessingException {
 		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 		OAuth2Authorization authorization = oAuth2AuthorizationService.findByToken(getToken(), FULL);
-		Assertions.assertNotNull(authorization);
+		assertThat(authorization).isNotNull();
 		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = authorization
 			.getAttribute(Principal.class.getName());
 		SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/AuthATest.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/AuthATest.java
@@ -17,7 +17,6 @@
 
 package org.laokou.auth;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.auth.model.*;
 import org.laokou.auth.factory.DomainFactory;
@@ -109,62 +108,62 @@ class AuthATest {
 		String decryptUsername = RSAUtils.decryptByPrivateKey(encryptUsername);
 		String encryptPassword = RSAUtils.encryptByPublicKey(password);
 		String decryptPassword = RSAUtils.decryptByPrivateKey(encryptPassword);
-		Assertions.assertEquals(username, decryptUsername);
-		Assertions.assertEquals(password, decryptPassword);
+		assertThat(username).isEqualTo(decryptUsername);
+		assertThat(password).isEqualTo(decryptPassword);
 		AuthA authA = getAuth(encryptUsername, encryptPassword, GrantTypeEnum.USERNAME_PASSWORD, EMPTY, EMPTY);
-		Assertions.assertDoesNotThrow(authA::decryptUsernamePassword);
-		Assertions.assertEquals(username, authA.getUsername());
-		Assertions.assertEquals(password, authA.getPassword());
+		assertThatNoException().isThrownBy(authA::decryptUsernamePassword);
+		assertThat(authA.getUsername()).isEqualTo(username);
+		assertThat(authA.getPassword()).isEqualTo(password);
 	}
 
 	@Test
 	void testCreateUserByTest() throws Exception {
 		AuthA authA = getAuth("admin", "123", GrantTypeEnum.TEST, EMPTY, EMPTY);
 		// 创建用户【测试】
-		Assertions.assertDoesNotThrow(authA::createUserByTest);
+		assertThatNoException().isThrownBy(authA::createUserByTest);
 		UserE user = authA.getUser();
-		Assertions.assertNotNull(user);
-		Assertions.assertEquals(AESUtils.encrypt("admin"), user.getUsername());
+		assertThat(user).isNotNull();
+		assertThat(user.getUsername()).isEqualTo(AESUtils.encrypt("admin"));
 	}
 
 	@Test
 	void testCreateUserByUsernamePassword() throws Exception {
 		AuthA authA = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
 		// 创建用户【用户名密码】
-		Assertions.assertDoesNotThrow(authA::createUserByUsernamePassword);
+		assertThatNoException().isThrownBy(authA::createUserByUsernamePassword);
 		UserE user = authA.getUser();
-		Assertions.assertNotNull(user);
-		Assertions.assertEquals(AESUtils.encrypt("admin"), user.getUsername());
+		assertThat(user).isNotNull();
+		assertThat(user.getUsername()).isEqualTo(AESUtils.encrypt("admin"));
 	}
 
 	@Test
 	void testCreateUserByMobile() throws Exception {
 		AuthA authA = getAuth(EMPTY, EMPTY, GrantTypeEnum.MOBILE, "18888888888", "123456");
 		// 创建用户【手机号】
-		Assertions.assertDoesNotThrow(authA::createUserByMobile);
+		assertThatNoException().isThrownBy(authA::createUserByMobile);
 		UserE user = authA.getUser();
-		Assertions.assertNotNull(user);
-		Assertions.assertEquals(AESUtils.encrypt("18888888888"), user.getMobile());
+		assertThat(user).isNotNull();
+		assertThat(user.getMobile()).isEqualTo(AESUtils.encrypt("18888888888"));
 	}
 
 	@Test
 	void testCreateUserByMail() throws Exception {
 		AuthA authA = getAuth(EMPTY, EMPTY, GrantTypeEnum.MAIL, "2413176044@qq.com", "123456");
 		// 创建用户【邮箱】
-		Assertions.assertDoesNotThrow(authA::createUserByMail);
+		assertThatNoException().isThrownBy(authA::createUserByMail);
 		UserE user = authA.getUser();
-		Assertions.assertNotNull(user);
-		Assertions.assertEquals(AESUtils.encrypt("2413176044@qq.com"), user.getMail());
+		assertThat(user).isNotNull();
+		assertThat(user.getMail()).isEqualTo(AESUtils.encrypt("2413176044@qq.com"));
 	}
 
 	@Test
 	void testCreateUserByAuthorizationCode() throws Exception {
 		AuthA authA = getAuth("admin", "123", GrantTypeEnum.AUTHORIZATION_CODE, EMPTY, EMPTY);
 		// 创建用户【授权码】
-		Assertions.assertDoesNotThrow(authA::createUserByAuthorizationCode);
+		assertThatNoException().isThrownBy(authA::createUserByAuthorizationCode);
 		UserE user = authA.getUser();
-		Assertions.assertNotNull(user);
-		Assertions.assertEquals(AESUtils.encrypt("admin"), user.getUsername());
+		assertThat(user).isNotNull();
+		assertThat(user.getUsername()).isEqualTo(AESUtils.encrypt("admin"));
 	}
 
 	@Test
@@ -174,9 +173,9 @@ class AuthATest {
 		// 校验租户ID
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
 		// 获取租户ID
-		Assertions.assertDoesNotThrow(auth::createUserByUsernamePassword);
-		Assertions.assertDoesNotThrow(() -> auth.getTenantId(tenantGateway.getTenantId(auth.getTenantCode())));
-		Assertions.assertDoesNotThrow(auth::checkTenantId);
+		assertThatNoException().isThrownBy(auth::createUserByUsernamePassword);
+		assertThatNoException().isThrownBy(() -> auth.getTenantId(tenantGateway.getTenantId(auth.getTenantCode())));
+		assertThatNoException().isThrownBy(auth::checkTenantId);
 		// 校验调用次数
 		verify(tenantGateway, times(1)).getTenantId("laokou");
 	}
@@ -192,13 +191,13 @@ class AuthATest {
 			.validateCaptcha(RedisKeyUtils.getMobileAuthCaptchaKey("18888888888"), "123456");
 		// 校验验证码【用户名密码登录】
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
-		Assertions.assertDoesNotThrow(auth::checkCaptcha);
+		assertThatNoException().isThrownBy(auth::checkCaptcha);
 		// 校验验证码【邮箱登录】
 		AuthA auth1 = getAuth(EMPTY, EMPTY, GrantTypeEnum.MAIL, "2413176044@qq.com", "123456");
-		Assertions.assertDoesNotThrow(auth1::checkCaptcha);
+		assertThatNoException().isThrownBy(auth1::checkCaptcha);
 		// 校验验证码【手机号登录】
 		AuthA auth2 = getAuth(EMPTY, EMPTY, GrantTypeEnum.MOBILE, "18888888888", "123456");
-		Assertions.assertDoesNotThrow(auth2::checkCaptcha);
+		assertThatNoException().isThrownBy(auth2::checkCaptcha);
 		// 校验调用次数
 		verify(captchaValidator, times(1)).validateCaptcha(RedisKeyUtils.getUsernamePasswordAuthCaptchaKey("1"),
 				"1234");
@@ -215,8 +214,8 @@ class AuthATest {
 		when(userGateway.getUserProfile(user)).thenReturn(user);
 		// 校验用户名
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
-		Assertions.assertDoesNotThrow(() -> auth.getUserInfo(userGateway.getUserProfile(user)));
-		Assertions.assertDoesNotThrow(auth::checkUsername);
+		assertThatNoException().isThrownBy(() -> auth.getUserInfo(userGateway.getUserProfile(user)));
+		assertThatNoException().isThrownBy(auth::checkUsername);
 	}
 
 	@Test
@@ -225,52 +224,52 @@ class AuthATest {
 		doReturn(true).when(passwordValidator).validatePassword("123", "202cb962ac59075b964b07152d234b70");
 		// 创建用户【用户名密码】
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
-		Assertions.assertDoesNotThrow(auth::createUserByUsernamePassword);
-		Assertions.assertNotNull(auth.getUser());
+		assertThatNoException().isThrownBy(auth::createUserByUsernamePassword);
+		assertThat(auth.getUser()).isNotNull();
 		// 构建密码
 		UserE user = auth.getUser();
-		Assertions.assertDoesNotThrow(() -> user
+		assertThatNoException().isThrownBy(() -> user
 			.setPassword(DigestUtils.md5DigestAsHex(auth.getPassword().getBytes(StandardCharsets.UTF_8))));
 		// 校验密码
-		Assertions.assertDoesNotThrow(auth::checkPassword);
+		assertThatNoException().isThrownBy(auth::checkPassword);
 	}
 
 	@Test
 	void testCheckUserStatus() {
 		// 创建用户【用户名密码】
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
-		Assertions.assertDoesNotThrow(auth::createUserByUsernamePassword);
-		Assertions.assertNotNull(auth.getUser());
+		assertThatNoException().isThrownBy(auth::createUserByUsernamePassword);
+		assertThat(auth.getUser()).isNotNull();
 		// 校验用户状态
-		Assertions.assertDoesNotThrow(auth::checkUserStatus);
+		assertThatNoException().isThrownBy(auth::checkUserStatus);
 	}
 
 	@Test
 	void testCheckMenuPermissions() {
 		// 创建用户【用户名密码】
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
-		Assertions.assertDoesNotThrow(auth::createUserByUsernamePassword);
+		assertThatNoException().isThrownBy(auth::createUserByUsernamePassword);
 		UserE user = auth.getUser();
-		Assertions.assertNotNull(user);
+		assertThat(user).isNotNull();
 		// 构造菜单
 		when(menuGateway.getMenuPermissions(user)).thenReturn(Set.of("sys:user:page"));
 		// 校验菜单权限集合
-		Assertions.assertDoesNotThrow(() -> auth.getMenuPermissions(menuGateway.getMenuPermissions(user)));
-		Assertions.assertDoesNotThrow(auth::checkMenuPermissions);
+		assertThatNoException().isThrownBy(() -> auth.getMenuPermissions(menuGateway.getMenuPermissions(user)));
+		assertThatNoException().isThrownBy(auth::checkMenuPermissions);
 	}
 
 	@Test
 	void testCheckDeptPaths() {
 		// 创建用户【用户名密码】
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
-		Assertions.assertDoesNotThrow(auth::createUserByUsernamePassword);
+		assertThatNoException().isThrownBy(auth::createUserByUsernamePassword);
 		UserE user = auth.getUser();
-		Assertions.assertNotNull(user);
+		assertThat(user).isNotNull();
 		// 构造部门
 		when(deptGateway.getDeptPaths(user)).thenReturn(new ArrayList<>(List.of("0", "0,1")));
 		// 校验部门路径集合
-		Assertions.assertDoesNotThrow(() -> auth.getDeptPaths(deptGateway.getDeptPaths(user)));
-		Assertions.assertDoesNotThrow(auth::checkDeptPaths);
+		assertThatNoException().isThrownBy(() -> auth.getDeptPaths(deptGateway.getDeptPaths(user)));
+		assertThatNoException().isThrownBy(auth::checkDeptPaths);
 	}
 
 	private AuthA getAuth(String username, String password, GrantTypeEnum grantTypeEnum, String uuid, String captcha) {

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/CaptchaETest.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/CaptchaETest.java
@@ -17,7 +17,6 @@
 
 package org.laokou.auth;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.auth.factory.DomainFactory;
 import org.laokou.auth.gateway.*;
@@ -28,6 +27,7 @@ import org.laokou.auth.model.SendCaptchaTypeEnum;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.laokou.auth.model.SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA;
 import static org.mockito.Mockito.*;
 
@@ -71,8 +71,9 @@ class CaptchaETest {
 		// 校验租户ID
 		CaptchaE captchaE = getCaptcha(SEND_MAIL_CAPTCHA.getCode());
 		// 获取租户ID
-		Assertions.assertDoesNotThrow(() -> captchaE.getTenantId(tenantGateway.getTenantId(captchaE.getTenantCode())));
-		Assertions.assertDoesNotThrow(captchaE::checkTenantId);
+		assertThatNoException()
+			.isThrownBy(() -> captchaE.getTenantId(tenantGateway.getTenantId(captchaE.getTenantCode())));
+		assertThatNoException().isThrownBy(captchaE::checkTenantId);
 		// 校验调用次数
 		verify(tenantGateway, times(1)).getTenantId("laokou");
 	}

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/DomainServiceTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/DomainServiceTest.java
@@ -17,7 +17,6 @@
 
 package org.laokou.auth;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.auth.ability.DomainService;
 import org.laokou.auth.model.CaptchaValidator;
@@ -35,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.laokou.auth.model.SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA;
 import static org.laokou.auth.model.SendCaptchaTypeEnum.SEND_MOBILE_CAPTCHA;
 import static org.laokou.common.i18n.common.constant.StringConstants.EMPTY;
@@ -103,7 +103,7 @@ class DomainServiceTest {
 	void testUsernamePasswordAuth() {
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
 		// 创建用户【用户名密码】
-		Assertions.assertDoesNotThrow(auth::createUserByUsernamePassword);
+		assertThatNoException().isThrownBy(auth::createUserByUsernamePassword);
 		// 构造租户
 		when(tenantGateway.getTenantId("laokou")).thenReturn(0L);
 		// 构造验证码校验
@@ -111,7 +111,7 @@ class DomainServiceTest {
 			.validateCaptcha(RedisKeyUtils.getUsernamePasswordAuthCaptchaKey("1"), "1234");
 		// 构造用户信息
 		UserE user = auth.getUser();
-		Assertions.assertDoesNotThrow(() -> user
+		assertThatNoException().isThrownBy(() -> user
 			.setPassword(DigestUtils.md5DigestAsHex(auth.getPassword().getBytes(StandardCharsets.UTF_8))));
 		when(userGateway.getUserProfile(user)).thenReturn(user);
 		// 构造密码校验
@@ -121,7 +121,7 @@ class DomainServiceTest {
 		// 构造部门
 		when(deptGateway.getDeptPaths(user)).thenReturn(new ArrayList<>(List.of("0", "0,1")));
 		// 用户名密码登录
-		Assertions.assertDoesNotThrow(() -> domainService.auth(auth));
+		assertThatNoException().isThrownBy(() -> domainService.auth(auth));
 		// 校验调用次数
 		verify(deptGateway, times(1)).getDeptPaths(user);
 		verify(menuGateway, times(1)).getMenuPermissions(user);
@@ -136,7 +136,7 @@ class DomainServiceTest {
 	void testMailAuth() {
 		AuthA auth = getAuth(EMPTY, EMPTY, GrantTypeEnum.MAIL, "2413176044@qq.com", "123456");
 		// 创建用户【邮箱】
-		Assertions.assertDoesNotThrow(auth::createUserByMail);
+		assertThatNoException().isThrownBy(auth::createUserByMail);
 		// 构造租户
 		when(tenantGateway.getTenantId("laokou")).thenReturn(0L);
 		// 构造验证码校验
@@ -150,7 +150,7 @@ class DomainServiceTest {
 		// 构造部门
 		when(deptGateway.getDeptPaths(user)).thenReturn(new ArrayList<>(List.of("0", "0,1")));
 		// 邮箱登录
-		Assertions.assertDoesNotThrow(() -> domainService.auth(auth));
+		assertThatNoException().isThrownBy(() -> domainService.auth(auth));
 		// 校验调用次数
 		verify(deptGateway, times(1)).getDeptPaths(user);
 		verify(menuGateway, times(1)).getMenuPermissions(user);
@@ -164,7 +164,7 @@ class DomainServiceTest {
 	void testMobileAuth() {
 		AuthA auth = getAuth(EMPTY, EMPTY, GrantTypeEnum.MOBILE, "18888888888", "123456");
 		// 创建用户【手机号】
-		Assertions.assertDoesNotThrow(auth::createUserByMobile);
+		assertThatNoException().isThrownBy(auth::createUserByMobile);
 		// 构造租户
 		when(tenantGateway.getTenantId("laokou")).thenReturn(0L);
 		// 构造验证码校验
@@ -178,7 +178,7 @@ class DomainServiceTest {
 		// 构造部门
 		when(deptGateway.getDeptPaths(user)).thenReturn(new ArrayList<>(List.of("0", "0,1")));
 		// 手机号登录
-		Assertions.assertDoesNotThrow(() -> domainService.auth(auth));
+		assertThatNoException().isThrownBy(() -> domainService.auth(auth));
 		// 校验调用次数
 		verify(deptGateway, times(1)).getDeptPaths(user);
 		verify(menuGateway, times(1)).getMenuPermissions(user);
@@ -190,12 +190,12 @@ class DomainServiceTest {
 	void testAuthorizationCodeAuth() {
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.AUTHORIZATION_CODE, EMPTY, EMPTY);
 		// 创建用户【授权码】
-		Assertions.assertDoesNotThrow(auth::createUserByAuthorizationCode);
+		assertThatNoException().isThrownBy(auth::createUserByAuthorizationCode);
 		// 构造租户
 		when(tenantGateway.getTenantId("laokou")).thenReturn(0L);
 		// 构造用户信息
 		UserE user = auth.getUser();
-		Assertions.assertDoesNotThrow(() -> user
+		assertThatNoException().isThrownBy(() -> user
 			.setPassword(DigestUtils.md5DigestAsHex(auth.getPassword().getBytes(StandardCharsets.UTF_8))));
 		when(userGateway.getUserProfile(user)).thenReturn(user);
 		// 构造密码校验
@@ -205,7 +205,7 @@ class DomainServiceTest {
 		// 构造部门
 		when(deptGateway.getDeptPaths(user)).thenReturn(new ArrayList<>(List.of("0", "0,1")));
 		// 授权码登录
-		Assertions.assertDoesNotThrow(() -> domainService.auth(auth));
+		assertThatNoException().isThrownBy(() -> domainService.auth(auth));
 		// 校验调用次数
 		verify(deptGateway, times(1)).getDeptPaths(user);
 		verify(menuGateway, times(1)).getMenuPermissions(user);
@@ -218,12 +218,12 @@ class DomainServiceTest {
 	void testTestAuth() {
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.TEST, EMPTY, EMPTY);
 		// 创建用户【测试】
-		Assertions.assertDoesNotThrow(auth::createUserByTest);
+		assertThatNoException().isThrownBy(auth::createUserByTest);
 		// 构造租户
 		when(tenantGateway.getTenantId("laokou")).thenReturn(0L);
 		// 构造用户信息
 		UserE user = auth.getUser();
-		Assertions.assertDoesNotThrow(() -> user
+		assertThatNoException().isThrownBy(() -> user
 			.setPassword(DigestUtils.md5DigestAsHex(auth.getPassword().getBytes(StandardCharsets.UTF_8))));
 		when(userGateway.getUserProfile(user)).thenReturn(user);
 		// 构造密码校验
@@ -233,7 +233,7 @@ class DomainServiceTest {
 		// 构造部门
 		when(deptGateway.getDeptPaths(user)).thenReturn(new ArrayList<>(List.of("0", "0,1")));
 		// 测试登录
-		Assertions.assertDoesNotThrow(() -> domainService.auth(auth));
+		assertThatNoException().isThrownBy(() -> domainService.auth(auth));
 		// 校验调用次数
 		verify(deptGateway, times(1)).getDeptPaths(user);
 		verify(menuGateway, times(1)).getMenuPermissions(user);
@@ -246,39 +246,39 @@ class DomainServiceTest {
 	void testCreateLoginLog() {
 		LoginLogE loginLog = DomainFactory.getLoginLog();
 		// 创建登录日志
-		Assertions.assertDoesNotThrow(() -> domainService.createLoginLog(loginLog));
+		assertThatNoException().isThrownBy(() -> domainService.createLoginLog(loginLog));
 	}
 
 	@Test
 	void testCreateSendCaptchaInfoByMail() {
 		// 创建发送验证码信息
 		CaptchaE captcha = getCaptcha("2413176044@qq.com", SEND_MAIL_CAPTCHA.getCode());
-		Assertions.assertDoesNotThrow(() -> domainService.createSendCaptchaInfo(captcha));
+		assertThatNoException().isThrownBy(() -> domainService.createSendCaptchaInfo(captcha));
 	}
 
 	@Test
 	void testCreateSendCaptchaInfoByMobile() {
 		// 创建发送验证码信息
 		CaptchaE captcha = getCaptcha("18888888888", SEND_MOBILE_CAPTCHA.getCode());
-		Assertions.assertDoesNotThrow(() -> domainService.createSendCaptchaInfo(captcha));
+		assertThatNoException().isThrownBy(() -> domainService.createSendCaptchaInfo(captcha));
 	}
 
 	@Test
 	void testCreateNoticeLogByMailCaptcha() {
 		// 创建通知日志
 		NoticeLogE noticeLog = DomainFactory.getNoticeLog();
-		Assertions.assertDoesNotThrow(() -> noticeLog.setCode(SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA.getCode()));
-		Assertions.assertDoesNotThrow(() -> noticeLog.setStatus(SendCaptchaStatusEnum.OK.getCode()));
-		Assertions.assertDoesNotThrow(() -> domainService.createNoticeLog(noticeLog));
+		assertThatNoException().isThrownBy(() -> noticeLog.setCode(SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA.getCode()));
+		assertThatNoException().isThrownBy(() -> noticeLog.setStatus(SendCaptchaStatusEnum.OK.getCode()));
+		assertThatNoException().isThrownBy(() -> domainService.createNoticeLog(noticeLog));
 	}
 
 	@Test
 	void testCreateNoticeLogByMobileCaptcha() {
 		// 创建通知日志
 		NoticeLogE noticeLog = DomainFactory.getNoticeLog();
-		Assertions.assertDoesNotThrow(() -> noticeLog.setCode(SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA.getCode()));
-		Assertions.assertDoesNotThrow(() -> noticeLog.setStatus(SendCaptchaStatusEnum.OK.getCode()));
-		Assertions.assertDoesNotThrow(() -> domainService.createNoticeLog(noticeLog));
+		assertThatNoException().isThrownBy(() -> noticeLog.setCode(SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA.getCode()));
+		assertThatNoException().isThrownBy(() -> noticeLog.setStatus(SendCaptchaStatusEnum.OK.getCode()));
+		assertThatNoException().isThrownBy(() -> domainService.createNoticeLog(noticeLog));
 	}
 
 	private CaptchaE getCaptcha(String uuid, String tag) {

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/AuthParamValidatorTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/AuthParamValidatorTest.java
@@ -17,7 +17,6 @@
 
 package org.laokou.auth;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.auth.factory.DomainFactory;
 import org.laokou.auth.model.AuthA;
@@ -27,6 +26,8 @@ import org.laokou.auth.model.GrantTypeEnum;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.laokou.common.i18n.common.constant.StringConstants.EMPTY;
 
 /**
@@ -64,36 +65,36 @@ class AuthParamValidatorTest {
 	void testTestAuthParamValidator() {
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.TEST, EMPTY, EMPTY);
 		// 校验测试登录
-		Assertions.assertDoesNotThrow(() -> testAuthParamValidator.validateAuth(auth));
+		assertThatNoException().isThrownBy(() -> testAuthParamValidator.validateAuth(auth));
 	}
 
 	@Test
 	void testUsernamePasswordAuthParamValidator() {
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.USERNAME_PASSWORD, "1", "1234");
 		// 校验用户名密码登录
-		Assertions.assertDoesNotThrow(() -> usernamePasswordAuthParamValidator.validateAuth(auth));
+		assertThatNoException().isThrownBy(() -> usernamePasswordAuthParamValidator.validateAuth(auth));
 	}
 
 	@Test
 	void testAuthorizationCodeAuthParamValidator() {
 		AuthA auth = getAuth("admin", "123", GrantTypeEnum.AUTHORIZATION_CODE, EMPTY, EMPTY);
 		// 校验授权码登录
-		Assertions.assertDoesNotThrow(() -> authorizationCodeAuthParamValidator.validateAuth(auth));
+		assertThatNoException().isThrownBy(() -> authorizationCodeAuthParamValidator.validateAuth(auth));
 	}
 
 	@Test
 	void testMailAuthParamValidator() {
 		AuthA auth = getAuth(EMPTY, EMPTY, GrantTypeEnum.MAIL, "2413176044@qq.com", "123456");
 		// 校验邮箱登录
-		Assertions.assertDoesNotThrow(() -> mailAuthParamValidator.validateAuth(auth));
+		assertThatNoException().isThrownBy(() -> mailAuthParamValidator.validateAuth(auth));
 	}
 
 	@Test
 	void testMobileAuthParamValidator() {
 		AuthA auth = getAuth(EMPTY, EMPTY, GrantTypeEnum.MOBILE, "18888888888", "123456");
-		Assertions.assertNotNull(auth);
+		assertThat(auth).isNotNull();
 		// 校验手机号登录
-		Assertions.assertDoesNotThrow(() -> mobileAuthParamValidator.validateAuth(auth));
+		assertThatNoException().isThrownBy(() -> mobileAuthParamValidator.validateAuth(auth));
 	}
 
 	private AuthA getAuth(String username, String password, GrantTypeEnum grantTypeEnum, String uuid, String captcha) {

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/CaptchaParamValidatorTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/CaptchaParamValidatorTest.java
@@ -17,7 +17,6 @@
 
 package org.laokou.auth;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.auth.factory.DomainFactory;
 import org.laokou.auth.model.*;
@@ -25,6 +24,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.laokou.auth.model.SendCaptchaTypeEnum.SEND_MAIL_CAPTCHA;
 import static org.laokou.auth.model.SendCaptchaTypeEnum.SEND_MOBILE_CAPTCHA;
 
@@ -56,14 +56,14 @@ class CaptchaParamValidatorTest {
 	void testMailCaptchaParamValidator() {
 		CaptchaE captcha = getCaptcha("2413176044@qq.com", SEND_MAIL_CAPTCHA.getCode());
 		// 校验邮箱验证码
-		Assertions.assertDoesNotThrow(() -> mailCaptchaParamValidator.validateCaptcha(captcha));
+		assertThatNoException().isThrownBy(() -> mailCaptchaParamValidator.validateCaptcha(captcha));
 	}
 
 	@Test
 	void testMobileCaptchaParamValidator() {
 		CaptchaE captcha = getCaptcha("18888888888", SEND_MOBILE_CAPTCHA.getCode());
 		// 校验手机号验证码
-		Assertions.assertDoesNotThrow(() -> mobileCaptchaParamValidator.validateCaptcha(captcha));
+		assertThatNoException().isThrownBy(() -> mobileCaptchaParamValidator.validateCaptcha(captcha));
 	}
 
 	private CaptchaE getCaptcha(String uuid, String tag) {

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -19,7 +19,6 @@ package org.laokou.auth;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.auth.dto.CaptchaSendCmd;
 import org.laokou.auth.dto.TokenRemoveCmd;
@@ -49,6 +48,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.laokou.common.i18n.common.constant.StringConstants.RISK;
 import static org.laokou.common.i18n.common.constant.TraceConstants.REQUEST_ID;
@@ -149,7 +149,7 @@ class OAuth2ApiTest {
 	void testEncodePassword() {
 		String pwd = passwordEncoder.encode(PASSWORD);
 		log.info("生成密码：{}", pwd);
-		Assertions.assertTrue(passwordEncoder.matches(PASSWORD, pwd));
+		assertThat(passwordEncoder.matches(PASSWORD, pwd)).isTrue();
 	}
 
 	@Test
@@ -160,8 +160,8 @@ class OAuth2ApiTest {
 		String encryptPassword = RSAUtils.encryptByPublicKey(PASSWORD);
 		String decryptUsername = RSAUtils.decryptByPrivateKey(encryptUsername);
 		String decryptPassword = RSAUtils.decryptByPrivateKey(encryptPassword);
-		Assertions.assertEquals(USERNAME, decryptUsername);
-		Assertions.assertEquals(PASSWORD, decryptPassword);
+		assertThat(decryptUsername).isEqualTo(USERNAME);
+		assertThat(decryptPassword).isEqualTo(PASSWORD);
 		Map<String, String> tokenMap = usernamePasswordAuth(captcha, encryptUsername, encryptPassword);
 		log.info("验证码：{}", captcha);
 		log.info("加密用户名：{}", encryptUsername);
@@ -278,7 +278,7 @@ class OAuth2ApiTest {
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=");
 			String json = HttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("设备授权码认证模式，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtils.readTree(json).get("refresh_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
@@ -297,7 +297,7 @@ class OAuth2ApiTest {
 					"Basic OTVUeFNzVFBGQTN0RjEyVEJTTW1VVkswZGE6RnBId0lmdzR3WTkyZE8=");
 			String json = HttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("客户端认证模式，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
 			return Map.of(ACCESS_TOKEN, accessToken);
@@ -316,7 +316,7 @@ class OAuth2ApiTest {
 					"Basic ZWI3RGVkNWJiRmJkNzg5NmY4YTJjZmREYzk6RHBBa1BmejRlVzE4ZDI=");
 			String json = HttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("授权码认证模式，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtils.readTree(json).get("refresh_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
@@ -343,7 +343,7 @@ class OAuth2ApiTest {
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
 			String json = HttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("手机号认证，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtils.readTree(json).get("refresh_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
@@ -364,7 +364,7 @@ class OAuth2ApiTest {
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
 			String json = HttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("邮箱认证，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtils.readTree(json).get("refresh_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
@@ -385,7 +385,7 @@ class OAuth2ApiTest {
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
 			String json = OkHttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("用户名密码认证模式，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtils.readTree(json).get("refresh_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
@@ -406,7 +406,7 @@ class OAuth2ApiTest {
 					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0");
 			String json = OkHttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("测试认证模式，返回信息：{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			String accessToken = JacksonUtils.readTree(json).get("access_token").asText();
 			String refreshToken = JacksonUtils.readTree(json).get("refresh_token").asText();
 			Assert.isTrue(StringUtils.isNotEmpty(accessToken), "access token is empty");
@@ -424,7 +424,7 @@ class OAuth2ApiTest {
 			Map<String, String> headers = Collections.singletonMap("Authorization", secretHeadValue);
 			String json = HttpUtils.doFormDataPost(apiUrl, params, headers);
 			log.info("刷新令牌模式，返回信息；{}", json);
-			Assertions.assertNotNull(json);
+			assertThat(json).isNotEmpty();
 			return JacksonUtils.readTree(json).get("access_token").asText();
 		}
 		catch (Exception e) {

--- a/laokou-service/laokou-oss/laokou-oss-start/src/test/java/org/laokou/oss/OssTest.java
+++ b/laokou-service/laokou-oss/laokou-oss-start/src/test/java/org/laokou/oss/OssTest.java
@@ -18,7 +18,6 @@
 package org.laokou.oss;
 
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.FileUtils;
 import org.laokou.common.core.util.UUIDGenerator;
@@ -28,6 +27,8 @@ import org.laokou.oss.api.OssServiceI;
 import org.laokou.oss.dto.OssUploadCmd;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -44,9 +45,9 @@ class OssTest {
 		byte[] bytes = ResourceUtils.getResource("classpath:1.jpg").getInputStream().readAllBytes();
 		Result<String> result = ossServiceI.uploadOss(new OssUploadCmd("image", bytes,
 				UUIDGenerator.generateUUID() + ".jpg", ".jpg", "image/jpeg", bytes.length));
-		Assertions.assertTrue(result.success());
-		Assertions.assertEquals("OK", result.getCode());
-		Assertions.assertArrayEquals(bytes, FileUtils.getBytesByUrl(result.getData()));
+		assertThat(result.success()).isTrue();
+		assertThat(result.getCode()).isEqualTo("OK");
+		assertThat(FileUtils.getBytesByUrl(result.getData())).isEqualTo(bytes);
 	}
 
 }


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Replace JUnit `assertDoesNotThrow` with AssertJ `assertThatNoException`

- Replace JUnit assertions with AssertJ equivalents

- Add AssertJ static imports across test files

- Remove unused JUnit Assertions imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JUnit Assertions"] --> B["AssertJ Assertions"]
  B --> C["assertDoesNotThrow()"]
  B --> D["assertEquals()"]
  B --> E["assertTrue()"]
  C --> F["assertThatNoException().isThrownBy()"]
  D --> G["assertThat().isEqualTo()"]
  E --> H["assertThat().isTrue()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated all test assertions to use AssertJ's fluent assertion style instead of JUnit's built-in assertions across the codebase.
  * Improved consistency and readability in test cases by standardizing assertion methods.
  * No changes to test logic, control flow, or test coverage; only assertion syntax and imports were updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->