### PR TITLE
feat: 修改maven快照发布

### DIFF
--- a/laokou-release/README.md
+++ b/laokou-release/README.md
@@ -1,6 +1,6 @@
 ```shell
-# 发布Github
-mvn clean deploy -P snapshot -DskipTests
-# 发布Maven Central
-mvn clean deploy -P release -DskipTests
+# 发布Github【快照版本】
+mvn clean deploy -P github-snapshot -DskipTests
+# 发布Maven Central【快照版本】
+mvn clean deploy -P maven-snapshot -DskipTests
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -804,14 +804,6 @@
     </repository>
   </repositories>
 
-  <distributionManagement>
-    <repository>
-      <id>kcloud-platform-iot-github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/KouShenhai/KCloud-Platform-IoT</url>
-    </repository>
-  </distributionManagement>
-
   <profiles>
     <!-- 开发环境 -->
     <profile>
@@ -895,13 +887,20 @@
       </activation>
     </profile>
     <profile>
-      <id>snapshot</id>
+      <id>github-snapshot</id>
+      <distributionManagement>
+        <repository>
+          <id>kcloud-platform-iot-github</id>
+          <name>GitHub Packages</name>
+          <url>https://maven.pkg.github.com/KouShenhai/KCloud-Platform-IoT</url>
+        </repository>
+      </distributionManagement>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
     <profile>
-      <id>release</id>
+      <id>maven-snapshot</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
## Summary by Sourcery

调整 Maven 快照发布配置和命令，以适配 GitHub Packages 和 Maven Central。

Build：
- 将 GitHub Packages 的 `distributionManagement` 配置移动到专用的 `github-snapshot` Maven profile 中。
- 将现有的 snapshot 和 release profiles 重命名为 `github-snapshot` 和 `maven-snapshot`，以便更好地区分发布目标。

Documentation：
- 更新发布说明 README，将快照部署步骤改为使用新的 `github-snapshot` 和 `maven-snapshot` profiles。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Maven snapshot publishing configuration and commands for GitHub Packages and Maven Central.

Build:
- Move GitHub Packages distributionManagement configuration into a dedicated github-snapshot Maven profile.
- Rename the existing snapshot and release profiles to github-snapshot and maven-snapshot to better distinguish publishing targets.

Documentation:
- Update release README instructions to use the new github-snapshot and maven-snapshot profiles for snapshot deployments.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with revised deployment command examples.

* **Chores**
  * Restructured build distribution configuration for improved organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->