### PR TITLE
fix：修改首页chart图表不适配页面问题

### DIFF
--- a/ui/src/pages/Home/index.less
+++ b/ui/src/pages/Home/index.less
@@ -36,3 +36,14 @@
 	width: 100%;
 	height: 600px;
 }
+
+.ant-pro-card .ant-pro-card-body-center div:nth-child(1) {
+	position: relative;
+	height: 500px !important;
+}
+.ant-pro-card .ant-pro-card-body-center div:nth-child(1) .g2-tooltip-title{
+	height: 40px !important;
+}
+.ant-pro-card-body canvas{
+	position: absolute;
+}


### PR DESCRIPTION
首页折线图 缩小页面后不适配问题

## Sourcery 总结

Bug 修复：
- 调整 LESS 样式，以确保首页折线图在页面调整大小时能正确适应，具体方法是为容器和工具提示设置相对定位并强制执行高度，以及为画布设置绝对定位

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust LESS styles to ensure the homepage line chart adapts correctly to page resizing by setting relative positioning and enforcing heights for the container and tooltip, and absolute positioning for the canvas

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased chart area height on the Home page for better visibility.
  * Standardized tooltip title height to improve readability.
  * Adjusted canvas positioning to ensure proper alignment within cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->