### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/User.java
+++ b/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/User.java
@@ -22,10 +22,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.jspecify.annotations.NullMarked;
-import org.springframework.security.core.AuthenticatedPrincipal;
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.io.Serializable;
+import java.security.Principal;
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @param id 用户ID.
@@ -45,12 +51,42 @@ import java.util.Set;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public record User(Long id, String username, String avatar, Boolean superAdmin, Integer status, String mail,
-		String mobile, Long tenantId, Set<String> permissions) implements AuthenticatedPrincipal, Serializable {
+		String mobile, Long tenantId, Set<String> permissions) implements Authentication, Principal, Serializable {
 
 	@Override
 	@NullMarked
 	public String getName() {
 		return username;
+	}
+
+	@Override
+	@NullMarked
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return this.permissions.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
+	}
+
+	@Override
+	public @Nullable Object getCredentials() {
+		return null;
+	}
+
+	@Override
+	public @Nullable Object getDetails() {
+		return username;
+	}
+
+	@Override
+	public @Nullable Object getPrincipal() {
+		return username;
+	}
+
+	@Override
+	public boolean isAuthenticated() {
+		return true;
+	}
+
+	@Override
+	public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
 	}
 
 }

--- a/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserExtDetails.java
+++ b/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserExtDetails.java
@@ -120,12 +120,6 @@ public final class UserExtDetails implements UserDetails, OAuth2AuthenticatedPri
 	@Getter
 	private Set<String> permissions;
 
-	public UserExtDetails toUserDetail(Long id, Long tenantId) {
-		this.id = id;
-		this.tenantId = tenantId;
-		return this;
-	}
-
 	public UserExtDetails toUserDetail(@NonNull User user) {
 		this.id = user.id();
 		this.username = getDecryptUsername(user.username());
@@ -229,11 +223,6 @@ public final class UserExtDetails implements UserDetails, OAuth2AuthenticatedPri
 	@NullMarked
 	public String getName() {
 		return this.username;
-	}
-
-	public UserExtDetails getDecryptInfo() {
-
-		return this;
 	}
 
 	public String getDecryptUsername(String username) {

--- a/laokou-common/laokou-common-context/src/test/java/org/laokou/common/context/UserUtilsTest.java
+++ b/laokou-common/laokou-common-context/src/test/java/org/laokou/common/context/UserUtilsTest.java
@@ -80,17 +80,16 @@ class UserUtilsTest {
 
 		@Override
 		public Object getPrincipal() {
-			User user = null;
 			try {
-				user = new User(1L, AESUtils.encrypt("admin"),
+				User user = new User(1L, AESUtils.encrypt("admin"),
 						"https://youke1.picui.cn/s1/2025/07/20/687ca202b2c53.jpg", true, 0,
 						AESUtils.encrypt("2413176044@qq.com"), AESUtils.encrypt("13574411111"), 0L,
 						Set.of("test:save"));
+				return SpringContextUtils.getBeanProvider(UserExtDetails.class).toUserDetail(user);
 			}
 			catch (Exception e) {
 				throw new RuntimeException(e);
 			}
-			return SpringContextUtils.getBeanProvider(UserExtDetails.class).toUserDetail(user);
 		}
 
 		@Override

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/util/RedisUtils.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/util/RedisUtils.java
@@ -17,7 +17,6 @@
 
 package org.laokou.common.redis.util;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.util.MapUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
@@ -51,8 +50,7 @@ import java.util.stream.Collectors;
  * @author laokou
  */
 @Slf4j
-@RequiredArgsConstructor
-public class RedisUtils {
+public record RedisUtils(RedisTemplate<String, Object> redisTemplate, RedissonClient redissonClient) {
 
 	/**
 	 * 24小时过期，单位：秒.
@@ -78,10 +76,6 @@ public class RedisUtils {
 	 * 永不过期.
 	 */
 	public static final long NOT_EXPIRE = -1L;
-
-	private final RedisTemplate<String, Object> redisTemplate;
-
-	private final RedissonClient redissonClient;
 
 	public RLock getLock(String key) {
 		return redissonClient.getLock(key);

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/util/RedisUtils.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/util/RedisUtils.java
@@ -63,14 +63,14 @@ public record RedisUtils(RedisTemplate<String, Object> redisTemplate, RedissonCl
 	public static final long ONE_HOUR_EXPIRE = 60 * 60;
 
 	/**
-	 * 6小时过期，单位：秒.
-	 */
-	public static final long SIX_HOUR_EXPIRE = 60 * 60 * 6;
-
-	/**
 	 * 5分钟过期，单位：秒.
 	 */
 	public static final long FIVE_MINUTE_EXPIRE = 5 * 60;
+
+	/**
+	 * 1分钟过期，单位：秒.
+	 */
+	public static final long ONE_MINUTE_EXPIRE = 60;
 
 	/**
 	 * 永不过期.
@@ -253,6 +253,13 @@ public record RedisUtils(RedisTemplate<String, Object> redisTemplate, RedissonCl
 		return redissonClient.getAtomicLong(key).get();
 	}
 
+	/**
+	 * 添加hash.
+	 * @param key 键
+	 * @param field 键字段.
+	 * @param value 值
+	 * @param expire 过期时间，单位：秒
+	 */
 	public void hSet(String key, String field, Object value, long expire) {
 		RMap<String, Object> map = redissonClient.getMap(key);
 		map.expire(Duration.ofSeconds(expire));

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2ModelMapper.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2ModelMapper.java
@@ -217,28 +217,32 @@ public final class OAuth2ModelMapper {
 		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = extractRefreshToken(authorization);
 		return new OAuth2UsernamePasswordGrantAuthorization(authorization.getId(),
 				authorization.getRegisteredClientId(), authorization.getPrincipalName(),
-				authorization.getAuthorizedScopes(), accessToken, refreshToken);
+				authorization.getAuthorizedScopes(), accessToken, refreshToken,
+				authorization.getAttribute(Principal.class.getName()));
 	}
 
 	static OAuth2TestGrantAuthorization convertOAuth2TestGrantAuthorization(OAuth2Authorization authorization) {
 		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = extractAccessToken(authorization);
 		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = extractRefreshToken(authorization);
 		return new OAuth2TestGrantAuthorization(authorization.getId(), authorization.getRegisteredClientId(),
-				authorization.getPrincipalName(), authorization.getAuthorizedScopes(), accessToken, refreshToken);
+				authorization.getPrincipalName(), authorization.getAuthorizedScopes(), accessToken, refreshToken,
+				authorization.getAttribute(Principal.class.getName()));
 	}
 
 	static OAuth2MailGrantAuthorization convertOAuth2MailGrantAuthorization(OAuth2Authorization authorization) {
 		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = extractAccessToken(authorization);
 		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = extractRefreshToken(authorization);
 		return new OAuth2MailGrantAuthorization(authorization.getId(), authorization.getRegisteredClientId(),
-				authorization.getPrincipalName(), authorization.getAuthorizedScopes(), accessToken, refreshToken);
+				authorization.getPrincipalName(), authorization.getAuthorizedScopes(), accessToken, refreshToken,
+				authorization.getAttribute(Principal.class.getName()));
 	}
 
 	static OAuth2MobileGrantAuthorization convertOAuth2MobileGrantAuthorization(OAuth2Authorization authorization) {
 		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = extractAccessToken(authorization);
 		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = extractRefreshToken(authorization);
 		return new OAuth2MobileGrantAuthorization(authorization.getId(), authorization.getRegisteredClientId(),
-				authorization.getPrincipalName(), authorization.getAuthorizedScopes(), accessToken, refreshToken);
+				authorization.getPrincipalName(), authorization.getAuthorizedScopes(), accessToken, refreshToken,
+				authorization.getAttribute(Principal.class.getName()));
 	}
 
 	static OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode extractAuthorizationCode(
@@ -471,7 +475,8 @@ public final class OAuth2ModelMapper {
 		builder.id(usernamePasswordGrantAuthorization.getId())
 			.principalName(usernamePasswordGrantAuthorization.getPrincipalName())
 			.authorizationGrantType(USERNAME_PASSWORD)
-			.authorizedScopes(usernamePasswordGrantAuthorization.getAuthorizedScopes());
+			.authorizedScopes(usernamePasswordGrantAuthorization.getAuthorizedScopes())
+			.attribute(Principal.class.getName(), usernamePasswordGrantAuthorization.getPrincipal());
 		mapAccessToken(usernamePasswordGrantAuthorization.getAccessToken(), builder);
 		mapRefreshToken(usernamePasswordGrantAuthorization.getRefreshToken(), builder);
 	}
@@ -481,7 +486,8 @@ public final class OAuth2ModelMapper {
 		builder.id(testGrantAuthorization.getId())
 			.principalName(testGrantAuthorization.getPrincipalName())
 			.authorizationGrantType(TEST)
-			.authorizedScopes(testGrantAuthorization.getAuthorizedScopes());
+			.authorizedScopes(testGrantAuthorization.getAuthorizedScopes())
+			.attribute(Principal.class.getName(), testGrantAuthorization.getPrincipal());
 		mapAccessToken(testGrantAuthorization.getAccessToken(), builder);
 		mapRefreshToken(testGrantAuthorization.getRefreshToken(), builder);
 	}
@@ -491,7 +497,8 @@ public final class OAuth2ModelMapper {
 		builder.id(mailGrantAuthorization.getId())
 			.principalName(mailGrantAuthorization.getPrincipalName())
 			.authorizationGrantType(MAIL)
-			.authorizedScopes(mailGrantAuthorization.getAuthorizedScopes());
+			.authorizedScopes(mailGrantAuthorization.getAuthorizedScopes())
+			.attribute(Principal.class.getName(), mailGrantAuthorization.getPrincipal());
 		mapAccessToken(mailGrantAuthorization.getAccessToken(), builder);
 		mapRefreshToken(mailGrantAuthorization.getRefreshToken(), builder);
 	}
@@ -501,7 +508,8 @@ public final class OAuth2ModelMapper {
 		builder.id(mobileGrantAuthorization.getId())
 			.principalName(mobileGrantAuthorization.getPrincipalName())
 			.authorizationGrantType(MOBILE)
-			.authorizedScopes(mobileGrantAuthorization.getAuthorizedScopes());
+			.authorizedScopes(mobileGrantAuthorization.getAuthorizedScopes())
+			.attribute(Principal.class.getName(), mobileGrantAuthorization.getPrincipal());
 		mapAccessToken(mobileGrantAuthorization.getAccessToken(), builder);
 		mapRefreshToken(mobileGrantAuthorization.getRefreshToken(), builder);
 	}

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
@@ -20,52 +20,43 @@ package org.laokou.common.security.config;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.context.util.User;
 import org.laokou.common.context.util.UserExtDetails;
-import org.laokou.common.core.util.RequestUtils;
-import org.laokou.common.i18n.util.SpringContextUtils;
 import org.laokou.common.i18n.common.exception.StatusCode;
-import org.laokou.common.i18n.util.InstantUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
-import org.laokou.common.i18n.util.RedisKeyUtils;
-import org.laokou.common.redis.util.RedisUtils;
+import org.laokou.common.i18n.util.SpringContextUtils;
 import org.laokou.common.security.handler.OAuth2ExceptionHandler;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 
-import java.time.Instant;
+import java.security.Principal;
 
 /**
  * @author laokou
  */
 @Slf4j
-public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authorizationService, JwtDecoder jwtDecoder,
-		RedisUtils redisUtils) implements OpaqueTokenIntrospector {
+public record OAuth2OpaqueTokenIntrospector(
+		OAuth2AuthorizationService authorizationService) implements OpaqueTokenIntrospector {
 
 	// @formatter:off
 	@Override
 	public OAuth2AuthenticatedPrincipal introspect(String token) {
-		Jwt jwt = jwtDecoder.decode(token);
-		Instant expiresAt = jwt.getExpiresAt();
-		if (ObjectUtils.isNotNull(expiresAt) && expiresAt.isBefore(InstantUtils.now())) {
-			OAuth2Authorization authorization = authorizationService.findByToken(token, OAuth2TokenType.ACCESS_TOKEN);
-			if (ObjectUtils.isNull(authorization)) {
-				throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
-			}
-			authorizationService.remove(authorization);
+		OAuth2Authorization authorization = authorizationService.findByToken(token, OAuth2TokenType.ACCESS_TOKEN);
+		if (ObjectUtils.isNull(authorization)) {
 			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
 		}
-		String jwtType = RequestUtils.getParamValue(RequestUtils.getHttpServletRequest(), "jwt_type");
-		String id = jwt.getClaimAsString("id");
-		if (ObjectUtils.equals(jwtType, "part")) {
-			return SpringContextUtils.getBeanProvider(UserExtDetails.class).toUserDetail(Long.valueOf(id), Long.valueOf(jwt.getClaimAsString("tenant_id")));
+		OAuth2Authorization.Token<OAuth2AccessToken> accessToken = authorization.getAccessToken();
+		OAuth2Authorization.Token<OAuth2RefreshToken> refreshToken = authorization.getRefreshToken();
+		if (ObjectUtils.isNull(accessToken) || ObjectUtils.isNull(refreshToken)) {
+			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
 		}
-		if (redisUtils.hGet(RedisKeyUtils.getUserDetailHashKey(), id) instanceof User user) {
+		if (accessToken.isActive() && authorization.getAttribute(Principal.class.getName()) instanceof User user) {
 			return SpringContextUtils.getBeanProvider(UserExtDetails.class).toUserDetail(user);
 		}
+		authorizationService.remove(authorization);
 		throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
 	}
 	// @formatter:on

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2MailGrantAuthorization.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2MailGrantAuthorization.java
@@ -35,6 +35,7 @@ package org.laokou.common.security.config.entity;
 
 import lombok.Getter;
 
+import java.security.Principal;
 import java.util.Set;
 
 /**
@@ -44,9 +45,12 @@ import java.util.Set;
 @Getter
 public final class OAuth2MailGrantAuthorization extends OAuth2AuthorizationGrantAuthorization {
 
+	private final Principal principal;
+
 	public OAuth2MailGrantAuthorization(String id, String registeredClientId, String principalName,
-			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken) {
+			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken, Principal principal) {
 		super(id, registeredClientId, principalName, authorizedScopes, accessToken, refreshToken);
+		this.principal = principal;
 	}
 
 }

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2MobileGrantAuthorization.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2MobileGrantAuthorization.java
@@ -35,6 +35,7 @@ package org.laokou.common.security.config.entity;
 
 import lombok.Getter;
 
+import java.security.Principal;
 import java.util.Set;
 
 /**
@@ -44,9 +45,12 @@ import java.util.Set;
 @Getter
 public final class OAuth2MobileGrantAuthorization extends OAuth2AuthorizationGrantAuthorization {
 
+	private final Principal principal;
+
 	public OAuth2MobileGrantAuthorization(String id, String registeredClientId, String principalName,
-			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken) {
+			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken, Principal principal) {
 		super(id, registeredClientId, principalName, authorizedScopes, accessToken, refreshToken);
+		this.principal = principal;
 	}
 
 }

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2TestGrantAuthorization.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2TestGrantAuthorization.java
@@ -35,6 +35,7 @@ package org.laokou.common.security.config.entity;
 
 import lombok.Getter;
 
+import java.security.Principal;
 import java.util.Set;
 
 /**
@@ -44,9 +45,12 @@ import java.util.Set;
 @Getter
 public final class OAuth2TestGrantAuthorization extends OAuth2AuthorizationGrantAuthorization {
 
+	private final Principal principal;
+
 	public OAuth2TestGrantAuthorization(String id, String registeredClientId, String principalName,
-			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken) {
+			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken, Principal principal) {
 		super(id, registeredClientId, principalName, authorizedScopes, accessToken, refreshToken);
+		this.principal = principal;
 	}
 
 }

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2UsernamePasswordGrantAuthorization.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/entity/OAuth2UsernamePasswordGrantAuthorization.java
@@ -35,6 +35,7 @@ package org.laokou.common.security.config.entity;
 
 import lombok.Getter;
 
+import java.security.Principal;
 import java.util.Set;
 
 /**
@@ -44,9 +45,12 @@ import java.util.Set;
 @Getter
 public final class OAuth2UsernamePasswordGrantAuthorization extends OAuth2AuthorizationGrantAuthorization {
 
+	private final Principal principal;
+
 	public OAuth2UsernamePasswordGrantAuthorization(String id, String registeredClientId, String principalName,
-			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken) {
+			Set<String> authorizedScopes, AccessToken accessToken, RefreshToken refreshToken, Principal principal) {
 		super(id, registeredClientId, principalName, authorizedScopes, accessToken, refreshToken);
+		this.principal = principal;
 	}
 
 }

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2AuthorizationServerConfig.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2AuthorizationServerConfig.java
@@ -26,7 +26,6 @@ import org.laokou.auth.config.authentication.OAuth2UsernamePasswordAuthenticatio
 import org.laokou.auth.model.CaptchaValidator;
 import org.laokou.auth.model.MqEnum;
 import org.laokou.auth.model.PasswordValidator;
-import org.laokou.common.context.util.User;
 import org.laokou.common.fory.config.ForyFactory;
 import org.laokou.common.i18n.dto.IdGenerator;
 import org.laokou.common.i18n.util.ObjectUtils;
@@ -51,20 +50,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.OAuth2Token;
-import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
-import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.oauth2.server.authorization.token.DelegatingOAuth2TokenGenerator;
-import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.JwtGenerator;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2AccessTokenGenerator;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2RefreshTokenGenerator;
-import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.DelegatingAuthenticationConverter;
@@ -154,7 +149,6 @@ class OAuth2AuthorizationServerConfig {
 	@Bean
 	OAuth2TokenGenerator<OAuth2Token> tokenGenerator(JwtEncoder jwtEncoder) {
 		JwtGenerator jwtGenerator = new JwtGenerator(jwtEncoder);
-		jwtGenerator.setJwtCustomizer(jwtCustomizer());
 		OAuth2AccessTokenGenerator accessTokenGenerator = new OAuth2AccessTokenGenerator();
 		OAuth2RefreshTokenGenerator refreshTokenGenerator = new OAuth2RefreshTokenGenerator();
 		return new DelegatingOAuth2TokenGenerator(jwtGenerator, accessTokenGenerator, refreshTokenGenerator);
@@ -240,19 +234,5 @@ class OAuth2AuthorizationServerConfig {
 		requestMatcher.setIgnoredMediaTypes(Set.of(MediaType.ALL));
 		return requestMatcher;
 	}
-
-	// @formatter:off
-	private OAuth2TokenCustomizer<JwtEncodingContext> jwtCustomizer() {
-		// https://docs.spring.io/spring-security/reference/servlet/oauth2/authorization-server/core-model-components.html#oauth2AuthorizationServer-oauth2-token-customizer
-		return context -> {
-			if (ObjectUtils.equals(context.getTokenType(), OAuth2TokenType.ACCESS_TOKEN)
-				&& context.getPrincipal().getPrincipal() instanceof User user) {
-				JwtClaimsSet.Builder claims = context.getClaims();
-				claims.claim("id", user.id().toString());
-				claims.claim("tenant_id", user.tenantId().toString());
-			}
-		};
-	}
-	// @formatter:on
 
 }

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/AbstractOAuth2AuthenticationProvider.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/AbstractOAuth2AuthenticationProvider.java
@@ -59,6 +59,7 @@ import org.springframework.security.oauth2.server.authorization.authentication.O
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContextHolder;
 import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.security.oauth2.server.authorization.token.DefaultOAuth2TokenContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
@@ -199,8 +200,10 @@ abstract class AbstractOAuth2AuthenticationProvider implements AuthenticationPro
 		if (principal.getPrincipal() instanceof User user) {
 			String userDetailHashKey = RedisKeyUtils.getUserDetailHashKey();
 			String field = user.id().toString();
+			TokenSettings tokenSettings = registeredClient.getTokenSettings();
 			redisUtils.hDel(userDetailHashKey, field);
-			redisUtils.hSet(userDetailHashKey, field, user, RedisUtils.SIX_HOUR_EXPIRE);
+			redisUtils.hSet(userDetailHashKey, field, user, tokenSettings.getRefreshTokenTimeToLive().toSeconds()
+					+ tokenSettings.getAccessTokenTimeToLive().toSeconds() + RedisUtils.ONE_MINUTE_EXPIRE);
 		}
 		// 存储认证信息
 		authorizationService.save(authorizationBuilder.build());

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/AbstractOAuth2AuthenticationProvider.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/AbstractOAuth2AuthenticationProvider.java
@@ -200,7 +200,7 @@ abstract class AbstractOAuth2AuthenticationProvider implements AuthenticationPro
 			String userDetailHashKey = RedisKeyUtils.getUserDetailHashKey();
 			String field = user.id().toString();
 			redisUtils.hDel(userDetailHashKey, field);
-			redisUtils.hSet(userDetailHashKey, field, user);
+			redisUtils.hSet(userDetailHashKey, field, user, RedisUtils.SIX_HOUR_EXPIRE);
 		}
 		// 存储认证信息
 		authorizationService.save(authorizationBuilder.build());

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2MailAuthenticationProvider.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2MailAuthenticationProvider.java
@@ -25,7 +25,6 @@ import org.laokou.auth.model.AuthA;
 import org.laokou.auth.model.Constants;
 import org.laokou.auth.model.GrantTypeEnum;
 import org.laokou.common.i18n.common.constant.StringConstants;
-import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.config.OAuth2ModelMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -45,8 +44,8 @@ final class OAuth2MailAuthenticationProvider extends AbstractOAuth2Authenticatio
 
 	public OAuth2MailAuthenticationProvider(OAuth2AuthorizationService authorizationService,
 			OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator,
-			OAuth2AuthenticationProcessor authenticationProcessor, RedisUtils redisUtils) {
-		super(authorizationService, tokenGenerator, authenticationProcessor, redisUtils);
+			OAuth2AuthenticationProcessor authenticationProcessor) {
+		super(authorizationService, tokenGenerator, authenticationProcessor);
 	}
 
 	@Override

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2MobileAuthenticationProvider.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2MobileAuthenticationProvider.java
@@ -25,7 +25,6 @@ import org.laokou.auth.model.AuthA;
 import org.laokou.auth.model.Constants;
 import org.laokou.auth.model.GrantTypeEnum;
 import org.laokou.common.i18n.common.constant.StringConstants;
-import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.config.OAuth2ModelMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -45,8 +44,8 @@ final class OAuth2MobileAuthenticationProvider extends AbstractOAuth2Authenticat
 
 	public OAuth2MobileAuthenticationProvider(OAuth2AuthorizationService authorizationService,
 			OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator,
-			OAuth2AuthenticationProcessor authenticationProcessor, RedisUtils redisUtils) {
-		super(authorizationService, tokenGenerator, authenticationProcessor, redisUtils);
+			OAuth2AuthenticationProcessor authenticationProcessor) {
+		super(authorizationService, tokenGenerator, authenticationProcessor);
 	}
 
 	@Override

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2TestAuthenticationProvider.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2TestAuthenticationProvider.java
@@ -25,7 +25,6 @@ import org.laokou.auth.model.AuthA;
 import org.laokou.auth.model.Constants;
 import org.laokou.auth.model.GrantTypeEnum;
 import org.laokou.common.i18n.common.constant.StringConstants;
-import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.config.OAuth2ModelMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -45,8 +44,8 @@ final class OAuth2TestAuthenticationProvider extends AbstractOAuth2Authenticatio
 
 	public OAuth2TestAuthenticationProvider(OAuth2AuthorizationService authorizationService,
 			OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator,
-			OAuth2AuthenticationProcessor authenticationProcessor, RedisUtils redisUtils) {
-		super(authorizationService, tokenGenerator, authenticationProcessor, redisUtils);
+			OAuth2AuthenticationProcessor authenticationProcessor) {
+		super(authorizationService, tokenGenerator, authenticationProcessor);
 	}
 
 	@Override

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2UsernamePasswordAuthenticationProvider.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/authentication/OAuth2UsernamePasswordAuthenticationProvider.java
@@ -24,7 +24,6 @@ import org.laokou.auth.convertor.AuthConvertor;
 import org.laokou.auth.model.AuthA;
 import org.laokou.auth.model.Constants;
 import org.laokou.auth.model.GrantTypeEnum;
-import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.config.OAuth2ModelMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -44,8 +43,8 @@ final class OAuth2UsernamePasswordAuthenticationProvider extends AbstractOAuth2A
 
 	public OAuth2UsernamePasswordAuthenticationProvider(OAuth2AuthorizationService authorizationService,
 			OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator,
-			OAuth2AuthenticationProcessor authenticationProcessor, RedisUtils redisUtils) {
-		super(authorizationService, tokenGenerator, authenticationProcessor, redisUtils);
+			OAuth2AuthenticationProcessor authenticationProcessor) {
+		super(authorizationService, tokenGenerator, authenticationProcessor);
 	}
 
 	@Override


### PR DESCRIPTION
### **PR Type**
Enhancement, Security


___

### **Description**
- Refactor `User` class to implement `Authentication` and `Principal` interfaces

- Store `Principal` object in OAuth2 authorization attributes instead of Redis

- Simplify `RedisUtils` to record type and add shorter expiration constants

- Remove JWT claims customization and Redis-based user detail caching

- Streamline token introspection and authorization removal logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Record"] -->|implements| B["Authentication + Principal"]
  C["OAuth2 Authorization"] -->|stores| D["Principal Attribute"]
  E["Token Introspection"] -->|retrieves| D
  F["Redis"] -->|removes| G["User Detail Cache"]
  H["RedisUtils"] -->|converts to| I["Record Type"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>User.java</strong><dd><code>User record implements Authentication and Principal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-f9c57f8c9cc2a7f76c90749f8fe3995497dbad56a89547c86d29f6bd26748cdb">+38/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserExtDetails.java</strong><dd><code>Remove redundant user detail conversion methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-c0d8f5f6aac8db1c7857c38ebc5ab74972cb6db201de44c1197ed22137351903">+0/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RedisUtils.java</strong><dd><code>Convert RedisUtils to record and add expiration constants</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-c950250d82e254a692903a1681b84d55fdb4db3abba95d5b4d608702d884c4c1">+12/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2ModelMapper.java</strong><dd><code>Store Principal in OAuth2 authorization attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-22a554ec0ef5c1a79a862b6a11833a4d3244307259e26499f5ae12132f3ab79e">+16/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2OpaqueTokenIntrospector.java</strong><dd><code>Simplify token introspection using authorization attributes</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-b93f5c2d0718812c0ecdae20e9c9b88c813979ab3343867ba80f7f9049601fc6">+14/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2MailGrantAuthorization.java</strong><dd><code>Add Principal field to mail grant authorization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-1b19a9bcfdc84200b8d6ab8b6b24cfd7995c08ff89b958b95a21cc7e2809927e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2MobileGrantAuthorization.java</strong><dd><code>Add Principal field to mobile grant authorization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-581ea737df1ee137d8312045b76179db751a01f46ece2c7740a5b8b482214fd3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2TestGrantAuthorization.java</strong><dd><code>Add Principal field to test grant authorization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-20f2f0c6e7b782aaabc4c37e775b638680fbcf096ddd024448dfd8b94bfdaee9">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2UsernamePasswordGrantAuthorization.java</strong><dd><code>Add Principal field to username password grant authorization</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-957b82f605b3d201ee61ec7afbbee953cb3033d0fd36103319e1d61ed8a51e40">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TokenRemoveCmdExe.java</strong><dd><code>Simplify cache eviction using Principal from authorization</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-b62d8d27bf4fe702a3f43864b7f6552415607ebf521c0f2484e684479c3886e7">+8/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2AuthorizationServerConfig.java</strong><dd><code>Remove JWT claims customizer and Redis caching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-5c1668b17ab6f8e41494e1fe5e1cb1ae62b999e260d0b89a7c21391f81f6302f">+0/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AbstractOAuth2AuthenticationProvider.java</strong><dd><code>Store Principal in authorization attributes instead of Redis</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-c95230a95ce7195c417c7345bbb3503c7aed180cc78d987e25449cfce8fb974b">+2/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2MailAuthenticationProvider.java</strong><dd><code>Remove RedisUtils dependency from constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-9700504f603be3ff946df755dcd7b3633f19965aa70d6eba74d1a4c696d4ccea">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2MobileAuthenticationProvider.java</strong><dd><code>Remove RedisUtils dependency from constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-c69b06eb5c0891f12713a567e93a9150dd94d0842ad739b98e060551453c83b7">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2TestAuthenticationProvider.java</strong><dd><code>Remove RedisUtils dependency from constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-ef5e7f4c32c134fec15f0542bd8c3d06ea0fb470373c050c3a7eeee9687bdaa2">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OAuth2UsernamePasswordAuthenticationProvider.java</strong><dd><code>Remove RedisUtils dependency from constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-222376811d3d071bac4649a8c55b16765a2a9d32e68814a7bbb818764f4fc870">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>UserUtilsTest.java</strong><dd><code>Fix variable scope in test authentication provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5198/files#diff-8eb1b9419f920bb9213062e73d286b45abc5dcb022e1bef1fead5bc70a6f5eac">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized authentication infrastructure with improved token validation and introspection processes.
  * Simplified user data management and authentication attribute storage mechanisms.
  * Enhanced principal attribute propagation across OAuth2 authentication flows for improved security consistency.
  * Streamlined authorization data handling by removing legacy caching layers.

* **Chores**
  * Infrastructure updates to align with modern OAuth2 security standards and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->