### PR TITLE
feat: 提交jdk25

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,7 +3,6 @@ on:
   pull_request: {}
   push:
     branches:
-    - main
     - master
     paths:
     - .github/workflows/semgrep.yml

--- a/archive/docs/01.指南/03.快速上手/01.项目启动【dev环境】.md
+++ b/archive/docs/01.指南/03.快速上手/01.项目启动【dev环境】.md
@@ -218,7 +218,7 @@ AUTH_PASSWORD=laokou123
 VERSION=3.5.4
 PROFILE=dev
 SERVER_PORT=8972
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC -Duser.timezone=GMT+08"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC -Duser.timezone=GMT+08"
 ```
 
 增加snail-job.env配置

--- a/doc/deploy/docker-compose/env/admin.env
+++ b/doc/deploy/docker-compose/env/admin.env
@@ -1,1 +1,1 @@
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=9990"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=9990"

--- a/doc/deploy/docker-compose/env/auth.env
+++ b/doc/deploy/docker-compose/env/auth.env
@@ -1,1 +1,1 @@
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=1111"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=1111"

--- a/doc/deploy/docker-compose/env/gateway.env
+++ b/doc/deploy/docker-compose/env/gateway.env
@@ -1,1 +1,1 @@
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=5555"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=5555"

--- a/doc/deploy/docker-compose/env/iot.env
+++ b/doc/deploy/docker-compose/env/iot.env
@@ -1,1 +1,1 @@
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=10005"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=10005"

--- a/doc/deploy/docker-compose/env/logstash.env
+++ b/doc/deploy/docker-compose/env/logstash.env
@@ -1,1 +1,1 @@
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=10003"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=10003"

--- a/doc/deploy/docker-compose/env/monitor.env
+++ b/doc/deploy/docker-compose/env/monitor.env
@@ -1,1 +1,1 @@
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=5000"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08 -Dserver.port=5000"

--- a/doc/deploy/docker-compose/env/nacos.env
+++ b/doc/deploy/docker-compose/env/nacos.env
@@ -9,5 +9,5 @@ DATASOURCE_PLATFORM=postgresql
 JASYPT_ENCRYPTOR_PASSWORD=laokou
 TZ=Asia/Shanghai
 LANG=zh_CN.UTF-8
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC  -Duser.timezone=GMT+08"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC  -Duser.timezone=GMT+08"
 NACOS_OPTS="-Dnacos.standalone=true -Dcom.google.protobuf.use_unsafe_pre22_gencode -Dnacos.home=/opt"

--- a/doc/deploy/docker-compose/env/sentinel.env
+++ b/doc/deploy/docker-compose/env/sentinel.env
@@ -3,6 +3,6 @@ AUTH_PASSWORD=laokou123
 VERSION=3.5.4
 PROFILE=dev
 SERVER_PORT=8972
-JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseG1GC -Duser.timezone=GMT+08"
+JVM_OPTS="-Xmx512m -Xms512m -Xmn256m -XX:+UseCompactObjectHeaders -XX:+UseG1GC -Duser.timezone=GMT+08"
 TZ=Asia/Shanghai
 LANG=zh_CN.UTF-8

--- a/laokou-cloud/laokou-nacos/src/main/java/org/laokou/nacos/NacosApp.java
+++ b/laokou-cloud/laokou-nacos/src/main/java/org/laokou/nacos/NacosApp.java
@@ -49,13 +49,12 @@ import static com.alibaba.nacos.sys.env.Constants.STANDALONE_MODE_PROPERTY_NAME;
 @EnableEncryptableProperties
 public class NacosApp {
 
-	public static void main(String[] args) {
+	static void main(String[] args) {
 		// @formatter:off
 		// -Dnacos.home => Nacos的根目录
 		// Nacos控制台 => http://【ip:8848】/nacos
 		// -Dnacos.standalone=true
 		// -Dcom.google.protobuf.use_unsafe_pre22_gencode
-		// -XX:+UseG1GC
 		// @formatter:on
 		System.setProperty("com.google.protobuf.use_unsafe_pre22_gencode", "true");
 		String standalone = System.getProperty(STANDALONE_MODE_PROPERTY_NAME, "");

--- a/laokou-common/laokou-common-bom/pom.xml
+++ b/laokou-common/laokou-common-bom/pom.xml
@@ -169,11 +169,18 @@
     <modbus4j.version>v3.1.0</modbus4j.version>
     <!--mongodb版本-->
     <mongodb.version>4.5.4</mongodb.version>
+    <!--fastjson版本-->
+    <fastjson>2.0.56</fastjson>
   </properties>
 
   <!-- 定义全局jar版本,模块使用需要再次引入但不用写版本号 -->
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.alibaba</groupId>
+        <artifactId>fastjson</artifactId>
+        <version>${fastjson}</version>
+      </dependency>
       <dependency>
         <groupId>org.laokou</groupId>
         <artifactId>laokou-common-mongodb</artifactId>

--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/Page.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/Page.java
@@ -17,10 +17,7 @@
 
 package org.laokou.common.i18n.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -32,8 +29,6 @@ import java.util.List;
  * @author laokou
  */
 @Data
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Page<T> implements Serializable {
 
 	/**
@@ -45,6 +40,11 @@ public final class Page<T> implements Serializable {
 	 * 数据项集合.
 	 */
 	private List<T> records;
+
+	private Page(long total, List<T> list) {
+		this.total = total;
+		this.records = list;
+	}
 
 	/**
 	 * 构建空对象集合.

--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/Result.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/Result.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  * @author laokou
  */
 @Data
-public class Result<T> implements Serializable {
+public final class Result<T> implements Serializable {
 
 	@Serial
 	private static final long serialVersionUID = -1286769110881865369L;
@@ -51,34 +51,26 @@ public class Result<T> implements Serializable {
 	@Schema(name = "标签ID", description = "标签ID")
 	private String spanId;
 
+	private Result(String code, String msg, T data) {
+		this.code = code;
+		this.msg = msg;
+		this.data = data;
+	}
+
 	public static <T> Result<T> ok(T data) {
-		Result<T> result = new Result<>();
-		result.setData(data);
-		result.setCode(StatusCode.OK);
-		result.setMsg(MessageUtils.getMessage(StatusCode.OK));
-		return result;
+		return new Result<>(StatusCode.OK, MessageUtils.getMessage(StatusCode.OK), data);
 	}
 
 	public static <T> Result<T> fail(String code) {
-		Result<T> result = new Result<>();
-		result.setCode(code);
-		result.setMsg(MessageUtils.getMessage(code));
-		return result;
+		return new Result<>(code, MessageUtils.getMessage(code), null);
 	}
 
 	public static <T> Result<T> fail(String code, String msg) {
-		Result<T> result = new Result<>();
-		result.setCode(code);
-		result.setMsg(msg);
-		return result;
+		return new Result<>(code, msg, null);
 	}
 
 	public static <T> Result<T> fail(String code, String msg, T data) {
-		Result<T> result = new Result<>();
-		result.setCode(code);
-		result.setMsg(msg);
-		result.setData(data);
-		return result;
+		return new Result<>(code, msg, data);
 	}
 
 	public boolean success() {

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/java/org/laokou/admin/AdminApp.java
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/java/org/laokou/admin/AdminApp.java
@@ -62,7 +62,7 @@ import java.security.NoSuchAlgorithmException;
 public class AdminApp {
 
 	// @formatter:off
-	public static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
+	static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
 		// undertow虚拟线程 => EmbeddedWebServerFactoryCustomizerAutoConfiguration#virtualThreadsUndertowDeploymentInfoCustomizer
 		StopWatch stopWatch = new StopWatch("Admin应用程序");
 		stopWatch.start();

--- a/laokou-service/laokou-distributed-identifier/laokou-distributed-identifier-infrastructure/pom.xml
+++ b/laokou-service/laokou-distributed-identifier/laokou-distributed-identifier-infrastructure/pom.xml
@@ -11,6 +11,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>fastjson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-distributed-identifier-domain</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
   </licenses>
   <properties>
     <laokou.version>3.5.4-SNAPSHOT</laokou.version>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
## Sourcery 总结

将项目升级到 JDK 25，引入 Fastjson 依赖管理，重构核心 DTO 和响应式流以实现不变性和清晰性，并简化入口点配置和 CI 触发器。

改进点：
- 重构 Result 和 Page DTO 以使用私有构造函数、静态工厂，并将类标记为 final
- 通过对未使用参数使用下划线来简化响应式路由仓库的 lambda 表达式，并在操作后发出刷新事件
- 从取消订阅事件监听器中移除异步注解，并将 NacosApp 和 AdminApp 中的 main 方法转换为包私有
- 移除过时的控制台标志和被注释掉的 JVM 选项

构建：
- 将项目 Java 版本从 21 提升到 25，并在 BOM 和模块中添加 Fastjson 版本管理及依赖

CI：
- 将 Semgrep 工作流触发器限制到 master 分支

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade project to JDK 25, introduce Fastjson dependency management, refactor core DTOs and reactive flows for immutability and clarity, and streamline entry-point configurations and CI triggers.

Enhancements:
- Refactor Result and Page DTOs to use private constructors, static factories, and mark classes as final
- Simplify reactive route repository lambdas by using underscore for unused parameters and emit refresh events after operations
- Remove asynchronous annotation from unsubscribe event listener and convert main methods in NacosApp and AdminApp to package-private
- Remove outdated console flags and commented JVM options

Build:
- Bump project Java version from 21 to 25 and add Fastjson version management with dependencies in BOM and modules

CI:
- Restrict Semgrep workflow triggers to the master branch

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded Java version to 25.
  - Standardized JVM options by adding a compact object headers flag across service environment configs.
  - Centralized FastJSON version management and added dependency where needed.
  - Adjusted static analysis workflow triggers.

- Documentation
  - Updated development quickstart to reflect the new JVM options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->