### PR TITLE
style: 优化network模块代码风格

### DIFF
--- a/laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/AbstractVertxServer.java
+++ b/laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/AbstractVertxServer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022-2025 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.server;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * @author laokou
+ */
+public abstract class AbstractVertxServer<T> extends AbstractVerticle implements VertxServer {
+
+	protected Future<T> serverFuture;
+
+	protected Future<String> deploymentIdFuture;
+
+	public AbstractVertxServer(Vertx vertx) {
+		super.vertx = vertx;
+	}
+
+	@Override
+	public void deploy() {
+		// 部署服务
+		deploymentIdFuture = deploy0();
+	}
+
+	@Override
+	public void undeploy() {
+		// 卸载服务
+		deploymentIdFuture = undeploy0();
+	}
+
+	@Override
+	public void start() {
+		// 启动服务
+		serverFuture = start0();
+	}
+
+	@Override
+	public void stop() {
+		// 停止服务
+		serverFuture = stop0();
+	}
+
+	public abstract Future<String> deploy0();
+
+	public abstract Future<String> undeploy0();
+
+	public abstract Future<T> start0();
+
+	public abstract Future<T> stop0();
+
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Extract common server lifecycle logic into `AbstractVertxServer` base class

- Eliminate code duplication across HTTP, MQTT, TCP, UDP server implementations

- Standardize server state management with generic type parameter

- Replace unused parameter with underscore in lambda expressions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AbstractVertxServer&lt;T&gt;<br/>New Base Class"] -->|"extends"| B["VertxHttpServer"]
  A -->|"extends"| C["VertxMqttServer"]
  A -->|"extends"| D["VertxTcpServer"]
  A -->|"extends"| E["VertxUdpServer"]
  B -->|"eliminates duplication"| F["Shared Lifecycle Methods"]
  C -->|"eliminates duplication"| F
  D -->|"eliminates duplication"| F
  E -->|"eliminates duplication"| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractVertxServer.java</strong><dd><code>New abstract base class for Vertx servers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/AbstractVertxServer.java

<ul><li>New abstract base class implementing <code>VertxServer</code> interface<br> <li> Defines generic type parameter <code><T></code> for server-specific types<br> <li> Provides template methods for <code>deploy()</code>, <code>undeploy()</code>, <code>start()</code>, <code>stop()</code><br> <li> Declares abstract methods <code>deploy0()</code>, <code>undeploy0()</code>, <code>start0()</code>, <code>stop0()</code><br> <li> Manages shared state: <code>serverFuture</code> and <code>deploymentIdFuture</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5184/files#diff-48953ff613c95ad2c856d2b22a5197fb520611b589e20dda1e16c803163e0388">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VertxHttpServer.java</strong><dd><code>Refactor to use AbstractVertxServer base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/http/config/VertxHttpServer.java

<ul><li>Refactor to extend <code>AbstractVertxServer<HttpServer></code> instead of <code>AbstractVerticle</code><br> <li> Remove duplicate lifecycle methods (<code>deploy()</code>, <code>undeploy()</code>, <code>start()</code>, <br><code>stop()</code>)<br> <li> Remove duplicate field declarations (<code>httpServerFuture</code>, <br><code>deploymentIdFuture</code>)<br> <li> Change method visibility from <code>private</code> to <code>public</code> for abstract method <br>implementations<br> <li> Replace unused parameter <code>v</code> with underscore <code>_</code> in lambda expressions<br> <li> Update constructor to call <code>super(vertx)</code> instead of direct field <br>assignment</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5184/files#diff-db34a819e9fdc6aa9a53c503f8b3dfb4ce4d599e8a7fcc0fe68d75d1a3954766">+14/-39</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VertxMqttServer.java</strong><dd><code>Refactor to use AbstractVertxServer base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/mqtt/config/VertxMqttServer.java

<ul><li>Refactor to extend <code>AbstractVertxServer<MqttServer></code> instead of <code>AbstractVerticle</code><br> <li> Remove duplicate lifecycle methods and field declarations<br> <li> Change method visibility from <code>private</code> to <code>public</code> for abstract method <br>implementations<br> <li> Update constructor to call <code>super(vertx)</code> instead of direct field <br>assignment<br> <li> Reorder imports to place <code>AbstractVertxServer</code> import after other <br>imports</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5184/files#diff-f7e53b943c89821e142e080c13ae43a5108719afefd1909591997cc46b69484c">+12/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VertxTcpServer.java</strong><dd><code>Refactor to use AbstractVertxServer base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/tcp/config/VertxTcpServer.java

<ul><li>Refactor to extend <code>AbstractVertxServer<NetServer></code> instead of <code>AbstractVerticle</code><br> <li> Remove duplicate lifecycle methods and field declarations<br> <li> Change method visibility from <code>private</code> to <code>public</code> for abstract method <br>implementations<br> <li> Update constructor to call <code>super(vertx)</code> instead of direct field <br>assignment<br> <li> Replace unused parameter with underscore <code>_</code> in lambda expression</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5184/files#diff-f37d6c29b4e16b635e037371e55a369797e45765230d110bd41f074ebae673e8">+12/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VertxUdpServer.java</strong><dd><code>Refactor to use AbstractVertxServer base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/server/udp/config/VertxUdpServer.java

<ul><li>Refactor to extend <code>AbstractVertxServer<DatagramSocket></code> instead of <code>AbstractVerticle</code><br> <li> Remove duplicate lifecycle methods and field declarations<br> <li> Change method visibility from <code>private</code> to <code>public</code> for abstract method <br>implementations<br> <li> Update constructor to call <code>super(vertx)</code> instead of direct field <br>assignment<br> <li> Add <code>this.</code> prefix to field assignment for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5184/files#diff-b6cf9b7d0d2fd53ead0bba776d1bce2610eb2adf8ea4dc324c82025f0562e2b6">+12/-37</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized server lifecycle management across all network services for improved consistency.
  * Enhanced error logging and failure diagnostics during deployment, startup, and shutdown operations for better debugging support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->