### PR TITLE
Dev

### DIFF
--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
@@ -79,7 +79,7 @@ public class AuthA extends AggregateRoot {
 	private transient CaptchaV captchaV;
 
 	/**
-	 * 数据权限.
+	 * 数据权限值对象.
 	 */
 	private transient DataFilterV dataFilterV;
 

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-infrastructure/pom.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-infrastructure/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>com.alibaba.cloud.ai</groupId>
       <artifactId>spring-ai-alibaba-starter-mcp-registry</artifactId>
+      <version>1.1.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.alibaba.nacos</groupId>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-infrastructure/pom.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-infrastructure/pom.xml
@@ -24,6 +24,7 @@
     <dependency>
       <groupId>com.alibaba.cloud.ai</groupId>
       <artifactId>spring-ai-alibaba-starter-mcp-registry</artifactId>
+      <version>1.1.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.alibaba.nacos</groupId>


### PR DESCRIPTION
## Summary by Sourcery

澄清 AuthA 聚合中的数据权限字段是一个值对象，并固定 MCP 客户端和服务端基础设施模块中使用的 MCP registry starter 依赖版本。

Enhancements:
- 澄清文档，将 AuthA 的数据权限字段描述为一个值对象。
- 在 MCP 客户端和服务端基础设施模块中，将 `spring-ai-alibaba-starter-mcp-registry` 依赖固定为 `1.1.2.0` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the AuthA aggregate's data permission field as a value object and pin the MCP registry starter dependency version used by MCP client and server infrastructure modules.

Enhancements:
- Clarify documentation to describe AuthA's data permission field as a value object.
- Pin the spring-ai-alibaba-starter-mcp-registry dependency to version 1.1.2.0 in MCP client and server infrastructure modules.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

澄清 AuthA 聚合中的数据权限字段是一个值对象，并固定 MCP 客户端和服务端基础设施模块中使用的 MCP registry starter 依赖版本。

Enhancements:
- 澄清文档，将 AuthA 的数据权限字段描述为一个值对象。
- 在 MCP 客户端和服务端基础设施模块中，将 `spring-ai-alibaba-starter-mcp-registry` 依赖固定为 `1.1.2.0` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the AuthA aggregate's data permission field as a value object and pin the MCP registry starter dependency version used by MCP client and server infrastructure modules.

Enhancements:
- Clarify documentation to describe AuthA's data permission field as a value object.
- Pin the spring-ai-alibaba-starter-mcp-registry dependency to version 1.1.2.0 in MCP client and server infrastructure modules.

</details>

</details>

改进内容：
- 在文档注释中，将 `AuthA` 聚合根的数据权限字段明确说明为一个值对象。
- 在 MCP 客户端和服务端基础设施模块中，将 `spring-ai-alibaba-starter-mcp-registry` 依赖固定为 `1.1.2.0` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

澄清 AuthA 聚合中的数据权限字段是一个值对象，并固定 MCP 客户端和服务端基础设施模块中使用的 MCP registry starter 依赖版本。

Enhancements:
- 澄清文档，将 AuthA 的数据权限字段描述为一个值对象。
- 在 MCP 客户端和服务端基础设施模块中，将 `spring-ai-alibaba-starter-mcp-registry` 依赖固定为 `1.1.2.0` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the AuthA aggregate's data permission field as a value object and pin the MCP registry starter dependency version used by MCP client and server infrastructure modules.

Enhancements:
- Clarify documentation to describe AuthA's data permission field as a value object.
- Pin the spring-ai-alibaba-starter-mcp-registry dependency to version 1.1.2.0 in MCP client and server infrastructure modules.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

澄清 AuthA 聚合中的数据权限字段是一个值对象，并固定 MCP 客户端和服务端基础设施模块中使用的 MCP registry starter 依赖版本。

Enhancements:
- 澄清文档，将 AuthA 的数据权限字段描述为一个值对象。
- 在 MCP 客户端和服务端基础设施模块中，将 `spring-ai-alibaba-starter-mcp-registry` 依赖固定为 `1.1.2.0` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the AuthA aggregate's data permission field as a value object and pin the MCP registry starter dependency version used by MCP client and server infrastructure modules.

Enhancements:
- Clarify documentation to describe AuthA's data permission field as a value object.
- Pin the spring-ai-alibaba-starter-mcp-registry dependency to version 1.1.2.0 in MCP client and server infrastructure modules.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation references.

* **Chores**
  * Updated framework dependency version specifications for infrastructure modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->