### PR TITLE
fix: 修复GitHub Action sql项目构建报错

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,6 @@ jobs:
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6.0.1
@@ -67,7 +66,7 @@ jobs:
             <server>
               <id>github</id>
               <username>${{ github.actor }}</username>
-              <password>${{ secrets.MAVEN_TOKEN }}</password>
+              <password>${{ secrets.USER_TOKEN }}</password>
             </server>
           </servers>
         </settings>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
               <server>
                 <id>github</id>
                 <username>${{ github.actor }}</username>
-                <password>${{ secrets.MAVEN_TOKEN }}</password>
+                <password>${{ secrets.USER_TOKEN }}</password>
               </server>
             </servers>
           </settings>


### PR DESCRIPTION
## Summary by Sourcery

更新 GitHub Actions 工作流，在 CodeQL 分析和 Maven 构建任务中使用正确的用户令牌进行 Maven 身份验证。

Build:
- 在 CodeQL 工作流中，将 Maven 服务器密码从 `MAVEN_TOKEN` 切换为 `USER_TOKEN`，用于 GitHub 软件包认证。
- 在 Maven 工作流中，将 Maven 服务器密码从 `MAVEN_TOKEN` 切换为 `USER_TOKEN`，用于 GitHub 软件包认证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions workflows to use the correct user token for Maven authentication in CodeQL analysis and Maven build jobs.

Build:
- Switch Maven server password in CodeQL workflow from MAVEN_TOKEN to USER_TOKEN for GitHub package authentication.
- Switch Maven server password in Maven workflow from MAVEN_TOKEN to USER_TOKEN for GitHub package authentication.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow authentication configuration to use new credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->