### PR TITLE
style: 优化代码风格

### DIFF
--- a/laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/model/OperateTypeEnum.java
+++ b/laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/model/OperateTypeEnum.java
@@ -44,7 +44,12 @@ public enum OperateTypeEnum {
 				if (ObjectUtils.isNotNull(valueWrapper)) {
 					return valueWrapper.get();
 				}
-				return cache.putIfAbsent(key, point.proceed());
+				Object newValue = point.proceed();
+				Object oldValue = cache.putIfAbsent(key, newValue);
+				if (ObjectUtils.isNull(oldValue)) {
+					return newValue;
+				}
+				return oldValue;
 			}
 			catch (GlobalException e) {
 				// 系统异常/业务异常/参数异常直接捕获并抛出

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/ability/DomainService.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/ability/DomainService.java
@@ -25,7 +25,10 @@ import org.laokou.auth.gateway.OssLogGateway;
 import org.laokou.auth.gateway.TenantGateway;
 import org.laokou.auth.gateway.UserGateway;
 import org.laokou.auth.model.AuthA;
+import org.laokou.auth.model.enums.DataScopeEnum;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
 
 /**
  * @author laokou
@@ -78,6 +81,10 @@ public class DomainService {
 		authA.getMenuPermissions(menuGateway.getMenuPermissions(authA.getUserE()));
 		// 校验菜单权限标识集合
 		authA.checkMenuPermissions();
+		// 获取数据权限
+		authA.getDataFilter(Set.of(DataScopeEnum.ALL.getCode()));
+		// 校验数据权限
+		authA.checkDataFilter();
 		// 获取用户头像
 		authA.getUserAvatar(ossLogGateway.getOssUrl(authA.getUserE().getAvatar()));
 	}

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
@@ -22,6 +22,7 @@ import org.laokou.auth.factory.DomainFactory;
 import org.laokou.auth.model.constant.Constants;
 import org.laokou.auth.model.constant.OAuth2Constants;
 import org.laokou.auth.model.entity.UserE;
+import org.laokou.auth.model.enums.DataScopeEnum;
 import org.laokou.auth.model.enums.GrantTypeEnum;
 import org.laokou.auth.model.enums.SendCaptchaTypeEnum;
 import org.laokou.auth.model.enums.UserStatusEnum;
@@ -55,6 +56,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.util.CollectionUtils;
 
 import java.io.Serial;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -253,7 +255,16 @@ public class AuthA extends AggregateRoot implements ValidateName {
 	}
 
 	public void getDataFilter(Set<String> dataScopes) {
-
+		if (CollectionUtils.isEmpty(dataScopes)) {
+			this.dataFilterV = null;
+			return;
+		}
+		if (dataScopes.contains(DataScopeEnum.ALL.getCode())) {
+			this.dataFilterV = DataFilterV.builder().deptIds(Collections.emptySet()).creator(null).build();
+		}
+		else {
+			this.dataFilterV = DataFilterV.builder().build();
+		}
 	}
 
 	public void checkCaptchaParam() {
@@ -315,6 +326,12 @@ public class AuthA extends AggregateRoot implements ValidateName {
 
 	public void checkMenuPermissions() {
 		if (CollectionUtils.isEmpty(this.userV.permissions())) {
+			throw new UserForbiddenException(StatusCode.FORBIDDEN);
+		}
+	}
+
+	public void checkDataFilter() {
+		if (ObjectUtils.isNull(dataFilterV)) {
 			throw new UserForbiddenException(StatusCode.FORBIDDEN);
 		}
 	}

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/valueobject/DataFilterV.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/valueobject/DataFilterV.java
@@ -17,12 +17,15 @@
 
 package org.laokou.auth.model.valueobject;
 
-import java.util.List;
+import lombok.Builder;
+
+import java.util.Set;
 
 /**
  * @author laokou
  * @param deptIds 部门IDS
  * @param creator 创建者
  */
-public record DataFilterV(List<Long> deptIds, Long creator) {
+@Builder(toBuilder = true)
+public record DataFilterV(Set<Long> deptIds, Long creator) {
 }

--- a/ui/src/pages/Sys/Permission/UserModifyAuthorityDrawer.tsx
+++ b/ui/src/pages/Sys/Permission/UserModifyAuthorityDrawer.tsx
@@ -16,7 +16,7 @@ interface UserAuthorityProps {
 type TableColumns = {
 	id: number;
 	username: string | undefined;
-	deptIds: string[];
+	deptId: number;
 	roleIds: string[];
 };
 
@@ -48,10 +48,9 @@ export const UserModifyAuthorityDrawer: React.FC<UserAuthorityProps> = ({ modalM
 			}}
 			onFinish={ async (value) => {
 				setLoading(true)
-				const deptIds = value?.deptIds.map((item: any) => item?.value ? item?.value : item)
 				const co = {
 					id: value?.id,
-					deptIds: deptIds,
+					deptId: value?.deptId,
 					roleIds: value?.roleIds,
 				}
 				modifyUserAuthority({co: co}).then(res => {
@@ -100,7 +99,7 @@ export const UserModifyAuthorityDrawer: React.FC<UserAuthorityProps> = ({ modalM
 
 			<ProFormTreeSelect
 				disabled={loading}
-				name="deptIds"
+				name="deptId"
 				label="所属部门"
 				allowClear={true}
 				placeholder={'请选择所属部门'}
@@ -111,24 +110,6 @@ export const UserModifyAuthorityDrawer: React.FC<UserAuthorityProps> = ({ modalM
 						value: 'id',
 						children: 'children'
 					},
-					// 最多显示多少个 tag，响应式模式会对性能产生损耗
-					maxTagCount: 6,
-					// 多选
-					multiple: true,
-					// 显示复选框
-					treeCheckable: true,
-					// 展示策略
-					showCheckedStrategy: 'SHOW_ALL',
-					// 取消父子节点联动
-					treeCheckStrictly: true,
-					// 默认展示所有节点
-					treeDefaultExpandAll: true,
-					// 高度
-					dropdownStyle: { maxHeight: 600 },
-					// 不显示搜索
-					showSearch: false,
-					// 高度
-					listHeight: 550
 				}}
 				request={async () => {
 					return deptTreeList


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Fix cache `putIfAbsent` logic to properly handle concurrent access scenarios

- Add data scope filtering validation to authentication flow

- Refactor `DataFilterV` from List to Set-based department IDs

- Simplify UI department selection from multi-select to single-select


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cache putIfAbsent Logic"] -->|"Improved handling"| B["Concurrent Access"]
  C["Authentication Flow"] -->|"Add validation"| D["Data Scope Filter"]
  E["DataFilterV Model"] -->|"Change structure"| F["Set-based deptIds"]
  G["User Authority UI"] -->|"Simplify selection"| H["Single Department"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperateTypeEnum.java</strong><dd><code>Fix cache putIfAbsent concurrent access handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/model/OperateTypeEnum.java

<ul><li>Refactored cache <code>putIfAbsent</code> logic to properly handle return values<br> <li> Store result of <code>point.proceed()</code> in variable to avoid double execution<br> <li> Check if <code>oldValue</code> is null to return appropriate cached value<br> <li> Fixes potential race condition in concurrent cache access scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5413/files#diff-06a71dcccdcdeb3e790e79dcb8568c54c46df6f9c441fab386394815706d34cd">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DomainService.java</strong><dd><code>Integrate data scope filtering into auth flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/ability/DomainService.java

<ul><li>Added imports for <code>DataScopeEnum</code> and <code>Set</code> utility<br> <li> Integrated data scope filtering into authentication workflow<br> <li> Added calls to <code>getDataFilter</code> and <code>checkDataFilter</code> methods<br> <li> Data filter validation now occurs after menu permission checks</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5413/files#diff-26d586b27515a332b430f36acc7ddfa218ad9d74b98308334e07b380088d05c7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthA.java</strong><dd><code>Implement data filter validation methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java

<ul><li>Added imports for <code>DataScopeEnum</code> and <code>Collections</code><br> <li> Implemented <code>getDataFilter</code> method with logic for handling data scopes<br> <li> Added <code>checkDataFilter</code> method to validate data filter presence<br> <li> Supports ALL scope with empty department IDs or custom scope handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5413/files#diff-8d2ef64e447f6aa2149db54388d7be605ddbe710663f93999dace3f6c2515df9">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataFilterV.java</strong><dd><code>Refactor DataFilterV to use Set for deptIds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/valueobject/DataFilterV.java

<ul><li>Changed <code>deptIds</code> field type from <code>List<Long></code> to <code>Set<Long></code><br> <li> Added <code>@Builder</code> annotation with <code>toBuilder</code> support<br> <li> Updated imports to use <code>Set</code> instead of <code>List</code><br> <li> Improves efficiency for department ID lookups and uniqueness</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5413/files#diff-92a2af587850c851f224793220cbf56984dbfa273e1bf9f3720f6948670a28c6">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserModifyAuthorityDrawer.tsx</strong><dd><code>Convert department selection from multi to single</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ui/src/pages/Sys/Permission/UserModifyAuthorityDrawer.tsx

<ul><li>Changed <code>deptIds</code> field from array to single <code>deptId</code> number in type <br>definition<br> <li> Removed array mapping logic for department IDs in form submission<br> <li> Simplified <code>ProFormTreeSelect</code> configuration by removing multi-select <br>properties<br> <li> Removed <code>maxTagCount</code>, <code>multiple</code>, <code>treeCheckable</code>, and other multi-select <br>settings</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5413/files#diff-07571254b309eb1cfb657acd59980ed4a90739f0062b66af1c7d710b7baf5fea">+3/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data authorization validation to enforce data scope permissions during authentication processes.

* **Bug Fixes**
  * Fixed cache behavior to return the correct computed value on cache misses instead of potential null values.

* **Refactor**
  * Simplified department field in user authority management interface from multi-select to single-select dropdown for improved usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->