### PR TITLE
fix: ci报错

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,24 @@
 version: 2.1
 
-jobs:
-  build:
-    docker:
-      - image: ghcr.io/graalvm/jdk-community:25.0.0
-
+executors:
+  ubuntu:
     environment:
       JVM_OPTS: -Xmx2048m
       TERM: dumb
+    machine:
+      image: ubuntu-2404:2024.11.1
+      docker_layer_caching: true
+    resource_class: arm.large
 
+jobs:
+  jdk25:
+    executor: ubuntu
     steps:
+      - run: sudo apt-get update
+      - run: sudo apt install openjdk-25-jdk
       - checkout
       - run: mvn clean install -P dev -DskipTests -B
 workflows:
   maven-build:
     jobs:
-      - build
+      - jdk25

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,4 +4,4 @@ version = 1
 name = "java"
 
   [analyzers.meta]
-  runtime_version = "21"
+  runtime_version = "25"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,11 +43,11 @@ jobs:
       uses: actions/checkout@v5.0.0
       with:
         fetch-depth: 2
-    - name: Set up JDK
+    - name: Set up GraalVM JDK 25
       uses: actions/setup-java@v5.0.0
       with:
-        java-version: '21'
-        distribution: 'temurin'
+        java-version: '25'
+        distribution: 'graalvm'
         cache: maven
         architecture: x64
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
## Sourcery 总结

将 CI 流水线和分析配置迁移到 Java 25 (GraalVM)，以解决构建错误

CI:
- 将 CircleCI 切换到 Ubuntu 24.04 上使用 OpenJDK 25 的机器执行器，并将构建作业重命名为 jdk25
- 更新 GitHub Actions CodeQL 工作流，以设置 GraalVM JDK 25，而不是 Temurin JDK 21
- 将 DeepSource 分析器 runtime_version 从 21 提升到 25

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate CI pipelines and analysis configuration to Java 25 (GraalVM) to resolve build errors

CI:
- Switch CircleCI to a machine executor on Ubuntu 24.04 with OpenJDK 25 and rename the build job to jdk25
- Update GitHub Actions CodeQL workflow to set up GraalVM JDK 25 instead of Temurin JDK 21
- Bump DeepSource analyzer runtime_version from 21 to 25

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded CI and static analysis environments to Java 25.
  - Migrated CI from container-based to a machine executor with explicit OS-level setup.
  - Updated security scanning to use GraalVM JDK 25.
  - General CI reliability and performance improvements.

- Notes
  - No user-facing functionality changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->