### PR TITLE
Assertj

### DIFF
--- a/archive/docs/01.指南/00.开发手册/27.组件【nacos】.md
+++ b/archive/docs/01.指南/00.开发手册/27.组件【nacos】.md
@@ -811,42 +811,41 @@ class ConfigUtilsTest {
 		nacosConfigProperties.setPassword("nacos");
 		nacosConfigProperties.setGroup("DEFAULT_GROUP");
 
-		Assertions.assertNotNull(nacosConfigProperties);
-		Assertions.assertEquals("public", nacosConfigProperties.getNamespace());
-		Assertions.assertEquals("127.0.0.1:8848", nacosConfigProperties.getServerAddr());
-		Assertions.assertEquals("nacos", nacosConfigProperties.getPassword());
-		Assertions.assertEquals("nacos", nacosConfigProperties.getUsername());
-		Assertions.assertEquals("DEFAULT_GROUP", nacosConfigProperties.getGroup());
-		Assertions.assertNotNull(nacosConfigProperties.assembleConfigServiceProperties());
+		assertThat(nacosConfigProperties).isNotNull();
+		assertThat( nacosConfigProperties.getNamespace()).isEqualTo("public");
+		assertThat( nacosConfigProperties.getServerAddr()).isEqualTo("127.0.0.1:8848");
+		assertThat(nacosConfigProperties.getPassword()).isEqualTo("nacos");
+		assertThat(nacosConfigProperties.getUsername()).isEqualTo("nacos");
+		assertThat( nacosConfigProperties.getGroup()).isEqualTo("DEFAULT_GROUP");
+		assertThat(nacosConfigProperties.assembleConfigServiceProperties()).isNotNull();
 
 		NacosConfigManager nacosConfigManager = new NacosConfigManager(nacosConfigProperties);
-		Assertions.assertNotNull(nacosConfigManager);
+		assertThat(nacosConfigManager).isNotNull();
 
 		configUtils = new ConfigUtils(nacosConfigManager);
-		Assertions.assertNotNull(configUtils);
+		assertThat(configUtils).isNotNull();
 	}
 
 	@Test
 	void testGetGroup() {
-		Assertions.assertEquals("DEFAULT_GROUP", configUtils.getGroup());
+		assertThat( configUtils.getGroup()).isEqualTo("DEFAULT_GROUP");
 	}
 
 	@Test
 	void testCreateConfigService() throws NacosException {
 		ConfigService configService = ConfigUtils.createConfigService(nacosConfigProperties.getServerAddr());
-		Assertions.assertNotNull(configService);
-		Assertions.assertEquals("UP", configService.getServerStatus());
+		assertThat(configService).isNotNull();
+		assertThat(configService.getServerStatus()).isEqualTo("UP");
 
 		configService = ConfigUtils.createConfigService(nacosConfigProperties.assembleConfigServiceProperties());
-		Assertions.assertNotNull(configService);
-		Assertions.assertEquals("UP", configService.getServerStatus());
+		assertThat(configService).isNotNull();
+		assertThat(configService.getServerStatus()).isEqualTo("UP");
 	}
 
 	@Test
 	void testGetConfig() throws NacosException {
 		String config = configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000);
-		Assertions.assertNotNull(config);
-		Assertions.assertTrue(config.contains("test"));
+		assertThat(config).isNotNull().contains("test");
 		config = configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000, new Listener() {
 			@Override
 			public Executor getExecutor() {
@@ -855,12 +854,10 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				Assertions.assertNotNull(s);
-				Assertions.assertTrue(s.contains("test"));
+				assertThat(s).isNotBlank().contains("test");
 			}
 		});
-		Assertions.assertNotNull(config);
-		Assertions.assertTrue(config.contains("test"));
+		assertThat(config).isNotNull().contains("test");
 	}
 
 	@Test
@@ -873,8 +870,7 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				Assertions.assertNotNull(s);
-				Assertions.assertTrue(s.contains("test"));
+				assertThat(s).isNotBlank().contains("test");
 			}
 		});
 	}
@@ -889,48 +885,47 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				Assertions.assertNotNull(s);
-				Assertions.assertTrue(s.contains("test"));
+				assertThat(s).isNotBlank().contains("test");
 			}
 		});
 	}
 
 	@Test
 	void testPublishConfig() throws NacosException, InterruptedException {
-		Assertions.assertTrue(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123"));
+		assertThat(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123")).isTrue();
 		Thread.sleep(100);
-		Assertions.assertEquals("test: 123", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 123");
 
-		Assertions.assertTrue(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 456", "yaml"));
-		Assertions.assertEquals("test: 456", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 456", "yaml")).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 456");
 
-		Assertions.assertTrue(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123"));
-		Assertions.assertEquals("test: 123", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123")).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 123");
 
 		String md5 = DigestUtils.md5DigestAsHex("test: 123".getBytes());
-		Assertions.assertEquals("5e76b5e94b54e1372f8b452ef64dc55c", md5);
-		Assertions.assertTrue(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 456", md5));
-		Assertions.assertEquals("test: 456", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(md5).isEqualTo("5e76b5e94b54e1372f8b452ef64dc55c");
+		assertThat(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 456", md5)).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 456");
 
 		md5 = DigestUtils.md5DigestAsHex("test: 456".getBytes());
-		Assertions.assertEquals("76e2eabbf24a8c90dc3b4372c20a72cf", md5);
-		Assertions.assertTrue(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 789", md5, "yaml"));
-		Assertions.assertEquals("test: 789", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(md5).isEqualTo("76e2eabbf24a8c90dc3b4372c20a72cf");
+		assertThat(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 789", md5, "yaml")).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 789");
 	}
 
 	@Test
 	void testRemoveConfig() throws NacosException, InterruptedException {
-		Assertions.assertTrue(configUtils.publishConfig("test1.yaml", nacosConfigProperties.getGroup(), "test: 123"));
+		assertThat(configUtils.publishConfig("test1.yaml", nacosConfigProperties.getGroup(), "test: 123")).isTrue();
 		Thread.sleep(2000);
-		Assertions.assertEquals("test: 123", configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat( configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 123");
 
-		Assertions.assertTrue(configUtils.removeConfig("test1.yaml", nacosConfigProperties.getGroup()));
-		Assertions.assertNull(configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.removeConfig("test1.yaml", nacosConfigProperties.getGroup())).isTrue();
+		assertThat(configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000)).isNull();
 	}
 
 	@Test
 	void testGetServerStatus() {
-		Assertions.assertEquals("UP", configUtils.getServerStatus());
+		assertThat(configUtils.getServerStatus()).isEqualTo("UP");
 	}
 	// @formatter:on
 
@@ -960,187 +955,181 @@ class NamingUtilsTest {
 
 	@BeforeEach
 	void setUp() {
-		Assertions.assertNotNull(nacosDiscoveryProperties);
-		Assertions.assertEquals("public", nacosDiscoveryProperties.getNamespace());
-		Assertions.assertEquals("127.0.0.1:8848", nacosDiscoveryProperties.getServerAddr());
-		Assertions.assertEquals("DEFAULT_GROUP", nacosDiscoveryProperties.getGroup());
-		Assertions.assertEquals("nacos", nacosDiscoveryProperties.getUsername());
-		Assertions.assertEquals("nacos", nacosDiscoveryProperties.getPassword());
-		Assertions.assertEquals("", nacosDiscoveryProperties.getEndpoint());
-		Assertions.assertEquals("", nacosDiscoveryProperties.getAccessKey());
-		Assertions.assertEquals("", nacosDiscoveryProperties.getSecretKey());
-		Assertions.assertEquals("nacos-cluster", nacosDiscoveryProperties.getClusterName());
-		Assertions.assertNotNull(nacosDiscoveryProperties.getNacosProperties());
-		Assertions.assertNotNull(namingUtils);
+		assertThat(nacosDiscoveryProperties).isNotNull();
+		assertThat(nacosDiscoveryProperties.getNamespace()).isEqualTo("public");
+		assertThat(nacosDiscoveryProperties.getServerAddr()).isEqualTo("127.0.0.1:8848");
+		assertThat(nacosDiscoveryProperties.getGroup()).isEqualTo("DEFAULT_GROUP");
+		assertThat(nacosDiscoveryProperties.getUsername()).isEqualTo("nacos");
+		assertThat(nacosDiscoveryProperties.getPassword()).isEqualTo("nacos");
+		assertThat(nacosDiscoveryProperties.getEndpoint()).isEqualTo("");
+		assertThat(nacosDiscoveryProperties.getAccessKey()).isEqualTo("");
+		assertThat(nacosDiscoveryProperties.getSecretKey()).isEqualTo("");
+		assertThat(nacosDiscoveryProperties.getClusterName()).isEqualTo("nacos-cluster");
+		assertThat(nacosDiscoveryProperties.getNacosProperties()).isNotNull();
+		assertThat(namingUtils).isNotNull();
 	}
 
 	@Test
 	void testCreateNamingService() throws Exception {
 		NamingService namingService = NamingUtils.createNamingService(nacosDiscoveryProperties.getServerAddr());
-		Assertions.assertNotNull(namingService);
+		assertThat(namingService).isNotNull();
 		namingService = NamingUtils.createNamingService(nacosDiscoveryProperties.getNacosProperties());
-		Assertions.assertNotNull(namingService);
-	}
-
-	@Test
-	void testGetNamingMaintainService() {
-		NamingMaintainService namingMaintainService = namingUtils.getNamingMaintainService(nacosDiscoveryProperties.getNacosProperties());
-		Assertions.assertNotNull(namingMaintainService);
+		assertThat(namingService).isNotNull();
 	}
 
 	@Test
 	void testIsNacosDiscoveryInfoChanged() {
-		Assertions.assertFalse(namingUtils.isNacosDiscoveryInfoChanged(nacosDiscoveryProperties));
+		assertThat(namingUtils.isNacosDiscoveryInfoChanged(nacosDiscoveryProperties)).isFalse();
 	}
 
 	@Test
 	void testGetAllInstances() throws NacosException, InterruptedException {
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service").isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service").isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service").isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service").isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty()).isTrue();
 
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", instance));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", instance));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", false).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty()).isFalse();
 
-		(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty()).isTrue();
 
-		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isFalse();
 
-		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testSelectInstances() throws NacosException, InterruptedException {
-		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 
-		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true, false).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true, false).isEmpty()).isFalse();
 
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true, false).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true, false).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty()).isFalse();
 
-		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testSelectOneHealthyInstance() throws NacosException, InterruptedException {
-		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service"));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP"));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", false));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName())));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName())));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false));
+		assertThat(namingUtils.selectOneHealthyInstance("test-service")).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP")).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", false)).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false)).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()))).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()))).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false)).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false)).isNotNull();
 
-		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testSubscribeService() throws NacosException, InterruptedException {
-		(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
-		(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", evt -> assertThat(evt).isNotNull()));
 
-		(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
-		(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", evt -> assertThat(evt).isNotNull()));
 
-		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
 
-		(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
 
 		// 只选择订阅ip为`127.0`开头的实例。
 		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
-		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
-		(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, evt -> assertThat(evt).isNotNull()));
 
-		(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
-		(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", selector, evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", selector, evt -> assertThat(evt).isNotNull()));
 
-		(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testGetServicesOfServer() throws NacosException, InterruptedException {
-		(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0);
-		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10).getCount() > 0);
+		assertThat(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0).isTrue();
+		assertThat(namingUtils.getServicesOfServer(1, 10).getCount() > 0).isTrue();
 
-		(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
-		Assertions.assertFalse(namingUtils.getSubscribeServices().isEmpty());
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", evt -> assertThat(evt).isNotNull()));
+		assertThat(namingUtils.getSubscribeServices().isEmpty()).isFalse();
 
-		(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
+		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 	}
 
 	@Test
@@ -1148,19 +1137,19 @@ class NamingUtilsTest {
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
-		(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		assertThatNoException().isThrownBy(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
-		Assertions.assertNotEquals(2, namingUtils.selectInstances("test-service", true).size());
+		assertThat(namingUtils.selectInstances("test-service", true).size()).isEqualTo(1);
 
-		(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
+		assertThatNoException().isThrownBy(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
-		Assertions.assertEquals(0, namingUtils.selectInstances("test-service", false).size());
+		assertThat(namingUtils.selectInstances("test-service", false).size()).isEqualTo(0);
 	}
 
 	@Test
 	void testNacosServiceShutDown() throws InterruptedException {
 		Thread.sleep(1000);
-		(namingUtils::nacosServiceShutDown);
+		assertThatNoException().isThrownBy(namingUtils::nacosServiceShutDown);
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/ArrayUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/ArrayUtilsTest.java
@@ -17,9 +17,10 @@
 
 package org.laokou.common.core;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.ArrayUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -29,22 +30,22 @@ class ArrayUtilsTest {
 	@Test
 	void testByteArray() {
 		byte[] bytes = { 1 };
-		Assertions.assertTrue(ArrayUtils.isNotEmpty(bytes));
-		Assertions.assertFalse(ArrayUtils.isEmpty(bytes));
+		assertThat(ArrayUtils.isNotEmpty(bytes)).isTrue();
+		assertThat(ArrayUtils.isEmpty(bytes)).isFalse();
 	}
 
 	@Test
 	void testStrArray() {
 		String[] str = { "1" };
-		Assertions.assertTrue(ArrayUtils.isNotEmpty(str));
-		Assertions.assertFalse(ArrayUtils.isEmpty(str));
+		assertThat(ArrayUtils.isNotEmpty(str)).isTrue();
+		assertThat(ArrayUtils.isEmpty(str)).isFalse();
 	}
 
 	@Test
 	void testObjArray() {
 		Object[] obj = { "1" };
-		Assertions.assertTrue(ArrayUtils.isNotEmpty(obj));
-		Assertions.assertFalse(ArrayUtils.isEmpty(obj));
+		assertThat(ArrayUtils.isNotEmpty(obj)).isTrue();
+		assertThat(ArrayUtils.isEmpty(obj)).isFalse();
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CollectionUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CollectionUtilsTest.java
@@ -22,10 +22,7 @@ import org.laokou.common.core.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * CollectionUtils测试类.
@@ -57,44 +54,28 @@ class CollectionUtilsTest {
 
 	@Test
 	void testToList() {
-		assertEquals(Arrays.asList("a", "b", "c"), CollectionUtils.toList("a,b,c", ","));
-		// 测试空字符串
-		assertTrue(CollectionUtils.toList("", ",").isEmpty());
-
-		// 测试null
-		assertTrue(CollectionUtils.toList(null, ",").isEmpty());
-
-		// 测试带空格的字符串
-		String strWithSpaces = "a, b , c";
-		List<String> expectedTrimmed = Arrays.asList("a", "b", "c");
-		assertEquals(expectedTrimmed, CollectionUtils.toList(strWithSpaces, ","));
+		assertThat(CollectionUtils.toList("a,b,c", ",")).isEqualTo(Arrays.asList("a", "b", "c"));
+		assertThat(CollectionUtils.toList("", ",").isEmpty()).isTrue();
+		assertThat(CollectionUtils.toList(null, ",").isEmpty()).isTrue();
+		assertThat(CollectionUtils.toList("a, b , c", ",")).isEqualTo(Arrays.asList("a", "b", "c"));
 	}
 
 	@Test
 	void testContains() {
-		List<String> list = Arrays.asList("a", "b", "c");
-		assertTrue(CollectionUtils.contains(list, "a"));
-		assertFalse(CollectionUtils.contains(list, "d"));
+		assertThat(CollectionUtils.contains(Arrays.asList("a", "b", "c"), "a")).isTrue();
+		assertThat(CollectionUtils.contains(Arrays.asList("a", "b", "c"), "d")).isFalse();
 	}
 
 	@Test
 	void testAnyMatch() {
-		List<String> list1 = Arrays.asList("a", "b", "c");
-		List<String> list2 = Arrays.asList("c", "d", "e");
-		assertTrue(CollectionUtils.anyMatch(list1, list2));
-
-		List<String> list3 = Arrays.asList("x", "y", "z");
-		assertFalse(CollectionUtils.anyMatch(list1, list3));
+		assertThat(CollectionUtils.anyMatch(Arrays.asList("a", "b", "c"), Arrays.asList("c", "d", "e"))).isTrue();
+		assertThat(CollectionUtils.anyMatch(Arrays.asList("c", "d", "e"), Arrays.asList("x", "y", "z"))).isFalse();
 	}
 
 	@Test
 	void testContainsAll() {
-		List<String> subList = Arrays.asList("a", "b");
-		List<String> fullList = Arrays.asList("a", "b", "c");
-		assertTrue(CollectionUtils.containsAll(subList, fullList));
-
-		List<String> differentList = Arrays.asList("x", "y");
-		assertFalse(CollectionUtils.containsAll(differentList, fullList));
+		assertThat(CollectionUtils.containsAll(Arrays.asList("a", "b"), Arrays.asList("a", "b", "c"))).isTrue();
+		assertThat(CollectionUtils.containsAll(Arrays.asList("x", "y"), Arrays.asList("a", "b", "c"))).isFalse();
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/ConvertUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/ConvertUtilsTest.java
@@ -25,6 +25,8 @@ import org.laokou.common.core.util.ConvertUtils;
 import java.io.Serializable;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author laokou
  */
@@ -34,7 +36,7 @@ class ConvertUtilsTest {
 	void test() {
 		TestUser testUser = new TestUser(1L, "laokou");
 		User user = ConvertUtils.sourceToTarget(testUser, User.class);
-		Assertions.assertNotNull(user);
+		assertThat(user).isNotNull();
 		Assertions.assertEquals(testUser.getId(), user.getId());
 		Assertions.assertEquals(testUser.getName(), user.getName());
 		TestUser testUser2 = new TestUser(2L, "老寇");

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/RegexUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/RegexUtilsTest.java
@@ -17,9 +17,10 @@
 
 package org.laokou.common.core;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.RegexUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -28,24 +29,24 @@ class RegexUtilsTest {
 
 	@Test
 	void testRegex() {
-		Assertions.assertTrue(RegexUtils.mailRegex("2413176044@qq.com"));
-		Assertions.assertFalse(RegexUtils.mailRegex("123"));
-		Assertions.assertTrue(RegexUtils.ipv4Regex("127.0.0.1"));
-		Assertions.assertFalse(RegexUtils.ipv4Regex("127.0.0.256"));
-		Assertions.assertFalse(RegexUtils.ipv4Regex("127.0.0.x"));
-		Assertions.assertFalse(RegexUtils.ipv4Regex("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
-		Assertions.assertTrue(RegexUtils.ipv6Regex("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
-		Assertions.assertFalse(RegexUtils.ipv6Regex("127.0.0.1"));
-		Assertions.assertFalse(RegexUtils.numberRegex("-1"));
-		Assertions.assertTrue(RegexUtils.numberRegex("123"));
-		Assertions.assertFalse(RegexUtils.numberRegex("xx"));
-		Assertions.assertTrue(RegexUtils.mobileRegex("18888888888"));
-		Assertions.assertFalse(RegexUtils.mobileRegex("188888888888"));
-		Assertions.assertFalse(RegexUtils.mobileRegex("1888888888"));
-		Assertions.assertFalse(RegexUtils.mobileRegex("1888888888x"));
-		Assertions.assertFalse(RegexUtils.matches("^[A-Za-z]+$|^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]+$", "哈哈哈"));
-		Assertions.assertTrue(RegexUtils.matches("^[A-Za-z]+$|^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]+$", "admin123"));
-		Assertions.assertEquals("v3", RegexUtils.getRegexValue("/v3/test", "/(v\\d+)/"));
+		assertThat(RegexUtils.mailRegex("2413176044@qq.com")).isTrue();
+		assertThat(RegexUtils.mailRegex("123")).isFalse();
+		assertThat(RegexUtils.ipv4Regex("127.0.0.1")).isTrue();
+		assertThat(RegexUtils.ipv4Regex("127.0.0.256")).isFalse();
+		assertThat(RegexUtils.ipv4Regex("127.0.0.x")).isFalse();
+		assertThat(RegexUtils.ipv4Regex("2001:0db8:85a3:0000:0000:8a2e:0370:7334")).isFalse();
+		assertThat(RegexUtils.ipv6Regex("2001:0db8:85a3:0000:0000:8a2e:0370:7334")).isTrue();
+		assertThat(RegexUtils.ipv6Regex("127.0.0.1")).isFalse();
+		assertThat(RegexUtils.numberRegex("-1")).isFalse();
+		assertThat(RegexUtils.numberRegex("123")).isTrue();
+		assertThat(RegexUtils.numberRegex("xx")).isFalse();
+		assertThat(RegexUtils.mobileRegex("18888888888")).isTrue();
+		assertThat(RegexUtils.mobileRegex("188888888888")).isFalse();
+		assertThat(RegexUtils.mobileRegex("1888888888")).isFalse();
+		assertThat(RegexUtils.mobileRegex("1888888888x")).isFalse();
+		assertThat(RegexUtils.matches("^[A-Za-z]+$|^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]+$", "哈哈哈")).isFalse();
+		assertThat(RegexUtils.matches("^[A-Za-z]+$|^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]+$", "admin123")).isTrue();
+		assertThat(RegexUtils.getRegexValue("/v3/test", "/(v\\d+)/")).isEqualTo("v3");
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/RequestUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/RequestUtilsTest.java
@@ -22,7 +22,6 @@ import com.blueconic.browscap.Capabilities;
 import com.blueconic.browscap.UserAgentParser;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.RequestUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,6 +30,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -49,43 +50,43 @@ class RequestUtilsTest {
 	@Test
 	void testRequest() throws Exception {
 		HttpServletRequest request = RequestUtils.getHttpServletRequest();
-		Assertions.assertNotNull(request);
-		Assertions.assertNotNull(handlerMapping);
-		Assertions.assertFalse(request.getHeaderNames().hasMoreElements());
+		assertThat(request).isNotNull();
+		assertThat(handlerMapping).isNotNull();
+		assertThat(request.getHeaderNames().hasMoreElements()).isFalse();
 		UserAgentParser parser = RequestUtils.getUserAgentParser();
-		Assertions.assertNotNull(parser);
+		assertThat(parser).isNotNull();
 		String defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3";
 		Capabilities capabilities = parser.parse(defaultUserAgent);
-		Assertions.assertEquals("Chrome", capabilities.getBrowser());
-		Assertions.assertEquals("Browser", capabilities.getBrowserType());
-		Assertions.assertEquals("58", capabilities.getBrowserMajorVersion());
-		Assertions.assertEquals("Win10", capabilities.getPlatform());
-		Assertions.assertEquals("10.0", capabilities.getPlatformVersion());
-		Assertions.assertEquals("Desktop", capabilities.getDeviceType());
-		Assertions.assertEquals("Microsoft Corporation", capabilities.getValue(BrowsCapField.PLATFORM_MAKER));
-		Assertions.assertEquals("Blink", capabilities.getValue(BrowsCapField.RENDERING_ENGINE_NAME));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.RENDERING_ENGINE_VERSION));
-		Assertions.assertEquals("Google Inc", capabilities.getValue(BrowsCapField.RENDERING_ENGINE_MAKER));
-		Assertions.assertNull(RequestUtils.getHandlerMethod(request, handlerMapping));
+		assertThat(capabilities.getBrowser()).isEqualTo("Chrome");
+		assertThat(capabilities.getBrowserType()).isEqualTo("Browser");
+		assertThat(capabilities.getBrowserMajorVersion()).isEqualTo("58");
+		assertThat(capabilities.getPlatform()).isEqualTo("Win10");
+		assertThat(capabilities.getPlatformVersion()).isEqualTo("10.0");
+		assertThat(capabilities.getDeviceType()).isEqualTo("Desktop");
+		assertThat(capabilities.getValue(BrowsCapField.PLATFORM_MAKER)).isEqualTo("Microsoft Corporation");
+		assertThat(capabilities.getValue(BrowsCapField.RENDERING_ENGINE_NAME)).isEqualTo("Blink");
+		assertThat(capabilities.getValue(BrowsCapField.RENDERING_ENGINE_VERSION)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.RENDERING_ENGINE_MAKER)).isEqualTo("Google Inc");
+		assertThat(RequestUtils.getHandlerMethod(request, handlerMapping)).isNull();
 		capabilities = RequestUtils.getCapabilities(request);
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.BROWSER));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.BROWSER_TYPE));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.BROWSER_MAJOR_VERSION));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.PLATFORM));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.PLATFORM_VERSION));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.PLATFORM_MAKER));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.DEVICE_TYPE));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.RENDERING_ENGINE_NAME));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.RENDERING_ENGINE_VERSION));
-		Assertions.assertEquals("Unknown", capabilities.getValue(BrowsCapField.RENDERING_ENGINE_MAKER));
-		Assertions.assertEquals("", RequestUtils.getParamValue(request, "test"));
+		assertThat(capabilities.getValue(BrowsCapField.BROWSER)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.BROWSER_TYPE)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.BROWSER_MAJOR_VERSION)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.PLATFORM)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.PLATFORM_VERSION)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.PLATFORM_MAKER)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.DEVICE_TYPE)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.RENDERING_ENGINE_NAME)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.RENDERING_ENGINE_VERSION)).isEqualTo("Unknown");
+		assertThat(capabilities.getValue(BrowsCapField.RENDERING_ENGINE_MAKER)).isEqualTo("Unknown");
+		assertThat(RequestUtils.getParamValue(request, "test")).isEqualTo("");
 		byte[] body = RequestUtils.getRequestBody(request);
-		Assertions.assertEquals(0, body.length);
-		Assertions.assertNotNull(RequestUtils.getInputStream(body));
+		assertThat(body.length).isEqualTo(0);
+		assertThat(RequestUtils.getInputStream(body)).isNotNull();
 		ServletRequest requestWrapper = new RequestUtils.RequestWrapper(request);
-		Assertions.assertNotNull(requestWrapper);
-		Assertions.assertNotNull(requestWrapper.getInputStream());
-		Assertions.assertNotNull(requestWrapper.getReader());
+		assertThat(requestWrapper).isNotNull();
+		assertThat(requestWrapper.getInputStream()).isNotNull();
+		assertThat(requestWrapper.getReader()).isNotNull();
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/UUIDGeneratorTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/UUIDGeneratorTest.java
@@ -17,9 +17,10 @@
 
 package org.laokou.common.core;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.UUIDGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -28,7 +29,7 @@ class UUIDGeneratorTest {
 
 	@Test
 	void testGenerateUUID() {
-		Assertions.assertNotNull(UUIDGenerator.generateUUID());
+		assertThat(UUIDGenerator.generateUUID()).isNotBlank();
 	}
 
 }

--- a/laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java
+++ b/laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java
@@ -18,7 +18,6 @@
 package org.laokou.common.csv;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.csv.utils.CsvUtils;
@@ -27,6 +26,7 @@ import org.springframework.boot.system.SystemProperties;
 import java.io.File;
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
@@ -47,7 +47,7 @@ class CsvUtilsTest {
 		String[] arr = { "1", "2", "3" };
 		File file = new File(testPath, fileName);
 		assertThatNoException().isThrownBy(() -> CsvUtils.execute(file, csvWriter -> csvWriter.writeNext(arr), false));
-		Assertions.assertEquals("\"1\",\"2\",\"3\"", FileUtils.readFileToString(file, "UTF-8").trim());
+		assertThat(FileUtils.readFileToString(file, "UTF-8").trim()).isEqualTo("\"1\",\"2\",\"3\"");
 		assertThatNoException().isThrownBy(() -> FileUtils.forceDeleteOnExit(file));
 	}
 

--- a/laokou-common/laokou-common-ftp/src/test/java/org/laokou/common/ftp/FtpTest.java
+++ b/laokou-common/laokou-common-ftp/src/test/java/org/laokou/common/ftp/FtpTest.java
@@ -18,7 +18,6 @@
 package org.laokou.common.ftp;
 
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.ftp.config.FtpProperties;
 import org.laokou.common.ftp.template.FtpTemplate;
@@ -30,6 +29,7 @@ import org.springframework.test.context.TestConstructor;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
@@ -51,10 +51,10 @@ class FtpTest {
 		assertThatNoException().isThrownBy(() -> ftpTemplate.upload(ftpProperties.getDirectory(), "测试中文文本.txt",
 				ResourceUtils.getResource("classpath:测试中文文本.txt").getInputStream()));
 		InputStream inputStream = ftpTemplate.download(ftpProperties.getDirectory(), "测试中文文本.txt");
-		Assertions.assertNotNull(inputStream);
-		Assertions.assertEquals("123", new String(inputStream.readAllBytes()).trim());
+		assertThat(inputStream).isNotNull();
+		assertThat(new String(inputStream.readAllBytes()).trim()).isEqualTo("123");
 		assertThatNoException().isThrownBy(() -> ftpTemplate.delete(ftpProperties.getDirectory(), "测试中文文本.txt"));
-		Assertions.assertNull(ftpTemplate.download(ftpProperties.getDirectory(), "测试中文文本.txt"));
+		assertThat(ftpTemplate.download(ftpProperties.getDirectory(), "测试中文文本.txt")).isNull();
 	}
 
 }

--- a/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/DateUtilsTest.java
+++ b/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/DateUtilsTest.java
@@ -17,12 +17,13 @@
 
 package org.laokou.common.i18n;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.util.DateUtils;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -33,11 +34,11 @@ class DateUtilsTest {
 	void test() {
 		String str = "2024-09-24 11:33:33";
 		LocalDateTime localDateTime = DateUtils.parseTime(str, DateUtils.YYYY_B_MM_B_DD_HH_R_MM_R_SS);
-		Assertions.assertEquals(str, DateUtils.format(localDateTime, DateUtils.YYYY_B_MM_B_DD_HH_R_MM_R_SS));
+		assertThat(DateUtils.format(localDateTime, DateUtils.YYYY_B_MM_B_DD_HH_R_MM_R_SS)).isEqualTo(str);
 		str = "2024-09-24 13:59:00";
 		Instant instant = DateUtils.parsInstant(str, DateUtils.YYYY_B_MM_B_DD_HH_R_MM_R_SS);
 		long between = DateUtils.betweenSeconds(DateUtils.nowInstant(), instant);
-		Assertions.assertTrue(between < 0);
+		assertThat(between < 0).isTrue();
 	}
 
 }

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
@@ -20,7 +20,6 @@ package org.laokou.common.mybatisplus;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.dto.PageQuery;
 import org.laokou.common.i18n.util.DateUtils;
@@ -32,6 +31,7 @@ import org.springframework.test.context.TestConstructor;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
@@ -50,37 +50,37 @@ class MybatisUtilsTest {
 	@Test
 	void testIgnoreTable() {
 		GlobalTenantLineHandler globalTenantLineHandler = new GlobalTenantLineHandler(Set.of("test", "t_user"));
-		Assertions.assertTrue(globalTenantLineHandler.ignoreTable("t_user"));
-		Assertions.assertTrue(globalTenantLineHandler.ignoreTable("t_test"));
-		Assertions.assertFalse(globalTenantLineHandler.ignoreTable("t_tes1"));
+		assertThat(globalTenantLineHandler.ignoreTable("t_user")).isTrue();
+		assertThat(globalTenantLineHandler.ignoreTable("t_test")).isFalse();
+		assertThat(globalTenantLineHandler.ignoreTable("t_tes1")).isFalse();
 	}
 
 	@Test
 	void test() {
-		Assertions.assertNotNull(testUserMapper);
-		Assertions.assertNotNull(mybatisUtils);
+		assertThat(testUserMapper).isNotNull();
+		assertThat(mybatisUtils).isNotNull();
 		assertThatNoException().isThrownBy(
 				() -> mybatisUtils.batch(List.of(getTestUserDO()), TestUserMapper.class, TestUserMapper::insert));
 		List<TestUserDO> list = testUserMapper.selectList(Wrappers.emptyWrapper());
-		Assertions.assertEquals(2, list.size());
-		Assertions.assertTrue(list.stream().map(TestUserDO::getName).anyMatch("张三"::equals));
+		assertThat(list.size()).isEqualTo(2);
+		assertThat(list.stream().map(TestUserDO::getName).anyMatch("张三"::equals)).isTrue();
 		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
-		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(1);
 		assertThatNoException().isThrownBy(() -> mybatisUtils.batch(List.of(getTestUserDO()), TestUserMapper.class,
 				"master", TestUserMapper::insert));
-		Assertions.assertEquals(2, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(2);
 		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
-		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(1);
 		assertThatNoException().isThrownBy(() -> mybatisUtils.batch(List.of(getTestUserDO()), 1000, 100, 180,
 				TestUserMapper.class, "master", TestUserMapper::insert));
-		Assertions.assertEquals(2, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(2);
 		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
-		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(1);
 		assertThatNoException().isThrownBy(() -> mybatisUtils.batch(List.of(getTestUserDO()), 1000, 100, 180,
 				TestUserMapper.class, TestUserMapper::insert));
-		Assertions.assertEquals(2, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(2);
 		assertThatNoException().isThrownBy(() -> testUserMapper.deleteTestUser(List.of(8L)));
-		Assertions.assertEquals(1, testUserMapper.selectObjectCount(new PageQuery()));
+		assertThat(testUserMapper.selectObjectCount(new PageQuery())).isEqualTo(1);
 	}
 
 	private TestUserDO getTestUserDO() {

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/SqlUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/SqlUtilsTest.java
@@ -18,9 +18,10 @@
 package org.laokou.common.mybatisplus;
 
 import net.sf.jsqlparser.statement.select.PlainSelect;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.mybatisplus.util.SqlUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -31,9 +32,9 @@ class SqlUtilsTest {
 	void test() {
 		String sql = "select * from t_user \nwhere id = 1";
 		PlainSelect plainSelect = SqlUtils.plainSelect(sql);
-		Assertions.assertEquals("t_user", plainSelect.getFromItem().toString());
-		Assertions.assertEquals("id = 1", plainSelect.getWhere().toString());
-		Assertions.assertEquals("SELECT * FROM t_user WHERE id = 1", SqlUtils.formatSql(sql));
+		assertThat(plainSelect.getFromItem().toString()).isEqualTo("t_user");
+		assertThat( plainSelect.getWhere().toString()).isEqualTo("id = 1");
+		assertThat(SqlUtils.formatSql(sql)).isEqualTo("SELECT * FROM t_user WHERE id = 1");
 	}
 
 }

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TestUserDO.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TestUserDO.java
@@ -19,9 +19,10 @@ package org.laokou.common.mybatisplus;
 
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.mybatisplus.mapper.BaseDO;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -36,7 +37,7 @@ class TestUserDO extends BaseDO {
 	void test() {
 		TestUserDO user = new TestUserDO();
 		user.setId(1L);
-		Assertions.assertEquals(1L, user.getId());
+		assertThat(user.getId()).isEqualTo(1L);
 	}
 
 }

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TransactionalUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TransactionalUtilsTest.java
@@ -20,7 +20,6 @@ package org.laokou.common.mybatisplus;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.util.DateUtils;
 import org.laokou.common.mybatisplus.util.TransactionalUtils;
@@ -30,6 +29,7 @@ import org.springframework.transaction.TransactionDefinition;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
@@ -49,65 +49,65 @@ class TransactionalUtilsTest {
 	void testWithoutResult() {
 		assertThatNoException()
 			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.insert(getTestUserDO())));
-		Assertions.assertEquals(1,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L))).isEqualTo(1);
 		assertThatNoException()
 			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
 					TransactionDefinition.ISOLATION_READ_COMMITTED, false));
-		Assertions.assertEquals(0,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L))).isEqualTo(0);
 		assertThatNoException()
 			.isThrownBy(() -> transactionalUtils.executeInNewTransaction(() -> testUserMapper.insert(getTestUserDO())));
-		Assertions.assertEquals(1,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L))).isEqualTo(1);
 		assertThatNoException().isThrownBy(
 				() -> transactionalUtils.executeInNewTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
 						TransactionDefinition.ISOLATION_READ_COMMITTED, false));
-		Assertions.assertEquals(0,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L))).isEqualTo(0);
 		assertThatNoException()
 			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.insert(getTestUserDO()),
 					TransactionDefinition.PROPAGATION_REQUIRED, TransactionDefinition.ISOLATION_READ_COMMITTED, false));
-		Assertions.assertEquals(1,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L))).isEqualTo(1);
 		assertThatNoException()
 			.isThrownBy(() -> transactionalUtils.executeInTransaction(() -> testUserMapper.deleteTestUser(List.of(9L)),
 					TransactionDefinition.PROPAGATION_REQUIRES_NEW, TransactionDefinition.ISOLATION_READ_COMMITTED,
 					false));
-		Assertions.assertEquals(0,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L)));
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 9L))).isEqualTo(0);
 	}
 
 	@Test
 	void testResult() {
 		int count = transactionalUtils.executeResultInNewTransaction(() -> testUserMapper.insert(getTestUserDO2()));
-		Assertions.assertTrue(count > 0);
-		Assertions.assertEquals(1,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L)));
+		assertThat(count > 0).isTrue();
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L))).isEqualTo(1);
 		count = transactionalUtils.executeResultInTransaction(() -> testUserMapper.deleteTestUser(List.of(10L)));
-		Assertions.assertTrue(count > 0);
-		Assertions.assertEquals(0,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L)));
+		assertThat(count > 0).isTrue();
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L))).isEqualTo(0);
 		count = transactionalUtils.executeResultInNewTransaction(() -> testUserMapper.insert(getTestUserDO2()),
 				TransactionDefinition.ISOLATION_READ_COMMITTED, false);
-		Assertions.assertTrue(count > 0);
-		Assertions.assertEquals(1,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L)));
+		assertThat(count > 0).isTrue();
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L))).isEqualTo(1);
 		count = transactionalUtils.executeResultInTransaction(() -> testUserMapper.deleteTestUser(List.of(10L)),
 				TransactionDefinition.ISOLATION_READ_COMMITTED, false);
-		Assertions.assertTrue(count > 0);
-		Assertions.assertEquals(0,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L)));
+		assertThat(count > 0).isTrue();
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L))).isEqualTo(0);
 		count = transactionalUtils.executeResultInTransaction(() -> testUserMapper.insert(getTestUserDO2()),
 				TransactionDefinition.PROPAGATION_REQUIRES_NEW, TransactionDefinition.ISOLATION_READ_COMMITTED, false);
-		Assertions.assertTrue(count > 0);
-		Assertions.assertEquals(1,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L)));
+		assertThat(count > 0).isTrue();
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L))).isEqualTo(1);
 		count = transactionalUtils.executeResultInTransaction(() -> testUserMapper.deleteTestUser(List.of(10L)),
 				TransactionDefinition.PROPAGATION_REQUIRED, TransactionDefinition.ISOLATION_READ_COMMITTED, false);
-		Assertions.assertTrue(count > 0);
-		Assertions.assertEquals(0,
-				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L)));
+		assertThat(count > 0).isTrue();
+		assertThat(
+				testUserMapper.selectCount(Wrappers.lambdaQuery(TestUserDO.class).eq(TestUserDO::getId, 10L))).isEqualTo(0);
 	}
 
 	private TestUserDO getTestUserDO() {

--- a/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -86,34 +86,11 @@ import static org.laokou.common.i18n.common.constant.TraceConstants.*;
 public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 
 	/**
-	 * Nacos集群配置.
-	 */
-	private static final String CLUSTER_CONFIG = "nacos.cluster";
-
-	/**
-	 * 版本.
-	 */
-	private static final String VERSION = "version";
-
-	/**
-	 * 版本号.
-	 */
-	private static final String DEFAULT_VERSION_VALUE = "v3";
-
-	/**
-	 * IPV6常量.
-	 */
-	private static final String IPV6_KEY = "IPv6";
-
-	/**
 	 * Storage local valid IPv6 address, it's a flag whether local machine support IPv6
 	 * address stack.
 	 */
 	public static String ipv6;
 
-	/**
-	 * 服务ID.
-	 */
 	private final String serviceId;
 
 	private final ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider;
@@ -145,7 +122,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	public void init() {
 		String ip = nacosDiscoveryProperties.getIp();
 		if (com.alibaba.cloud.commons.lang.StringUtils.isNotEmpty(ip)) {
-			ipv6 = RegexUtils.ipv4Regex(ip) ? nacosDiscoveryProperties.getMetadata().get(IPV6_KEY) : ip;
+			ipv6 = RegexUtils.ipv4Regex(ip) ? nacosDiscoveryProperties.getMetadata().get("IPv6") : ip;
 		}
 		else {
 			ipv6 = inetIPv6Utils.findIPv6Address();
@@ -162,7 +139,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 			List<ServiceInstance> ipv6InstanceList = new ArrayList<>();
 			for (ServiceInstance instance : instances) {
 				if (RegexUtils.ipv4Regex(instance.getHost())) {
-					if (com.alibaba.cloud.commons.lang.StringUtils.isNotEmpty(instance.getMetadata().get(IPV6_KEY))) {
+					if (com.alibaba.cloud.commons.lang.StringUtils.isNotEmpty(instance.getMetadata().get("IPv6"))) {
 						ipv6InstanceList.add(instance);
 					}
 				}
@@ -213,7 +190,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 				String version = RegexUtils.getRegexValue(path, "/(v\\d+)/");
 				if (StringUtils.isNotEmpty(version)) {
 					serviceInstances = serviceInstances.stream()
-						.filter(item -> item.getMetadata().getOrDefault(VERSION, DEFAULT_VERSION_VALUE).equals(version))
+						.filter(item -> item.getMetadata().getOrDefault("version", "v3").equals(version))
 						.toList();
 				}
 			}
@@ -236,7 +213,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 			List<ServiceInstance> instancesToChoose = serviceInstances;
 			if (com.alibaba.cloud.commons.lang.StringUtils.isNotBlank(clusterName)) {
 				List<ServiceInstance> sameClusterInstances = serviceInstances.stream().filter(serviceInstance -> {
-					String cluster = serviceInstance.getMetadata().get(CLUSTER_CONFIG);
+					String cluster = serviceInstance.getMetadata().get("nacos.cluster");
 					return com.alibaba.cloud.commons.lang.StringUtils.equals(cluster, clusterName);
 				}).toList();
 				if (!CollectionUtils.isEmpty(sameClusterInstances)) {

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java
@@ -22,7 +22,6 @@ import com.alibaba.cloud.nacos.NacosConfigProperties;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.listener.Listener;
 import com.alibaba.nacos.api.exception.NacosException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.nacos.util.ConfigUtils;
@@ -52,42 +51,41 @@ class ConfigUtilsTest {
 		nacosConfigProperties.setPassword("nacos");
 		nacosConfigProperties.setGroup("DEFAULT_GROUP");
 
-		Assertions.assertNotNull(nacosConfigProperties);
-		Assertions.assertEquals("public", nacosConfigProperties.getNamespace());
-		Assertions.assertEquals("127.0.0.1:8848", nacosConfigProperties.getServerAddr());
-		Assertions.assertEquals("nacos", nacosConfigProperties.getPassword());
-		Assertions.assertEquals("nacos", nacosConfigProperties.getUsername());
-		Assertions.assertEquals("DEFAULT_GROUP", nacosConfigProperties.getGroup());
-		Assertions.assertNotNull(nacosConfigProperties.assembleConfigServiceProperties());
+		assertThat(nacosConfigProperties).isNotNull();
+		assertThat( nacosConfigProperties.getNamespace()).isEqualTo("public");
+		assertThat( nacosConfigProperties.getServerAddr()).isEqualTo("127.0.0.1:8848");
+		assertThat(nacosConfigProperties.getPassword()).isEqualTo("nacos");
+		assertThat(nacosConfigProperties.getUsername()).isEqualTo("nacos");
+		assertThat( nacosConfigProperties.getGroup()).isEqualTo("DEFAULT_GROUP");
+		assertThat(nacosConfigProperties.assembleConfigServiceProperties()).isNotNull();
 
 		NacosConfigManager nacosConfigManager = new NacosConfigManager(nacosConfigProperties);
-		Assertions.assertNotNull(nacosConfigManager);
+		assertThat(nacosConfigManager).isNotNull();
 
 		configUtils = new ConfigUtils(nacosConfigManager);
-		Assertions.assertNotNull(configUtils);
+		assertThat(configUtils).isNotNull();
 	}
 
 	@Test
 	void testGetGroup() {
-		Assertions.assertEquals("DEFAULT_GROUP", configUtils.getGroup());
+		assertThat( configUtils.getGroup()).isEqualTo("DEFAULT_GROUP");
 	}
 
 	@Test
 	void testCreateConfigService() throws NacosException {
 		ConfigService configService = ConfigUtils.createConfigService(nacosConfigProperties.getServerAddr());
-		Assertions.assertNotNull(configService);
-		Assertions.assertEquals("UP", configService.getServerStatus());
+		assertThat(configService).isNotNull();
+		assertThat(configService.getServerStatus()).isEqualTo("UP");
 
 		configService = ConfigUtils.createConfigService(nacosConfigProperties.assembleConfigServiceProperties());
-		Assertions.assertNotNull(configService);
-		Assertions.assertEquals("UP", configService.getServerStatus());
+		assertThat(configService).isNotNull();
+		assertThat(configService.getServerStatus()).isEqualTo("UP");
 	}
 
 	@Test
 	void testGetConfig() throws NacosException {
 		String config = configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000);
-		Assertions.assertNotNull(config);
-		Assertions.assertTrue(config.contains("test"));
+		assertThat(config).isNotNull().contains("test");
 		config = configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000, new Listener() {
 			@Override
 			public Executor getExecutor() {
@@ -96,12 +94,10 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				Assertions.assertNotNull(s);
-				Assertions.assertTrue(s.contains("test"));
+				assertThat(s).isNotBlank().contains("test");
 			}
 		});
-		Assertions.assertNotNull(config);
-		Assertions.assertTrue(config.contains("test"));
+		assertThat(config).isNotNull().contains("test");
 	}
 
 	@Test
@@ -114,8 +110,7 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				assertThat(s).isNotBlank();
-				assertThat(s.contains("test")).isTrue();
+				assertThat(s).isNotBlank().contains("test");
 			}
 		});
 	}
@@ -130,48 +125,47 @@ class ConfigUtilsTest {
 
 			@Override
 			public void receiveConfigInfo(String s) {
-				Assertions.assertNotNull(s);
-				Assertions.assertTrue(s.contains("test"));
+				assertThat(s).isNotBlank().contains("test");
 			}
 		});
 	}
 
 	@Test
 	void testPublishConfig() throws NacosException, InterruptedException {
-		Assertions.assertTrue(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123"));
+		assertThat(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123")).isTrue();
 		Thread.sleep(100);
-		Assertions.assertEquals("test: 123", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 123");
 
-		Assertions.assertTrue(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 456", "yaml"));
-		Assertions.assertEquals("test: 456", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 456", "yaml")).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 456");
 
-		Assertions.assertTrue(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123"));
-		Assertions.assertEquals("test: 123", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.publishConfig("test.yaml", nacosConfigProperties.getGroup(), "test: 123")).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 123");
 
 		String md5 = DigestUtils.md5DigestAsHex("test: 123".getBytes());
-		Assertions.assertEquals("5e76b5e94b54e1372f8b452ef64dc55c", md5);
-		Assertions.assertTrue(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 456", md5));
-		Assertions.assertEquals("test: 456", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(md5).isEqualTo("5e76b5e94b54e1372f8b452ef64dc55c");
+		assertThat(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 456", md5)).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 456");
 
 		md5 = DigestUtils.md5DigestAsHex("test: 456".getBytes());
-		Assertions.assertEquals("76e2eabbf24a8c90dc3b4372c20a72cf", md5);
-		Assertions.assertTrue(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 789", md5, "yaml"));
-		Assertions.assertEquals("test: 789", configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(md5).isEqualTo("76e2eabbf24a8c90dc3b4372c20a72cf");
+		assertThat(configUtils.publishConfigCas("test.yaml", nacosConfigProperties.getGroup(), "test: 789", md5, "yaml")).isTrue();
+		assertThat(configUtils.getConfig("test.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 789");
 	}
 
 	@Test
 	void testRemoveConfig() throws NacosException, InterruptedException {
-		Assertions.assertTrue(configUtils.publishConfig("test1.yaml", nacosConfigProperties.getGroup(), "test: 123"));
+		assertThat(configUtils.publishConfig("test1.yaml", nacosConfigProperties.getGroup(), "test: 123")).isTrue();
 		Thread.sleep(2000);
-		Assertions.assertEquals("test: 123", configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat( configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000)).isEqualTo("test: 123");
 
-		Assertions.assertTrue(configUtils.removeConfig("test1.yaml", nacosConfigProperties.getGroup()));
-		Assertions.assertNull(configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000));
+		assertThat(configUtils.removeConfig("test1.yaml", nacosConfigProperties.getGroup())).isTrue();
+		assertThat(configUtils.getConfig("test1.yaml", nacosConfigProperties.getGroup(), 5000)).isNull();
 	}
 
 	@Test
 	void testGetServerStatus() {
-		Assertions.assertEquals("UP", configUtils.getServerStatus());
+		assertThat(configUtils.getServerStatus()).isEqualTo("UP");
 	}
 	// @formatter:on
 

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
@@ -27,7 +27,6 @@ import com.alibaba.nacos.api.naming.selector.NamingSelector;
 import com.alibaba.nacos.client.naming.selector.NamingSelectorFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.nacos.util.NamingUtils;
@@ -42,6 +41,7 @@ import org.springframework.test.context.TestConstructor;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
@@ -68,181 +68,181 @@ class NamingUtilsTest {
 
 	@BeforeEach
 	void setUp() {
-		Assertions.assertNotNull(nacosDiscoveryProperties);
-		Assertions.assertEquals("public", nacosDiscoveryProperties.getNamespace());
-		Assertions.assertEquals("127.0.0.1:8848", nacosDiscoveryProperties.getServerAddr());
-		Assertions.assertEquals("DEFAULT_GROUP", nacosDiscoveryProperties.getGroup());
-		Assertions.assertEquals("nacos", nacosDiscoveryProperties.getUsername());
-		Assertions.assertEquals("nacos", nacosDiscoveryProperties.getPassword());
-		Assertions.assertEquals("", nacosDiscoveryProperties.getEndpoint());
-		Assertions.assertEquals("", nacosDiscoveryProperties.getAccessKey());
-		Assertions.assertEquals("", nacosDiscoveryProperties.getSecretKey());
-		Assertions.assertEquals("nacos-cluster", nacosDiscoveryProperties.getClusterName());
-		Assertions.assertNotNull(nacosDiscoveryProperties.getNacosProperties());
-		Assertions.assertNotNull(namingUtils);
+		assertThat(nacosDiscoveryProperties).isNotNull();
+		assertThat(nacosDiscoveryProperties.getNamespace()).isEqualTo("public");
+		assertThat(nacosDiscoveryProperties.getServerAddr()).isEqualTo("127.0.0.1:8848");
+		assertThat(nacosDiscoveryProperties.getGroup()).isEqualTo("DEFAULT_GROUP");
+		assertThat(nacosDiscoveryProperties.getUsername()).isEqualTo("nacos");
+		assertThat(nacosDiscoveryProperties.getPassword()).isEqualTo("nacos");
+		assertThat(nacosDiscoveryProperties.getEndpoint()).isEqualTo("");
+		assertThat(nacosDiscoveryProperties.getAccessKey()).isEqualTo("");
+		assertThat(nacosDiscoveryProperties.getSecretKey()).isEqualTo("");
+		assertThat(nacosDiscoveryProperties.getClusterName()).isEqualTo("nacos-cluster");
+		assertThat(nacosDiscoveryProperties.getNacosProperties()).isNotNull();
+		assertThat(namingUtils).isNotNull();
 	}
 
 	@Test
 	void testCreateNamingService() throws Exception {
 		NamingService namingService = NamingUtils.createNamingService(nacosDiscoveryProperties.getServerAddr());
-		Assertions.assertNotNull(namingService);
+		assertThat(namingService).isNotNull();
 		namingService = NamingUtils.createNamingService(nacosDiscoveryProperties.getNacosProperties());
-		Assertions.assertNotNull(namingService);
+		assertThat(namingService).isNotNull();
 	}
 
 	@Test
 	void testIsNacosDiscoveryInfoChanged() {
-		Assertions.assertFalse(namingUtils.isNacosDiscoveryInfoChanged(nacosDiscoveryProperties));
+		assertThat(namingUtils.isNacosDiscoveryInfoChanged(nacosDiscoveryProperties)).isFalse();
 	}
 
 	@Test
 	void testGetAllInstances() throws NacosException, InterruptedException {
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service").isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service").isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service").isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service").isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP").isEmpty()).isTrue();
 
 		Instance instance = new Instance();
 		instance.setIp("127.0.0.1");
 		instance.setPort(8080);
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", instance));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", instance));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", false).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", Collections.emptyList()).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", instance));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList()).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", false).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testSelectInstances() throws NacosException, InterruptedException {
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true, false).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true, false).isEmpty()).isFalse();
 
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true, false).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty());
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true, false).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", List.of(nacosDiscoveryProperties.getClusterName()), true, false).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", true).isEmpty()).isFalse();
+		assertThat(namingUtils.selectInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), true).isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty());
+		assertThat(namingUtils.getAllInstances("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testSelectOneHealthyInstance() throws NacosException, InterruptedException {
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service"));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP"));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", false));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName())));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName())));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false));
-		Assertions.assertNotNull(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false));
+		assertThat(namingUtils.selectOneHealthyInstance("test-service")).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP")).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", false)).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false)).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()))).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()))).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", List.of(nacosDiscoveryProperties.getClusterName()), false)).isNotNull();
+		assertThat(namingUtils.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), false)).isNotNull();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testSubscribeService() throws NacosException, InterruptedException {
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
-		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", evt -> assertThat(evt).isNotNull()));
 
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", Assertions::assertNotNull));
-		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", evt -> assertThat(evt).isNotNull()));
 
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
 
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
-		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", List.of(nacosDiscoveryProperties.getClusterName()), evt -> assertThat(evt).isNotNull()));
 
 		// 只选择订阅ip为`127.0`开头的实例。
 		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
-		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", selector, evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", "DEFAULT_GROUP", selector, evt -> assertThat(evt).isNotNull()));
 
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", selector, Assertions::assertNotNull));
-		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", selector, Assertions::assertNotNull));
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", selector, evt -> assertThat(evt).isNotNull()));
+		assertThatNoException().isThrownBy(() -> namingUtils.unsubscribe("test-service", selector, evt -> assertThat(evt).isNotNull()));
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 	}
 
 	@Test
 	void testGetServicesOfServer() throws NacosException, InterruptedException {
 		assertThatNoException().isThrownBy(() -> namingUtils.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertFalse(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isFalse();
 
-		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0);
-		Assertions.assertTrue(namingUtils.getServicesOfServer(1, 10).getCount() > 0);
+		assertThat(namingUtils.getServicesOfServer(1, 10, "DEFAULT_GROUP").getCount() > 0).isTrue();
+		assertThat(namingUtils.getServicesOfServer(1, 10).getCount() > 0).isTrue();
 
-		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", Assertions::assertNotNull));
-		Assertions.assertFalse(namingUtils.getSubscribeServices().isEmpty());
+		assertThatNoException().isThrownBy(() -> namingUtils.subscribe("test-service", "DEFAULT_GROUP", evt -> assertThat(evt).isNotNull()));
+		assertThat(namingUtils.getSubscribeServices().isEmpty()).isFalse();
 
 		assertThatNoException().isThrownBy(() -> namingUtils.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, nacosDiscoveryProperties.getClusterName()));
 		Thread.sleep(1000);
-		Assertions.assertTrue(namingUtils.selectInstances("test-service", true).isEmpty());
+		assertThat(namingUtils.selectInstances("test-service", true).isEmpty()).isTrue();
 	}
 
 	@Test
@@ -252,11 +252,11 @@ class NamingUtilsTest {
 		instance.setPort(8080);
 		assertThatNoException().isThrownBy(() -> namingUtils.batchRegisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
-		Assertions.assertNotEquals(2, namingUtils.selectInstances("test-service", true).size());
+		assertThat(namingUtils.selectInstances("test-service", true).size()).isEqualTo(1);
 
 		assertThatNoException().isThrownBy(() -> namingUtils.batchDeregisterInstance("test-service", "DEFAULT_GROUP", List.of(instance)));
 		Thread.sleep(1000);
-		Assertions.assertEquals(0, namingUtils.selectInstances("test-service", false).size());
+		assertThat(namingUtils.selectInstances("test-service", false).size()).isEqualTo(0);
 	}
 
 	@Test

--- a/laokou-common/laokou-common-network/laokou-common-network-mqtt-client/src/test/java/org/laokou/common/network/mqtt/client/TopicUtilsTest.java
+++ b/laokou-common/laokou-common-network/laokou-common-network-mqtt-client/src/test/java/org/laokou/common/network/mqtt/client/TopicUtilsTest.java
@@ -17,9 +17,10 @@
 
 package org.laokou.common.network.mqtt.client;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.network.mqtt.client.util.VertxMqttUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -28,12 +29,12 @@ class TopicUtilsTest {
 
 	@Test
 	void testMatch() {
-		Assertions.assertTrue(VertxMqttUtils.matchTopic("test/topic", "test/topic"));
-		Assertions.assertFalse(VertxMqttUtils.matchTopic("test/topic", "test/topic/"));
-		Assertions.assertTrue(VertxMqttUtils.matchTopic("test/#", "test/topic/test"));
-		Assertions.assertTrue(VertxMqttUtils.matchTopic("test/+", "test/topic"));
-		Assertions.assertTrue(VertxMqttUtils.matchTopic("test/+/test", "test/topic/test"));
-		Assertions.assertTrue(VertxMqttUtils.matchTopic("test/+/+", "test/topic/test"));
+		assertThat(VertxMqttUtils.matchTopic("test/topic", "test/topic")).isTrue();
+		assertThat(VertxMqttUtils.matchTopic("test/topic", "test/topic/")).isFalse();
+		assertThat(VertxMqttUtils.matchTopic("test/#", "test/topic/test")).isTrue();
+		assertThat(VertxMqttUtils.matchTopic("test/+", "test/topic")).isTrue();
+		assertThat(VertxMqttUtils.matchTopic("test/+/test", "test/topic/test")).isTrue();
+		assertThat(VertxMqttUtils.matchTopic("test/+/+", "test/topic/test")).isTrue();
 	}
 
 }

--- a/laokou-common/laokou-common-secret/src/test/java/org/laokou/common/secret/SecretUtilsTest.java
+++ b/laokou-common/laokou-common-secret/src/test/java/org/laokou/common/secret/SecretUtilsTest.java
@@ -17,9 +17,10 @@
 
 package org.laokou.common.secret;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.secret.util.SecretUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author laokou
@@ -29,7 +30,7 @@ class SecretUtilsTest {
 	@Test
 	void test() {
 		String sign = SecretUtils.sign(SecretUtils.APP_KEY, SecretUtils.APP_SECRET, "1", String.valueOf(100000), "");
-		Assertions.assertEquals("e1506abd8395b0763f08d2a0e56f6738", sign);
+		assertThat(sign).isEqualTo("e1506abd8395b0763f08d2a0e56f6738");
 	}
 
 }

--- a/laokou-common/laokou-common-sensitive/src/test/java/org/laokou/common/sensitive/SensitiveUtilsTest.java
+++ b/laokou-common/laokou-common-sensitive/src/test/java/org/laokou/common/sensitive/SensitiveUtilsTest.java
@@ -17,10 +17,10 @@
 
 package org.laokou.common.sensitive;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.sensitive.util.SensitiveUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.laokou.common.i18n.common.constant.StringConstants.EMPTY;
 
 /**
@@ -30,28 +30,28 @@ class SensitiveUtilsTest {
 
 	@Test
 	void testMobile() {
-		Assertions.assertEquals("188****8888", SensitiveUtils.formatMobile("18888888888"));
-		Assertions.assertEquals(EMPTY, SensitiveUtils.formatMobile(EMPTY));
-		Assertions.assertEquals(EMPTY, SensitiveUtils.formatMobile(null));
+		assertThat(SensitiveUtils.formatMobile("18888888888")).isEqualTo("188****8888");
+		assertThat(SensitiveUtils.formatMobile(EMPTY)).isEqualTo(EMPTY);
+		assertThat(SensitiveUtils.formatMobile(null)).isEqualTo(EMPTY);
 	}
 
 	@Test
 	void testStr() {
-		Assertions.assertEquals(EMPTY, SensitiveUtils.formatStr(null, "", 3, 7));
-		Assertions.assertEquals(EMPTY, SensitiveUtils.formatStr("", "", 3, 7));
-		Assertions.assertEquals("123890", SensitiveUtils.formatStr("1234567890", null, 3, 7));
-		Assertions.assertEquals("123890", SensitiveUtils.formatStr("1234567890", EMPTY, 3, 7));
-		Assertions.assertEquals("890", SensitiveUtils.formatStr("1234567890", EMPTY, -1, 7));
-		Assertions.assertEquals("1234567", SensitiveUtils.formatStr("1234567890", EMPTY, 11, 7));
-		Assertions.assertEquals("1", SensitiveUtils.formatStr("1234567890", EMPTY, 1, 12));
-		Assertions.assertEquals("234567890", SensitiveUtils.formatStr("1234567890", EMPTY, 1, -1));
+		assertThat(SensitiveUtils.formatStr(null, "", 3, 7)).isEqualTo(EMPTY);
+		assertThat(SensitiveUtils.formatStr("", "", 3, 7)).isEqualTo(EMPTY);
+		assertThat( SensitiveUtils.formatStr("1234567890", null, 3, 7)).isEqualTo("123890");
+		assertThat(SensitiveUtils.formatStr("1234567890", EMPTY, 3, 7)).isEqualTo("123890");
+		assertThat( SensitiveUtils.formatStr("1234567890", EMPTY, -1, 7)).isEqualTo("890");
+		assertThat( SensitiveUtils.formatStr("1234567890", EMPTY, 11, 7)).isEqualTo("1234567");
+		assertThat( SensitiveUtils.formatStr("1234567890", EMPTY, 1, 12)).isEqualTo("1");
+		assertThat( SensitiveUtils.formatStr("1234567890", EMPTY, 1, -1)).isEqualTo("234567890");
 	}
 
 	@Test
 	void testMail() {
-		Assertions.assertEquals("2****@qq.com", SensitiveUtils.formatMail("2413176044@qq.com"));
-		Assertions.assertEquals(EMPTY, SensitiveUtils.formatMail(null));
-		Assertions.assertEquals(EMPTY, SensitiveUtils.formatMail(EMPTY));
+		assertThat( SensitiveUtils.formatMail("2413176044@qq.com")).isEqualTo("2****@qq.com");
+		assertThat(SensitiveUtils.formatMail(null)).isEqualTo(EMPTY);
+		assertThat(SensitiveUtils.formatMail(EMPTY)).isEqualTo(EMPTY);
 	}
 
 }

--- a/laokou-common/laokou-common-xss/src/test/java/org/laokou/common/xss/XssTest.java
+++ b/laokou-common/laokou-common-xss/src/test/java/org/laokou/common/xss/XssTest.java
@@ -18,7 +18,6 @@
 package org.laokou.common.xss;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.xss.util.XssUtils;
 
@@ -39,27 +38,27 @@ class XssTest {
 	void testHtmlScripTagJsonString() {
 		String json = "{\"s\": \"" + xssAttackVectors[0] + "\"}";
 		String cleaned = XssUtils.clearHtml(json);
-		Assertions.assertEquals("{\"s\": \"alert(1)\"}", cleaned);
-		Assertions.assertTrue(cleaned.startsWith("{") && cleaned.endsWith("}"));
-		Assertions.assertFalse(cleaned.contains("<script>"));
+		assertThat( cleaned).isEqualTo("{\"s\": \"alert(1)\"}");
+		assertThat(cleaned.startsWith("{") && cleaned.endsWith("}")).isTrue();
+		assertThat(cleaned.contains("<script>")).isFalse();
 	}
 
 	@Test
 	void testHtmlTagJsonString() {
 		String json = "{\"s\": \"" + xssAttackVectors[1] + "\"}";
 		String cleaned = XssUtils.clearHtml(json);
-		Assertions.assertEquals("{\"s\": \"<img>\"}", cleaned);
-		Assertions.assertTrue(cleaned.startsWith("{") && cleaned.endsWith("}"));
-		Assertions.assertFalse(cleaned.contains("<IMG"));
+		assertThat( cleaned).isEqualTo("{\"s\": \"<img>\"}");
+		assertThat(cleaned.startsWith("{") && cleaned.endsWith("}")).isTrue();
+		assertThat(cleaned.contains("<IMG")).isFalse();
 	}
 
 	@Test
 	void testSvgJsonString() {
 		String json = "{\"s\": \"" + xssAttackVectors[2] + "\"}";
 		String cleaned = XssUtils.clearHtml(json);
-		Assertions.assertEquals("{\"s\": \"\"}", cleaned);
-		Assertions.assertTrue(cleaned.startsWith("{") && cleaned.endsWith("}"));
-		Assertions.assertFalse(cleaned.contains("<svg"));
+		assertThat(cleaned).isEqualTo("{\"s\": \"\"}");
+		assertThat(cleaned.startsWith("{") && cleaned.endsWith("}")).isTrue();
+		assertThat(cleaned.contains("<svg")).isFalse();
 	}
 
 	@Test
@@ -82,7 +81,7 @@ class XssTest {
 		catch (Exception e) {
 			sqlInjection = true;
 		}
-		Assertions.assertTrue(sqlInjection);
+		assertThat(sqlInjection).isTrue();
 	}
 
 }


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Replace JUnit Assertions with AssertJ assertions

- Migrate from `Assertions.assertEquals/assertTrue/assertFalse` to `assertThat().isEqualTo/isTrue/isFalse`

- Update imports to use AssertJ static imports

- Improve test readability with fluent assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JUnit Assertions"] --> B["AssertJ assertThat"]
  C["assertEquals/assertTrue"] --> D["isEqualTo/isTrue/isFalse"]
  E["Import changes"] --> F["Static AssertJ imports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

## Sourcery 总结

将所有测试中的 JUnit 断言替换为 AssertJ 流式断言，并通过移除元数据键常量并内联其字符串字面量来简化 NacosLoadBalancer。

改进：
- 将测试从 JUnit 断言迁移到 AssertJ 的 `assertThat` 和 `assertThatNoException`，以提高可读性和一致性
- 移除 NacosLoadBalancer 中的 `CLUSTER_CONFIG`、`VERSION`、`DEFAULT_VERSION_VALUE` 和 `IPV6_KEY` 常量，并内联其字符串值

测试：
- 更新所有测试类中的静态导入以使用 AssertJ
- 在所有测试中将 `assertEquals`/`assertTrue`/`assertFalse` 调用替换为 `assertThat().isEqualTo()/isTrue()/isFalse()`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace JUnit assertions with AssertJ fluent assertions across all tests and simplify NacosLoadBalancer by removing metadata key constants and inlining their string literals.

Enhancements:
- Migrate tests from JUnit Assertions to AssertJ’s assertThat and assertThatNoException for improved readability and consistency
- Remove CLUSTER_CONFIG, VERSION, DEFAULT_VERSION_VALUE and IPV6_KEY constants in NacosLoadBalancer and inline their string values

Tests:
- Update static imports in all test classes to use AssertJ
- Replace assertEquals/assertTrue/assertFalse calls with assertThat().isEqualTo()/isTrue()/isFalse() throughout tests

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated all test assertions across multiple modules to use AssertJ's fluent assertion style instead of JUnit's native assertions for improved readability and consistency.
  * Replaced string constants with direct string literals in metadata lookups for load balancer configuration.
* **Style**
  * Cleaned up imports in test files to remove unused JUnit imports and add AssertJ imports where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->