### PR TITLE
style: 优化context模块代码风格

### DIFF
--- a/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/DomainFactory.java
+++ b/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/DomainFactory.java
@@ -17,28 +17,18 @@
 
 package org.laokou.common.context.util;
 
+import org.laokou.common.i18n.util.SpringContextUtils;
+
 /**
  * @author laokou
  */
-public final class UserConvertor {
+public final class DomainFactory {
 
-	public static UserExtDetails toUserDetails(User user) {
-		return DomainFactory.getUserDetails()
-			.toBuilder()
-			.id(user.id())
-			.username(user.username())
-			.password(user.password())
-			.avatar(user.avatar())
-			.superAdmin(user.superAdmin())
-			.tenantId(user.tenantId())
-			.permissions(user.permissions())
-			.status(user.status())
-			.mail(user.mail())
-			.mobile(user.mobile())
-			.build()
-			.decryptUsername()
-			.decryptMail()
-			.decryptMobile();
+	private DomainFactory() {
+	}
+
+	public static UserExtDetails getUserDetails() {
+		return SpringContextUtils.getBeanProvider(UserExtDetails.class);
 	}
 
 }

--- a/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserUtils.java
+++ b/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserUtils.java
@@ -35,8 +35,8 @@ public final class UserUtils {
 			if (authentication.getPrincipal() instanceof UserExtDetails userExtDetails) {
 				return userExtDetails;
 			}
-			return UserConvertor.toUserDetails();
-		}).orElse(UserConvertor.toUserDetails());
+			return DomainFactory.getUserDetails();
+		}).orElse(DomainFactory.getUserDetails());
 	}
 
 	/**

--- a/laokou-common/laokou-common-context/src/test/java/org/laokou/common/context/UserUtilsTest.java
+++ b/laokou-common/laokou-common-context/src/test/java/org/laokou/common/context/UserUtilsTest.java
@@ -20,6 +20,7 @@ package org.laokou.common.context;
 import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
+import org.laokou.common.context.util.DomainFactory;
 import org.laokou.common.context.util.User;
 import org.laokou.common.context.util.UserConvertor;
 import org.laokou.common.context.util.UserExtDetails;
@@ -42,18 +43,14 @@ class UserUtilsTest {
 
 	@Test
 	void test() {
-		Assertions.assertThat(UserUtils.userDetail())
-			.isNotNull()
-			.isEqualTo(SpringContextUtils.getBeanProvider(UserExtDetails.class));
+		Assertions.assertThat(UserUtils.userDetail()).isNotNull().isEqualTo(DomainFactory.getUserDetails());
 		Assertions.assertThat(UserUtils.getUserId()).isNull();
 		Assertions.assertThat(UserUtils.getUserName()).isBlank();
 		Assertions.assertThat(UserUtils.getTenantId()).isNull();
 		Assertions.assertThat(UserUtils.isSuperAdmin()).isNull();
 		Assertions.assertThat(UserUtils.userDetail().getPermissions()).isNull();
 		SecurityContextHolder.getContext().setAuthentication(new TestAuthentication());
-		Assertions.assertThat(UserUtils.userDetail())
-			.isNotNull()
-			.isNotEqualTo(SpringContextUtils.getBeanProvider(UserExtDetails.class));
+		Assertions.assertThat(UserUtils.userDetail()).isNotNull().isNotEqualTo(DomainFactory.getUserDetails());
 		Assertions.assertThat(UserUtils.getUserId()).isNotNull().isEqualTo(1L);
 		Assertions.assertThat(UserUtils.getUserName()).isNotNull().isEqualTo("admin");
 		Assertions.assertThat(UserUtils.getTenantId()).isNotNull().isEqualTo(0L);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduce `DomainFactory` utility class for centralized bean retrieval

- Remove static helper method from `UserConvertor` to reduce duplication

- Replace direct `SpringContextUtils` calls with `DomainFactory.getUserDetails()`

- Update test assertions to use new factory pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UserConvertor<br/>UserUtils<br/>UserUtilsTest"] -->|"Replace with"| B["DomainFactory.getUserDetails()"]
  C["SpringContextUtils<br/>Direct calls"] -->|"Encapsulate in"| B
  B -->|"Provides"| D["UserExtDetails"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DomainFactory.java</strong><dd><code>Create DomainFactory utility class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/DomainFactory.java

<ul><li>New utility class created to centralize bean retrieval logic<br> <li> Provides static <code>getUserDetails()</code> method wrapping <br><code>SpringContextUtils.getBeanProvider()</code><br> <li> Follows factory pattern for cleaner dependency access</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5246/files#diff-6c158b7435502008b17b710739c1368b49e95a386f061944734efab12ae038d7">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserConvertor.java</strong><dd><code>Refactor to use DomainFactory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserConvertor.java

<ul><li>Remove static <code>toUserDetails()</code> helper method<br> <li> Update <code>toUserDetails(User user)</code> to use <code>DomainFactory.getUserDetails()</code><br> <li> Remove unused <code>SpringContextUtils</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5246/files#diff-05d17bba3c68f9f382636f73212cf44b5147fafd3055a4bacfed05e609226f61">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserUtils.java</strong><dd><code>Update to use DomainFactory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserUtils.java

<ul><li>Replace two <code>UserConvertor.toUserDetails()</code> calls with <br><code>DomainFactory.getUserDetails()</code><br> <li> Maintain same logic flow with improved code clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5246/files#diff-692a82e21f783915ad652ad8959c5ee775e153836b27cd93061e651bafd30755">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserUtilsTest.java</strong><dd><code>Update tests to use DomainFactory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-context/src/test/java/org/laokou/common/context/UserUtilsTest.java

<ul><li>Add import for <code>DomainFactory</code><br> <li> Replace <code>SpringContextUtils.getBeanProvider()</code> calls with <br><code>DomainFactory.getUserDetails()</code><br> <li> Simplify assertion formatting for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5246/files#diff-8eb1b9419f920bb9213062e73d286b45abc5dcb022e1bef1fead5bc70a6f5eac">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

通过新的 DomainFactory 集中获取 UserExtDetails，并更新上下文工具类和测试以使用该工厂。

Enhancements:
- 引入 DomainFactory 工具，用于封装从 Spring 上下文中获取 UserExtDetails bean 的逻辑。
- 重构 UserUtils 和 UserConvertor，使其在获取默认的 UserExtDetails 实例时使用 DomainFactory，而不是直接访问 SpringContextUtils。

Tests:
- 调整 UserUtilsTest 中的断言，使其改为通过 DomainFactory 获取 UserExtDetails，并简化断言链式调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize retrieval of UserExtDetails via a new DomainFactory and update context utilities and tests to use it.

Enhancements:
- Introduce DomainFactory utility to encapsulate UserExtDetails bean retrieval from the Spring context.
- Refactor UserUtils and UserConvertor to use DomainFactory instead of direct SpringContextUtils access for default UserExtDetails instances.

Tests:
- Adjust UserUtilsTest assertions to use DomainFactory-based UserExtDetails retrieval and simplify assertion chaining.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal user detail retrieval mechanism by introducing a centralized factory pattern that consolidates multiple access points into a single component, improving code maintainability and reducing duplication across authentication utilities.

* **Tests**
  * Updated unit tests to validate behavior with the refactored user detail resolution mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->