### PR TITLE
test: 优化测试用例

### DIFF
--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/SystemUtils.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/SystemUtils.java
@@ -33,7 +33,7 @@ public final class SystemUtils {
 	 * 判断是否是Window系统.
 	 */
 	public static boolean isWindows() {
-		return System.getProperty("os.name").equalsIgnoreCase("windows");
+		return System.getProperty("os.name").contains("Windows");
 	}
 
 	public static boolean isArchLinux() {

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CmdUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CmdUtilsTest.java
@@ -20,6 +20,7 @@ package org.laokou.common.core;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.CmdUtils;
+import org.laokou.common.core.util.SystemUtils;
 
 import java.io.IOException;
 
@@ -30,8 +31,15 @@ class CmdUtilsTest {
 
 	@Test
 	void test() throws IOException, InterruptedException {
-		Assertions.assertThat(CmdUtils.execute("echo", "hello world!").getFirst()).isEqualTo("hello world!");
-		Assertions.assertThatNoException().isThrownBy(() -> CmdUtils.executeVoid("top"));
+		if (!SystemUtils.isWindows()) {
+			Assertions.assertThat(CmdUtils.execute("echo", "hello world!").getFirst()).isEqualTo("hello world!");
+			Assertions.assertThatNoException().isThrownBy(() -> CmdUtils.executeVoid("top"));
+		}
+		else {
+			Assertions.assertThat(CmdUtils.execute("cmd", "/c", "echo hello world!").getFirst())
+				.isEqualTo("hello world!");
+			Assertions.assertThatNoException().isThrownBy(() -> CmdUtils.executeVoid("cmd", "/c", "cd", "c:/"));
+		}
 	}
 
 }

--- a/laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java
+++ b/laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java
@@ -17,12 +17,12 @@
 
 package org.laokou.common.csv;
 
-import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.csv.utils.CsvUtils;
 import org.springframework.boot.system.SystemProperties;
+import wiremock.org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/laokou-common/laokou-common-excel/pom.xml
+++ b/laokou-common/laokou-common-excel/pom.xml
@@ -13,12 +13,6 @@
     <dependency>
       <groupId>cn.idev.excel</groupId>
       <artifactId>fastexcel</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-collections4</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
@@ -43,6 +37,16 @@
       <version>${project.version}</version>
       <scope>test</scope>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Copyright © 2018 organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.dynamic.datasource.spring.boot.autoconfigure;
+
+import com.baomidou.dynamic.datasource.DynamicRoutingDataSource;
+import com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.CollectionUtils;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+/**
+ * 动态数据源核心自动配置类.
+ *
+ * @author TaoYu Kanyuxia
+ * @author laokou
+ * @since 1.0.0
+ */
+@Slf4j
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore(value = DataSourceAutoConfiguration.class,
+		name = { "com.alibaba.druid.spring.boot.autoconfigure.DruidDataSourceAutoConfigure",
+				"com.alibaba.druid.spring.boot3.autoconfigure.DruidDataSourceAutoConfigure" })
+@Import({ DruidDynamicDataSourceConfiguration.class, DynamicDataSourceCreatorAutoConfiguration.class,
+		DynamicDataSourceAopConfiguration.class, DynamicDataSourceAssistConfiguration.class })
+@ConditionalOnProperty(prefix = DynamicDataSourceProperties.PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class DynamicDataSourceAutoConfiguration implements InitializingBean {
+
+	private final DynamicDataSourceProperties properties;
+
+	private final List<DynamicDataSourcePropertiesCustomizer> dataSourcePropertiesCustomizers;
+
+	public DynamicDataSourceAutoConfiguration(DynamicDataSourceProperties properties,
+			ObjectProvider<List<DynamicDataSourcePropertiesCustomizer>> dataSourcePropertiesCustomizers) {
+		this.properties = properties;
+		this.dataSourcePropertiesCustomizers = dataSourcePropertiesCustomizers.getIfAvailable();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public DataSource dataSource(List<DynamicDataSourceProvider> providers) {
+		DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource(providers);
+		dataSource.setPrimary(properties.getPrimary());
+		dataSource.setStrict(properties.getStrict());
+		dataSource.setStrategy(properties.getStrategy());
+		dataSource.setP6spy(properties.getP6spy());
+		dataSource.setSeata(properties.getSeata());
+		dataSource.setGraceDestroy(properties.getGraceDestroy());
+		return dataSource;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		if (!CollectionUtils.isEmpty(dataSourcePropertiesCustomizers)) {
+			for (DynamicDataSourcePropertiesCustomizer customizer : dataSourcePropertiesCustomizers) {
+				customizer.customize(properties);
+			}
+		}
+	}
+
+}

--- a/laokou-common/laokou-common-test/pom.xml
+++ b/laokou-common/laokou-common-test/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-testcontainers/pom.xml
+++ b/laokou-common/laokou-common-testcontainers/pom.xml
@@ -29,11 +29,11 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>elasticsearch</artifactId>
+      <artifactId>testcontainers-elasticsearch</artifactId>
       <exclusions>
         <exclusion>
           <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,8 @@
     <swagger-annotations-jakarta.version>2.2.40</swagger-annotations-jakarta.version>
     <!--jsqlparser版本-->
     <jsqlparser.version>5.2</jsqlparser.version>
+    <!--commons-io-->
+    <commons-io.version>2.21.0</commons-io.version>
     <!--spotbugs版本-->
     <spotbugs.version>4.9.8</spotbugs.version>
     <!--docker主机-->
@@ -497,7 +499,7 @@
       </dependency>
       <dependency>
         <groupId>org.wiremock</groupId>
-        <artifactId>wiremock</artifactId>
+        <artifactId>wiremock-standalone</artifactId>
         <version>${wiremock.version}</version>
       </dependency>
       <dependency>
@@ -693,6 +695,12 @@
         <groupId>com.github.jsqlparser</groupId>
         <artifactId>jsqlparser</artifactId>
         <version>${jsqlparser.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Improved Windows OS detection using `contains()` instead of `equalsIgnoreCase()`

- Enhanced `CmdUtilsTest` with platform-specific test cases for Windows and Unix

- Fixed dependency management: replaced `wiremock` with `wiremock-standalone`

- Updated testcontainers artifact names to match current naming convention

- Added `commons-io` dependency and resolved import conflicts in CSV tests

- Added dynamic datasource auto-configuration class for Spring Boot integration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SystemUtils<br/>Windows Detection"] -->|improved| B["Platform-aware<br/>Detection Logic"]
  C["CmdUtilsTest"] -->|enhanced| D["Platform-specific<br/>Test Cases"]
  E["Dependency<br/>Management"] -->|fixed| F["wiremock-standalone<br/>& commons-io"]
  G["New Configuration"] -->|added| H["DynamicDataSourceAutoConfiguration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SystemUtils.java</strong><dd><code>Improved Windows OS detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/SystemUtils.java

<ul><li>Changed Windows OS detection from <code>equalsIgnoreCase("windows")</code> to <br><code>contains("Windows")</code><br> <li> Improves compatibility with various Windows OS naming conventions</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-9c143dcfe360cf25bab7850f43f9bf48da5bf3592248814bd4fb7a2f97fac640">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DynamicDataSourceAutoConfiguration.java</strong><dd><code>Add dynamic datasource auto-configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-mybatis-plus/src/main/java/com/baomidou/dynamic/datasource/spring/boot/autoconfigure/DynamicDataSourceAutoConfiguration.java

<ul><li>New auto-configuration class for dynamic datasource routing<br> <li> Implements Spring Boot auto-configuration with conditional bean <br>creation<br> <li> Configures <code>DynamicRoutingDataSource</code> with properties and customizers<br> <li> Includes dual licensing (KCloud-Platform-IoT and baomidou)</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-e1958a8f8619eb4bfebbebf0f4f3a7778b2ee0ec781ec1c6fb6a93033f571a6c">+102/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CmdUtilsTest.java</strong><dd><code>Add platform-specific command execution tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/CmdUtilsTest.java

<ul><li>Added <code>SystemUtils</code> import for platform detection<br> <li> Implemented conditional test logic: Unix commands for non-Windows, cmd <br>commands for Windows<br> <li> Added Windows-specific test cases using <code>cmd /c</code> for echo and directory <br>navigation</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-e209af933917e98d1d53748a87acafd5b0e22c0a480331531dc9ff775d1b6dca">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CsvUtilsTest.java</strong><dd><code>Fix FileUtils import conflict</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-csv/src/test/java/org/laokou/common/csv/CsvUtilsTest.java

<ul><li>Replaced <code>org.apache.commons.io.FileUtils</code> import with <br><code>wiremock.org.apache.commons.io.FileUtils</code><br> <li> Resolves import conflict by using wiremock's bundled commons-io</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-1ddd7567608732e2a44fff8c5f02cb238028350e594f7ee119668f6b4537bca0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update dependency exclusions and add commons-io</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-excel/pom.xml

<ul><li>Removed <code>commons-collections4</code> exclusion from <code>fastexcel</code> dependency<br> <li> Added <code>commons-compress</code> exclusion to <code>laokou-common-testcontainers</code><br> <li> Added explicit <code>commons-io</code> dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-0a5e32f0b49d729c166dc68b9d836a76d801e172c25fa43ee8ade1756b122fc4">+10/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update wiremock to standalone artifact</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-test/pom.xml

<ul><li>Changed wiremock artifact from <code>wiremock</code> to <code>wiremock-standalone</code><br> <li> Ensures correct wiremock standalone version is used in tests</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-f1fe169d95dca154f6c105e5968ccb145418eea7b1bd030a72451e712983ee74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update testcontainers artifact naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/pom.xml

<ul><li>Updated testcontainers artifact names: <code>postgresql</code> to <br><code>testcontainers-postgresql</code><br> <li> Updated testcontainers artifact names: <code>elasticsearch</code> to <br><code>testcontainers-elasticsearch</code><br> <li> Aligns with current testcontainers naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-4668960e7b298784b411fe18d9055c9d700265f61228a84584fcce1ffe77be68">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Add commons-io and update wiremock artifact</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml

<ul><li>Added <code>commons-io</code> version property <code>2.21.0</code><br> <li> Changed wiremock artifact from <code>wiremock</code> to <code>wiremock-standalone</code> in <br>dependency management<br> <li> Added <code>commons-io</code> dependency to dependency management section</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5143/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows operating system detection to support additional variants.

* **Dependencies**
  * Updated WireMock to standalone version; added commons-io library management; updated Testcontainers artifact identifiers.

* **Tests**
  * Enhanced test coverage with OS-specific behavior for command execution across different platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->