### PR TITLE
Dev

### DIFF
--- a/archive/docs/01.指南/03.快速上手/04.更新日志.md
+++ b/archive/docs/01.指南/03.快速上手/04.更新日志.md
@@ -20,7 +20,7 @@ permalink: /pages/b04951/
 
 🚀 Jackson2迁移至Jackson3
 
-🚀 Dubbo替换掉为gRPC
+🚀 Dubbo替换为gRPC
 
 #### 3.5.4更新日志
 

--- a/laokou-common/laokou-common-grpc/pom.xml
+++ b/laokou-common/laokou-common-grpc/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.laokou</groupId>
+    <artifactId>laokou-common</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>laokou-common-grpc</artifactId>
+  <version>4.0.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-nacos</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.grpc</groupId>
+      <artifactId>spring-grpc-client-spring-boot-starter</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryGrpcChannelFactory.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryGrpcChannelFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.config;
+
+import io.grpc.ChannelCredentials;
+import io.grpc.netty.NettyChannelBuilder;
+import org.springframework.grpc.client.ClientInterceptorsConfigurer;
+import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
+import org.springframework.grpc.client.NettyGrpcChannelFactory;
+
+import java.util.List;
+
+/**
+ * @author laokou
+ */
+final class DiscoveryGrpcChannelFactory extends NettyGrpcChannelFactory {
+
+	/**
+	 * 构建通道工厂实例.
+	 * @param globalCustomizers 要应用于所有已创建频道的全局自定义设置
+	 * @param interceptorsConfigurer 配置已创建通道上的客户端拦截器
+	 */
+	public DiscoveryGrpcChannelFactory(List<GrpcChannelBuilderCustomizer<NettyChannelBuilder>> globalCustomizers,
+			ClientInterceptorsConfigurer interceptorsConfigurer) {
+		super(globalCustomizers, interceptorsConfigurer);
+		setVirtualTargets((p) -> p.substring(12));
+	}
+
+	@Override
+	public boolean supports(String target) {
+		return target.startsWith("discovery:");
+	}
+
+	@Override
+	protected NettyChannelBuilder newChannelBuilder(String target, ChannelCredentials credentials) {
+		return NettyChannelBuilder.forTarget(String.format("discovery://%s", target), credentials);
+	}
+
+}

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolver.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolver.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.config;
+
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.grpc.StatusOr;
+import org.laokou.common.i18n.util.JacksonUtils;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * @author laokou
+ */
+final class DiscoveryNameResolver extends NameResolver {
+
+	private final String serviceName;
+
+	private final DiscoveryClient discoveryClient;
+
+	private final ExecutorService executorService;
+
+	private final ServiceConfigParser serviceConfigParser;
+
+	private final AtomicReference<List<ServiceInstance>> serviceInstanceReference;
+
+	private final AtomicBoolean resolving;
+
+	private Listener2 listener;
+
+	public DiscoveryNameResolver(String serviceName, DiscoveryClient discoveryClient, ExecutorService executorService,
+			Args args) {
+		this.serviceName = serviceName;
+		this.discoveryClient = discoveryClient;
+		this.executorService = executorService;
+		this.serviceInstanceReference = new AtomicReference<>(Collections.emptyList());
+		this.serviceConfigParser = args.getServiceConfigParser();
+		this.resolving = new AtomicBoolean(false);
+	}
+
+	@Override
+	public String getServiceAuthority() {
+		return serviceName;
+	}
+
+	@Override
+	public void shutdown() {
+		this.serviceInstanceReference.set(null);
+	}
+
+	@Override
+	public void start(Listener2 listener) {
+		this.listener = listener;
+		resolve();
+	}
+
+	@Override
+	public void refresh() {
+		resolve();
+	}
+
+	public void refreshFromExternal() {
+		executorService.execute(() -> {
+			if (Objects.nonNull(listener)) {
+				resolve();
+			}
+		});
+	}
+
+	private void resolve() {
+		if (this.resolving.compareAndSet(false, true)) {
+			this.executorService.execute(() -> {
+				this.serviceInstanceReference.set(resolveInternal());
+				this.resolving.set(false);
+			});
+		}
+	}
+
+	private List<ServiceInstance> resolveInternal() {
+		List<ServiceInstance> serviceInstances = serviceInstanceReference.get();
+		List<ServiceInstance> newServiceInstanceList = this.discoveryClient.getInstances(this.serviceName);
+		if (CollectionUtils.isEmpty(newServiceInstanceList)) {
+			listener.onError(Status.UNAVAILABLE.withDescription("No servers found for " + serviceName));
+			return Collections.emptyList();
+		}
+		if (!isUpdateServiceInstance(serviceInstances, newServiceInstanceList)) {
+			return serviceInstances;
+		}
+		this.listener.onResult(ResolutionResult.newBuilder()
+			.setAddressesOrError(StatusOr.fromValue(toAddresses(newServiceInstanceList)))
+			.setServiceConfig(resolveServiceConfig(newServiceInstanceList))
+			.build());
+		return newServiceInstanceList;
+	}
+
+	private boolean isUpdateServiceInstance(List<ServiceInstance> serviceInstances,
+			List<ServiceInstance> newServiceInstanceList) {
+		if (serviceInstances.size() != newServiceInstanceList.size()) {
+			return true;
+		}
+		Set<String> oldSet = serviceInstances.stream().map(this::getAddressStr).collect(Collectors.toSet());
+		Set<String> newSet = newServiceInstanceList.stream().map(this::getAddressStr).collect(Collectors.toSet());
+		return !Objects.equals(oldSet, newSet);
+	}
+
+	private ConfigOrError resolveServiceConfig(List<ServiceInstance> newServiceInstanceList) {
+		String serviceConfig = getServiceConfig(newServiceInstanceList);
+		if (StringUtils.hasText(serviceConfig)) {
+			return serviceConfigParser
+				.parseServiceConfig(JacksonUtils.toMap(serviceConfig, String.class, Object.class));
+		}
+		return null;
+	}
+
+	private String getServiceConfig(List<ServiceInstance> newServiceInstanceList) {
+		for (ServiceInstance serviceInstance : newServiceInstanceList) {
+			return serviceInstance.getMetadata().getOrDefault("grpc_service_config", "");
+		}
+		return "";
+	}
+
+	private List<EquivalentAddressGroup> toAddresses(List<ServiceInstance> newServiceInstanceList) {
+		List<EquivalentAddressGroup> addresses = new ArrayList<>(newServiceInstanceList.size());
+		for (ServiceInstance serviceInstance : newServiceInstanceList) {
+			addresses.add(toAddress(serviceInstance));
+		}
+		return addresses;
+	}
+
+	private EquivalentAddressGroup toAddress(ServiceInstance serviceInstance) {
+		String host = serviceInstance.getHost();
+		int port = getGrpcPost(serviceInstance);
+		return new EquivalentAddressGroup(new InetSocketAddress(host, port), getAttributes(serviceInstance));
+	}
+
+	private Attributes getAttributes(ServiceInstance serviceInstance) {
+		return Attributes.newBuilder()
+			.set(Attributes.Key.create("SERVICE_NAME"), serviceName)
+			.set(Attributes.Key.create("SERVICE_INSTANCE_ID"), serviceInstance.getInstanceId())
+			.build();
+	}
+
+	private String getAddressStr(ServiceInstance serviceInstance) {
+		return serviceInstance.getHost() + ":" + getGrpcPost(serviceInstance);
+	}
+
+	private int getGrpcPost(ServiceInstance serviceInstance) {
+		return Integer.parseInt(serviceInstance.getMetadata().getOrDefault("grpc_port", "9090"));
+	}
+
+}

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolverProvider.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolverProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.config;
+
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.context.event.EventListener;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * @author laokou
+ */
+final class DiscoveryNameResolverProvider extends NameResolverProvider {
+
+	private final DiscoveryClient discoveryClient;
+
+	private final ExecutorService executorService;
+
+	private final Set<DiscoveryNameResolver> discoveryNameResolvers;
+
+	public DiscoveryNameResolverProvider(DiscoveryClient discoveryClient, ExecutorService executorService) {
+		this.discoveryClient = discoveryClient;
+		this.executorService = executorService;
+		this.discoveryNameResolvers = new HashSet<>();
+	}
+
+	@Override
+	protected boolean isAvailable() {
+		return true;
+	}
+
+	@Override
+	protected int priority() {
+		return 6;
+	}
+
+	@Override
+	public NameResolver newNameResolver(URI uri, NameResolver.Args args) {
+		DiscoveryNameResolver discoveryNameResolver = new DiscoveryNameResolver(uri.getHost(), discoveryClient,
+				executorService, args);
+		discoveryNameResolvers.add(discoveryNameResolver);
+		return discoveryNameResolver;
+	}
+
+	@Override
+	public String getDefaultScheme() {
+		return "discovery";
+	}
+
+	@EventListener(HeartbeatEvent.class)
+	public void onHeartbeatEvent(HeartbeatEvent event) {
+		for (DiscoveryNameResolver discoveryNameResolver : discoveryNameResolvers) {
+			discoveryNameResolver.refreshFromExternal();
+		}
+	}
+
+}

--- a/laokou-common/pom.xml
+++ b/laokou-common/pom.xml
@@ -84,6 +84,7 @@
     <module>laokou-common-modbus4j</module>
     <module>laokou-common-testcontainers</module>
     <module>laokou-common-mongodb</module>
+    <module>laokou-common-grpc</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!--spring-asciidoctor-backends版本-->
     <spring-asciidoctor-backends.version>0.0.7</spring-asciidoctor-backends.version>
     <!--spring-boot版本-->
-    <spring-boot.version>4.0.0-RC1</spring-boot.version>
+    <spring-boot.version>4.0.0-RC2</spring-boot.version>
     <!--spring-cloud版本-->
     <spring-cloud.version>2025.1.0-M4</spring-cloud.version>
     <!--cloud-alibaba版本-->
@@ -110,7 +110,9 @@
     <!--spring-data版本-->
     <spring-data.version>2025.1.0-RC2</spring-data.version>
     <!--spring-security版本-->
-    <spring-security.version>7.0.0-RC1</spring-security.version>
+    <spring-security.version>7.0.0-RC3</spring-security.version>
+    <!--spring-grpc版本-->
+    <spring-grpc.version>0.12.0</spring-grpc.version>
     <!--spring-ai版本-->
     <spring-ai.version>1.0.3</spring-ai.version>
     <!--spring-ai-alibaba版本-->
@@ -301,6 +303,16 @@
         <scope>import</scope>
       </dependency>
       <!-- =============================== 定义 Spring Security 版本 =============================== -->
+
+      <!-- =============================== 定义 Spring gRPC 版本 =============================== -->
+      <dependency>
+        <groupId>org.springframework.grpc</groupId>
+        <artifactId>spring-grpc-dependencies</artifactId>
+        <version>${spring-grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- =============================== 定义 Spring gRPC 版本 =============================== -->
 
       <!-- =============================== 定义 Spring Ai 版本 =============================== -->
       <dependency>


### PR DESCRIPTION
## Sourcery 总结

通过添加一个带有服务发现集成的新 grpc 模块来启用 Spring gRPC 支持，并将项目依赖更新到最新的 Spring Boot 和 Security 发布候选版本

新特性:
- 添加 `laokou-common-grpc` 模块，提供基于服务发现的 gRPC `NameResolver`、`NameResolverProvider` 和 Netty 通道工厂

改进:
- 升级 Spring Boot 到 4.0.0-RC2 和 Spring Security 到 7.0.0-RC3

构建:
- 引入 `spring-grpc.version` 属性并在根 POM 中导入 `spring-grpc BOM`

杂项:
- 在父 `laokou-common` POM 中注册 `laokou-common-grpc` 模块

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Spring gRPC support by adding a new grpc module with discovery integration, and update project dependencies to the latest Spring Boot and Security release candidates

New Features:
- Add laokou-common-grpc module providing discovery-based gRPC NameResolver, NameResolverProvider, and Netty channel factory

Enhancements:
- Upgrade Spring Boot to 4.0.0-RC2 and Spring Security to 7.0.0-RC3

Build:
- Introduce spring-grpc.version property and import spring-grpc BOM in the root POM

Chores:
- Register laokou-common-grpc module in the parent laokou-common POM

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gRPC support with Spring Cloud Discovery integration for improved service-to-service communication.

* **Chores**
  * Upgraded Spring Boot from 4.0.0-RC1 to 4.0.0-RC2.
  * Integrated Spring gRPC framework dependencies (version 0.12.0) for gRPC functionality.

* **Documentation**
  * Minor text correction in migration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->