### PR TITLE
Dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
           <servers>
           <server>
           <id>github</id>
-          <username>${{ github.actor }}</username>
-          <password>${{ secrets.USER_TOKEN }}</password>
+          <username>KouShenhai</username>
+          <password>${{ secrets.MAVEN_TOKEN }}</password>
           </server>
           </servers>
           </settings>

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,8 +65,8 @@ jobs:
           <servers>
             <server>
               <id>github</id>
-              <username>${{ github.actor }}</username>
-              <password>${{ secrets.USER_TOKEN }}</password>
+              <username>KouShenhai</username>
+              <password>${{ secrets.MAVEN_TOKEN }}</password>
             </server>
           </servers>
         </settings>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,8 +41,8 @@ jobs:
             <servers>
               <server>
                 <id>github</id>
-                <username>${{ github.actor }}</username>
-                <password>${{ secrets.USER_TOKEN }}</password>
+                <username>KouShenhai</username>
+                <password>${{ secrets.MAVEN_TOKEN }}</password>
               </server>
             </servers>
           </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -802,6 +802,14 @@
     </repository>
   </repositories>
 
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/KouShenhai/KCloud-Platform-IoT</url>
+    </repository>
+  </distributionManagement>
+
   <profiles>
     <!-- 开发环境 -->
     <profile>


### PR DESCRIPTION
## Summary by Sourcery

为发布到 GitHub Packages 配置 Maven 分发管理，并使 CI 工作流与新的仓库凭证保持一致。

Build:
- 添加指向 GitHub Packages 仓库的 Maven `distributionManagement` 配置段。
- 更新 CI 中的 Maven 设置，使其在 GitHub 服务器凭证中使用固定的 GitHub 用户名和 `MAVEN_TOKEN` 机密。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure Maven distribution management for publishing to GitHub Packages and align CI workflows with the new repository credentials.

Build:
- Add Maven distributionManagement section pointing to the GitHub Packages repository.
- Update CI Maven settings to use a fixed GitHub username and MAVEN_TOKEN secret for the GitHub server credentials.

</details>