### PR TITLE
style: 优化代码风格

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,7 +73,6 @@ jobs:
             ./laokou-common/laokou-common-elasticsearch/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-mybatis-plus/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-starrocks/target/site/jacoco/jacoco.xml,
-            ./laokou-common/laokou-common-grpc/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-ftp/target/site/jacoco/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build the Docker image

--- a/laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/model/OperateTypeEnum.java
+++ b/laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/model/OperateTypeEnum.java
@@ -39,11 +39,12 @@ public enum OperateTypeEnum {
 		@Override
 		public Object execute(String name, String key, ProceedingJoinPoint point, CacheManager cacheManager) {
 			try {
-				Cache.ValueWrapper valueWrapper = getCache(cacheManager, name).putIfAbsent(key, point.proceed());
+				Cache cache = getCache(cacheManager, name);
+				Cache.ValueWrapper valueWrapper = cache.get(key);
 				if (ObjectUtils.isNotNull(valueWrapper)) {
 					return valueWrapper.get();
 				}
-				return point.proceed();
+				return cache.putIfAbsent(key, point.proceed());
 			}
 			catch (GlobalException e) {
 				// 系统异常/业务异常/参数异常直接捕获并抛出

--- a/laokou-common/laokou-common-grpc/pom.xml
+++ b/laokou-common/laokou-common-grpc/pom.xml
@@ -54,6 +54,12 @@
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClient.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClient.java
@@ -29,8 +29,8 @@ import java.lang.annotation.Target;
  */
 @Inherited
 @Documented
-@Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
 public @interface GrpcClient {
 
 	String serviceId();

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcClientTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcClientTest.java
@@ -31,6 +31,7 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
@@ -72,6 +73,7 @@ class GrpcClientTest {
 		Assertions.assertThat(helloReply.getMessage()).isEqualTo("Hello ==> test");
 	}
 
+	@EnableDiscoveryClient
 	@SpringBootApplication(scanBasePackages = { "org.laokou" })
 	static class GrpcTest {
 

--- a/laokou-common/laokou-common-grpc/src/test/resources/application.yml
+++ b/laokou-common/laokou-common-grpc/src/test/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8975
 spring:
   application:
     name: laokou-common-grpc
@@ -11,11 +13,24 @@ spring:
         laokou-common-grpc:
            address: discovery://laokou-common-grpc
            enable-keep-alive: true
+           idle-timeout: 60s
   cloud:
     nacos:
       config:
-        enabled: false
+        enabled: true
+        server-addr: nacos:8848
+        username: nacos
+        password: nacos
+        namespace: public
+        group: DEFAULT_GROUP
+        import-check:
+          enabled: false
       discovery:
         enabled: true
+        server-addr: nacos:8848
+        username: nacos
+        password: nacos
+        namespace: public
+        group: DEFAULT_GROUP
         metadata:
           laokou_common_grpc_grpc_port: 9097


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored cache retrieval logic to check cache first before proceeding

- Expanded @GrpcClient annotation target to support methods and parameters

- Added method-level injection support in GrpcClientBeanPostProcessor

- Enhanced test configuration with Nacos discovery and server settings

- Removed grpc module from codecov reporting due to test coverage issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cache Logic Refactor"] --> B["Check cache first"]
  C["GrpcClient Annotation"] --> D["Support Methods & Parameters"]
  E["BeanPostProcessor"] --> F["Handle Field & Method Injection"]
  G["Test Configuration"] --> H["Add Nacos Discovery Setup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperateTypeEnum.java</strong><dd><code>Optimize cache retrieval with early existence check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/model/OperateTypeEnum.java

<ul><li>Refactored cache retrieval to check cache before executing join point<br> <li> Split logic into separate cache retrieval and putIfAbsent operations<br> <li> Improved cache hit efficiency by checking for existing values first</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-06a71dcccdcdeb3e790e79dcb8568c54c46df6f9c441fab386394815706d34cd">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GrpcClient.java</strong><dd><code>Expand GrpcClient annotation target scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClient.java

<ul><li>Expanded @Target to include ANNOTATION_TYPE, METHOD, and PARAMETER<br> <li> Reordered annotation declarations for consistency<br> <li> Enables annotation usage on methods and parameters in addition to <br>fields</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-312c413aac67b9bb0a251f626484753dcdc39ebb0094abe0e76c60d00181d60b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GrpcClientBeanPostProcessor.java</strong><dd><code>Add method-level gRPC client injection support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessor.java

<ul><li>Added support for method-level injection via new setMethods() method<br> <li> Renamed processFields() to setFields() for clarity<br> <li> Renamed processInjectionPoint() to getClient() for better semantics<br> <li> Added Method import and reflection-based method invocation</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-b8d44208d3f528e949b7bf237dd78f38a6836868b93e8e98715af8425e00cd75">+17/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcClientTest.java</strong><dd><code>Enable discovery client in test application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcClientTest.java

<ul><li>Added @EnableDiscoveryClient annotation to test application class<br> <li> Added import for EnableDiscoveryClient<br> <li> Enables service discovery functionality in test environment</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-490f991dffb51741edb237191ed52e34984e2af03cc30dc58e36507f6542dd19">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven.yml</strong><dd><code>Remove grpc module from codecov reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven.yml

<ul><li>Removed grpc module from codecov jacoco.xml reporting list<br> <li> Simplifies code coverage reporting by excluding problematic module</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application.yml</strong><dd><code>Configure Nacos discovery and server settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/resources/application.yml

<ul><li>Added server port configuration (8975)<br> <li> Enabled Nacos config server with credentials and namespace settings<br> <li> Added idle-timeout configuration for gRPC client channels<br> <li> Configured Nacos discovery with server address and authentication</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-eb2fa4f9af46e7db20ad17c57b9f210cce63475d885b98e37938922df38270d9">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Add spring-boot-starter-webmvc test dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/pom.xml

<ul><li>Added spring-boot-starter-webmvc test dependency<br> <li> Configured as optional test-scoped dependency<br> <li> Provides web MVC support for test environment</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5380/files#diff-b93f7f1efce77d2306197ab4cfd4536ff94338c2256c7fab4ae9517ac0c2c4b4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

优化缓存使用方式，扩展 gRPC 客户端注入能力，并调整 gRPC 模块的测试与 CI 配置。

New Features:
- 通过 `GrpcClient` 注解和 Bean 后置处理器，支持方法级和参数级的 gRPC 客户端注入。

Bug Fixes:
- 改进缓存读取逻辑：在调用底层连接点前先检查是否已有缓存值，避免不必要的缓存写入和方法执行。

Enhancements:
- 重构 `GrpcClientBeanPostProcessor` 的字段注入逻辑，并集中管理 gRPC 客户端的创建，以提升语义清晰度和复用性。

CI:
- 在 Maven GitHub Actions 工作流中，将 gRPC 模块从 Codecov Jacoco 覆盖率统计中排除。

Tests:
- 在 gRPC 测试中启用服务发现客户端和基于 Nacos 的配置（包括服务端端口和空闲超时设置），并为 gRPC 模块增加一个 Web MVC 测试依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine cache usage, extend gRPC client injection capabilities, and adjust test and CI configuration for the gRPC module.

New Features:
- Support method- and parameter-level gRPC client injection via the GrpcClient annotation and bean post-processor.

Bug Fixes:
- Improve cache retrieval by checking for existing values before invoking the underlying join point, avoiding unnecessary cache writes and executions.

Enhancements:
- Refactor GrpcClientBeanPostProcessor field injection logic and centralize gRPC client creation for clearer semantics and reuse.

CI:
- Exclude the gRPC module from Codecov Jacoco coverage reporting in the Maven GitHub Actions workflow.

Tests:
- Enable discovery client and Nacos-based configuration in gRPC tests, including server port and idle-timeout settings, and add a Web MVC test dependency for the gRPC module.

</details>

增强功能：
- 更改缓存读取逻辑，在调用连接点之前先检查是否已有缓存值，从而提升缓存命中效率。
- 扩展 `GrpcClient` 注解和 Bean 后置处理器，以支持基于方法级别和参数级别的 gRPC 客户端注入。

CI：
- 在 Maven GitHub Actions 工作流中，将 gRPC 模块从 Codecov Jacoco 覆盖率报告中排除。

测试：
- 在 gRPC 测试中启用服务发现客户端和基于 Nacos 的配置（包括服务器端口和空闲超时设置），并为 gRPC 模块添加一个 Web MVC 测试依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化缓存使用方式，扩展 gRPC 客户端注入能力，并调整 gRPC 模块的测试与 CI 配置。

New Features:
- 通过 `GrpcClient` 注解和 Bean 后置处理器，支持方法级和参数级的 gRPC 客户端注入。

Bug Fixes:
- 改进缓存读取逻辑：在调用底层连接点前先检查是否已有缓存值，避免不必要的缓存写入和方法执行。

Enhancements:
- 重构 `GrpcClientBeanPostProcessor` 的字段注入逻辑，并集中管理 gRPC 客户端的创建，以提升语义清晰度和复用性。

CI:
- 在 Maven GitHub Actions 工作流中，将 gRPC 模块从 Codecov Jacoco 覆盖率统计中排除。

Tests:
- 在 gRPC 测试中启用服务发现客户端和基于 Nacos 的配置（包括服务端端口和空闲超时设置），并为 gRPC 模块增加一个 Web MVC 测试依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine cache usage, extend gRPC client injection capabilities, and adjust test and CI configuration for the gRPC module.

New Features:
- Support method- and parameter-level gRPC client injection via the GrpcClient annotation and bean post-processor.

Bug Fixes:
- Improve cache retrieval by checking for existing values before invoking the underlying join point, avoiding unnecessary cache writes and executions.

Enhancements:
- Refactor GrpcClientBeanPostProcessor field injection logic and centralize gRPC client creation for clearer semantics and reuse.

CI:
- Exclude the gRPC module from Codecov Jacoco coverage reporting in the Maven GitHub Actions workflow.

Tests:
- Enable discovery client and Nacos-based configuration in gRPC tests, including server port and idle-timeout settings, and add a Web MVC test dependency for the gRPC module.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized internal caching mechanism to improve performance by checking for existing cached values before writes.

* **Chores**
  * Updated testing infrastructure and configurations.
  * Enhanced internal service integration capabilities to support additional injection patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->