### PR TITLE
style: circleci缩进

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,16 +12,16 @@ jobs:
           mkdir -p ~/.m2
           cat <<EOF > ~/.m2/settings.xml
           <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-          https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-          <server>
-          <id>github</id>
-          <username>KouShenhai</username>
-          <password>${{ secrets.MAVEN_TOKEN }}</password>
-          </server>
-          </servers>
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                        https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>KouShenhai</username>
+                <password>${{ secrets.MAVEN_TOKEN }}</password>
+              </server>
+            </servers>
           </settings>
           EOF
       - run: mvn clean install -P dev -DskipTests


### PR DESCRIPTION
## 由 Sourcery 提供的总结

CI：
- 重新格式化 `.circleci/config.yml` 中的 Maven `settings.xml` 代码片段，使其缩进风格保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Reformat the Maven settings.xml snippet in .circleci/config.yml to use consistent indentation.

</details>