### PR TITLE
Dev

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,7 +73,8 @@ jobs:
             ./laokou-common/laokou-common-elasticsearch/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-mybatis-plus/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-starrocks/target/site/jacoco/jacoco.xml,
-            ./laokou-common/laokou-common-ftp/target/site/jacoco/jacoco.xml
+            ./laokou-common/laokou-common-ftp/target/site/jacoco/jacoco.xml,
+            ./laokou-common/laokou-common-redis/target/site/jacoco/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build the Docker image
         run: |

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/AddressUtils.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/AddressUtils.java
@@ -41,7 +41,7 @@ public final class AddressUtils {
 	/**
 	 * IP搜索器.
 	 */
-	private static Ip2Region IP_REGION = null;
+	private static Ip2Region ipRegion = null;
 
 	static {
 		try {
@@ -61,7 +61,7 @@ public final class AddressUtils {
 				.setXdbFile(ResourceExtUtils.getResource("ip2region_v6.xdb").getFile())
 				// 设置初始化的查询器数量
 				.asV6();
-			IP_REGION = Ip2Region.create(v4Config, v6Config);
+			ipRegion = Ip2Region.create(v4Config, v6Config);
 		}
 		catch (IOException | InvalidConfigException | XdbException ex) {
 			log.error("Ip2region加载失败，错误信息：{}", ex.getMessage(), ex);
@@ -69,9 +69,9 @@ public final class AddressUtils {
 		}
 		finally {
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-				if (ObjectUtils.isNotNull(IP_REGION)) {
+				if (ObjectUtils.isNotNull(ipRegion)) {
 					try {
-						IP_REGION.close();
+						ipRegion.close();
 					}
 					catch (InterruptedException ex) {
 						throw new RuntimeException(ex);
@@ -90,7 +90,7 @@ public final class AddressUtils {
 	 * @return 所属位置
 	 */
 	public static String getRealAddress(String ip) throws InetAddressException, IOException, InterruptedException {
-		return IpUtils.internalIp(ip) ? "内网IP" : addressFormat(IP_REGION.search(ip));
+		return IpUtils.internalIp(ip) ? "内网IP" : addressFormat(ipRegion.search(ip));
 	}
 
 	/**

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/DigestUtils.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/DigestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.core.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author laokou
+ */
+public final class DigestUtils {
+
+	private DigestUtils() {
+	}
+
+	public static byte[] digest(byte[] buff) {
+		return digest("SHA-512", buff);
+	}
+
+	public static byte[] digest(String algorithm, byte[] buff) {
+		return getDigest(algorithm).digest(buff);
+	}
+
+	private static MessageDigest getDigest(String algorithm) {
+		try {
+			return MessageDigest.getInstance(algorithm);
+		}
+		catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("Could not find MessageDigest with algorithm \"" + algorithm + "\"", ex);
+		}
+	}
+
+}

--- a/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/DigestUtilsTest.java
+++ b/laokou-common/laokou-common-core/src/test/java/org/laokou/common/core/DigestUtilsTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.core;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.core.util.DigestUtils;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author laokou
+ */
+class DigestUtilsTest {
+
+	@Test
+	void test_digest_default_sha512() {
+		// Given
+		String input = "test data";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result = DigestUtils.digest(inputBytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(64); // SHA-512 produces 64
+																// bytes
+	}
+
+	@Test
+	void test_digest_with_sha256() {
+		// Given
+		String input = "test data";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result = DigestUtils.digest("SHA-256", inputBytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(32); // SHA-256 produces 32
+																// bytes
+	}
+
+	@Test
+	void test_digest_with_sha512() {
+		// Given
+		String input = "test data";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result = DigestUtils.digest("SHA-512", inputBytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(64); // SHA-512 produces 64
+																// bytes
+	}
+
+	@Test
+	void test_digest_with_md5() {
+		// Given
+		String input = "test data";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result = DigestUtils.digest("MD5", inputBytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(16); // MD5 produces 16 bytes
+	}
+
+	@Test
+	void test_digest_empty_input() {
+		// Given
+		byte[] emptyInput = new byte[0];
+
+		// When
+		byte[] result = DigestUtils.digest(emptyInput);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(64); // SHA-512 produces 64
+																// bytes even for empty
+																// input
+	}
+
+	@Test
+	void test_digest_consistency() {
+		// Given
+		String input = "consistent data";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result1 = DigestUtils.digest(inputBytes);
+		byte[] result2 = DigestUtils.digest(inputBytes);
+
+		// Then
+		Assertions.assertThat(result1).isEqualTo(result2); // Same input should produce
+															// same hash
+	}
+
+	@Test
+	void test_digest_different_inputs_produce_different_hashes() {
+		// Given
+		String input1 = "data1";
+		String input2 = "data2";
+		byte[] inputBytes1 = input1.getBytes(StandardCharsets.UTF_8);
+		byte[] inputBytes2 = input2.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result1 = DigestUtils.digest(inputBytes1);
+		byte[] result2 = DigestUtils.digest(inputBytes2);
+
+		// Then
+		Assertions.assertThat(result1).isNotEqualTo(result2); // Different inputs should
+																// produce different
+																// hashes
+	}
+
+	@Test
+	void test_digest_same_inputs_produce_different_hashes() {
+		// Given
+		String input1 = "data";
+		String input2 = "data";
+		byte[] inputBytes1 = input1.getBytes(StandardCharsets.UTF_8);
+		byte[] inputBytes2 = input2.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result1 = DigestUtils.digest(inputBytes1);
+		byte[] result2 = DigestUtils.digest(inputBytes2);
+
+		// Then
+		Assertions.assertThat(result1).isEqualTo(result2); // Different inputs should
+															// produce different hashes
+	}
+
+	@Test
+	void test_digest_with_invalid_algorithm() {
+		// Given
+		String input = "test data";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When & Then
+		Assertions.assertThatThrownBy(() -> DigestUtils.digest("INVALID-ALGORITHM", inputBytes))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Could not find MessageDigest with algorithm \"INVALID-ALGORITHM\"");
+	}
+
+	@Test
+	void test_digest_with_large_input() {
+		// Given
+		byte[] largeInput = new byte[1024 * 1024]; // 1MB
+		for (int i = 0; i < largeInput.length; i++) {
+			largeInput[i] = (byte) (i % 256);
+		}
+
+		// When
+		byte[] result = DigestUtils.digest(largeInput);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(64); // SHA-512 produces 64
+																// bytes
+	}
+
+	@Test
+	void test_digest_with_special_characters() {
+		// Given
+		String input = "特殊字符测试!@#$%^&*()_+-=[]{}|;':\",./<>?";
+		byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+
+		// When
+		byte[] result = DigestUtils.digest(inputBytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().hasSize(64); // SHA-512 produces 64
+																// bytes
+	}
+
+}

--- a/laokou-common/laokou-common-redis/pom.xml
+++ b/laokou-common/laokou-common-redis/pom.xml
@@ -55,5 +55,19 @@
       <artifactId>laokou-common-fory</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-testcontainers</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/CodecTypeEnum.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/CodecTypeEnum.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.redis.config;
+
+import lombok.Getter;
+import org.redisson.client.codec.Codec;
+
+@Getter
+public enum CodecTypeEnum {
+
+	FORY("fory", "Fory") {
+		@Override
+		public Codec getCodec() {
+			return ForyCodec.INSTANCE;
+		}
+	},
+
+	JACKSON("jackson", "Jackson") {
+		@Override
+		public Codec getCodec() {
+			return JacksonCodec.INSTANCE;
+		}
+	};
+
+	private final String code;
+
+	private final String desc;
+
+	CodecTypeEnum(String code, String desc) {
+		this.code = code;
+		this.desc = desc;
+	}
+
+	public abstract Codec getCodec();
+
+}

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/ForyRedisSerializer.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/ForyRedisSerializer.java
@@ -47,7 +47,7 @@ public final class ForyRedisSerializer implements RedisSerializer<@NonNull Objec
 	}
 
 	public static StringRedisSerializer getStringRedisSerializer() {
-		return new Md5DigestStringRedisSerializer(StandardCharsets.UTF_8);
+		return new Sha512DigestStringRedisSerializer(StandardCharsets.UTF_8);
 	}
 
 	public static ForyRedisSerializer foryRedisSerializer() {

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/JacksonCodec.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/JacksonCodec.java
@@ -23,7 +23,7 @@ import org.redisson.codec.JsonJackson3Codec;
 /**
  * @author laokou
  */
-final class JacksonCodec extends JsonJackson3Codec {
+public final class JacksonCodec extends JsonJackson3Codec {
 
 	/**
 	 * 实例.

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/LoadBalancerTypeEnum.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/LoadBalancerTypeEnum.java
@@ -18,11 +18,34 @@
 package org.laokou.common.redis.config;
 
 import lombok.Getter;
+import org.redisson.connection.balancer.LoadBalancer;
+import org.redisson.connection.balancer.RandomLoadBalancer;
+import org.redisson.connection.balancer.RoundRobinLoadBalancer;
 
 @Getter
 public enum LoadBalancerTypeEnum {
 
-	;
+	RANDOM("random", "随机") {
+		@Override
+		LoadBalancer get() {
+			return new RandomLoadBalancer();
+		}
+	},
+
+	WEIGHTED_ROUND_ROBIN("weighted_round_robin", "加权轮询") {
+		@Override
+		LoadBalancer get() {
+			throw new UnsupportedOperationException("Unsupported WeightedRoundRobinBalancer.");
+		}
+	},
+
+	ROUND_ROBIN("round_robin", "轮询") {
+		@Override
+		LoadBalancer get() {
+			return new RoundRobinLoadBalancer();
+		}
+	};
+
 	private final String code;
 
 	private final String desc;
@@ -31,5 +54,7 @@ public enum LoadBalancerTypeEnum {
 		this.code = code;
 		this.desc = desc;
 	}
+
+	abstract LoadBalancer get();
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/LoadBalancerTypeEnum.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/LoadBalancerTypeEnum.java
@@ -18,34 +18,18 @@
 package org.laokou.common.redis.config;
 
 import lombok.Getter;
-import org.redisson.client.codec.Codec;
 
 @Getter
-public enum CodecEnum {
+public enum LoadBalancerTypeEnum {
 
-	FORY("fory", "Fory") {
-		@Override
-		public Codec getCodec() {
-			return ForyCodec.INSTANCE;
-		}
-	},
-
-	JACKSON("jackson", "Jackson") {
-		@Override
-		public Codec getCodec() {
-			return JacksonCodec.INSTANCE;
-		}
-	};
-
+	;
 	private final String code;
 
 	private final String desc;
 
-	CodecEnum(String code, String desc) {
+	LoadBalancerTypeEnum(String code, String desc) {
 		this.code = code;
 		this.desc = desc;
 	}
-
-	public abstract Codec getCodec();
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/NodeTypeEnum.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/NodeTypeEnum.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.redis.config;
+
+import lombok.Getter;
+
+@Getter
+public enum NodeTypeEnum {
+
+	;
+
+	private final String code;
+
+	private final String desc;
+
+	NodeTypeEnum(String code, String desc) {
+		this.code = code;
+		this.desc = desc;
+	}
+
+}

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/NodeTypeEnum.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/NodeTypeEnum.java
@@ -18,11 +18,52 @@
 package org.laokou.common.redis.config;
 
 import lombok.Getter;
+import org.redisson.config.Config;
 
 @Getter
 public enum NodeTypeEnum {
 
-	;
+	SINGLE("single", "单机模式") {
+		@Override
+		Config getConfig(SpringRedissonProperties springRedissonProperties) {
+			SpringRedissonProperties.Single single = springRedissonProperties.getNode().getSingle();
+			Config config = springRedissonProperties.createDefaultConfig();
+			config.useSingleServer()
+				.setAddress(single.getAddress())
+				.setConnectTimeout(single.getConnectTimeout())
+				.setTimeout(single.getTimeout())
+				.setDatabase(single.getDatabase());
+			return config;
+		}
+	},
+
+	CLUSTER("cluster", "集群模式") {
+		@Override
+		Config getConfig(SpringRedissonProperties springRedissonProperties) {
+			return null;
+		}
+	},
+
+	SENTINEL("sentinel", "哨兵模式") {
+		@Override
+		Config getConfig(SpringRedissonProperties springRedissonProperties) {
+			return null;
+		}
+	},
+
+	MASTER_SLAVE("master_slave", "主从模式") {
+		@Override
+		Config getConfig(SpringRedissonProperties springRedissonProperties) {
+			return null;
+		}
+	},
+
+	REPLICATED("replicated", "复制模式") {
+		@Override
+		Config getConfig(SpringRedissonProperties springRedissonProperties) {
+			return null;
+		}
+	};
 
 	private final String code;
 
@@ -32,5 +73,7 @@ public enum NodeTypeEnum {
 		this.code = code;
 		this.desc = desc;
 	}
+
+	abstract Config getConfig(SpringRedissonProperties springRedissonProperties);
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/NodeTypeEnum.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/NodeTypeEnum.java
@@ -17,7 +17,10 @@
 
 package org.laokou.common.redis.config;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import lombok.Getter;
+import org.laokou.common.core.util.ThreadUtils;
 import org.redisson.config.Config;
 
 @Getter
@@ -26,42 +29,35 @@ public enum NodeTypeEnum {
 	SINGLE("single", "单机模式") {
 		@Override
 		Config getConfig(SpringRedissonProperties springRedissonProperties) {
-			SpringRedissonProperties.Single single = springRedissonProperties.getNode().getSingle();
-			Config config = springRedissonProperties.createDefaultConfig();
-			config.useSingleServer()
-				.setAddress(single.getAddress())
-				.setConnectTimeout(single.getConnectTimeout())
-				.setTimeout(single.getTimeout())
-				.setDatabase(single.getDatabase());
-			return config;
+			return useSingleServer(springRedissonProperties);
 		}
 	},
 
 	CLUSTER("cluster", "集群模式") {
 		@Override
 		Config getConfig(SpringRedissonProperties springRedissonProperties) {
-			return null;
+			return useClusterServers(springRedissonProperties);
 		}
 	},
 
 	SENTINEL("sentinel", "哨兵模式") {
 		@Override
 		Config getConfig(SpringRedissonProperties springRedissonProperties) {
-			return null;
+			return useSentinelServers(springRedissonProperties);
 		}
 	},
 
 	MASTER_SLAVE("master_slave", "主从模式") {
 		@Override
 		Config getConfig(SpringRedissonProperties springRedissonProperties) {
-			return null;
+			throw new UnsupportedOperationException("Unsupported master and slave");
 		}
 	},
 
 	REPLICATED("replicated", "复制模式") {
 		@Override
 		Config getConfig(SpringRedissonProperties springRedissonProperties) {
-			return null;
+			throw new UnsupportedOperationException("Unsupported replicated");
 		}
 	};
 
@@ -75,5 +71,126 @@ public enum NodeTypeEnum {
 	}
 
 	abstract Config getConfig(SpringRedissonProperties springRedissonProperties);
+
+	private static Config useSingleServer(SpringRedissonProperties springRedissonProperties) {
+		Config config = createDefaultConfig(springRedissonProperties);
+		SpringRedissonProperties.Single single = springRedissonProperties.getNode().getSingle();
+		config.useSingleServer()
+			.setAddress(single.getAddress())
+			.setConnectTimeout(single.getConnectTimeout())
+			.setTimeout(single.getTimeout())
+			.setSubscriptionTimeout(single.getSubscriptionTimeout())
+			.setRetryAttempts(single.getRetryAttempts())
+			.setSubscriptionsPerConnection(single.getSubscriptionsPerConnection())
+			.setClientName(single.getClientName())
+			.setPingConnectionInterval(single.getPingConnectionInterval())
+			.setSubscriptionConnectionMinimumIdleSize(single.getSubscriptionConnectionMinimumIdleSize())
+			.setSubscriptionConnectionPoolSize(single.getSubscriptionConnectionPoolSize())
+			.setConnectionMinimumIdleSize(single.getConnectionMinimumIdleSize())
+			.setConnectionPoolSize(single.getConnectionPoolSize())
+			.setDnsMonitoringInterval(single.getDnsMonitoringInterval())
+			.setDatabase(single.getDatabase());
+		return config;
+	}
+
+	private static Config useClusterServers(SpringRedissonProperties springRedissonProperties) {
+		Config config = createDefaultConfig(springRedissonProperties);
+		SpringRedissonProperties.Cluster cluster = springRedissonProperties.getNode().getCluster();
+		config.useClusterServers()
+			.addNodeAddress(cluster.getNodeAddresses().toArray(String[]::new))
+			.setConnectTimeout(cluster.getConnectTimeout())
+			.setSubscriptionTimeout(cluster.getSubscriptionTimeout())
+			.setRetryAttempts(cluster.getRetryAttempts())
+			.setSubscriptionsPerConnection(cluster.getSubscriptionsPerConnection())
+			.setClientName(cluster.getClientName())
+			.setPingConnectionInterval(cluster.getPingConnectionInterval())
+			.setSubscriptionConnectionMinimumIdleSize(cluster.getSubscriptionConnectionMinimumIdleSize())
+			.setSubscriptionConnectionPoolSize(cluster.getSubscriptionConnectionPoolSize())
+			.setIdleConnectionTimeout(cluster.getIdleConnectionTimeout())
+			.setTimeout(cluster.getTimeout())
+			.setLoadBalancer(cluster.getLoadBalancer().get())
+			.setSlaveConnectionMinimumIdleSize(cluster.getSlaveConnectionMinimumIdleSize())
+			.setSlaveConnectionPoolSize(cluster.getSlaveConnectionPoolSize())
+			.setFailedSlaveReconnectionInterval(cluster.getFailedSlaveReconnectionInterval())
+			.setMasterConnectionMinimumIdleSize(cluster.getMasterConnectionMinimumIdleSize())
+			.setMasterConnectionPoolSize(cluster.getMasterConnectionPoolSize())
+			.setReadMode(cluster.getReadMode())
+			.setSubscriptionMode(cluster.getSubscriptionMode())
+			.setDnsMonitoringInterval(cluster.getDnsMonitoringInterval())
+			.setScanInterval(cluster.getScanInterval())
+			.setCheckSlotsCoverage(cluster.isCheckSlotsCoverage())
+			.setCheckMasterLinkStatus(cluster.isCheckMasterLinkStatus())
+			.setShardedSubscriptionMode(cluster.getShardedSubscriptionMode())
+			.setDatabase(cluster.getDatabase());
+		return config;
+	}
+
+	private static Config useSentinelServers(SpringRedissonProperties springRedissonProperties) {
+		Config config = createDefaultConfig(springRedissonProperties);
+		SpringRedissonProperties.Sentinel sentinel = springRedissonProperties.getNode().getSentinel();
+		config.useSentinelServers()
+			.setMasterName(sentinel.getMasterName())
+			.addSentinelAddress(sentinel.getSentinelAddresses().toArray(String[]::new))
+			.setIdleConnectionTimeout(sentinel.getIdleConnectionTimeout())
+			.setConnectTimeout(sentinel.getConnectTimeout())
+			.setTimeout(sentinel.getTimeout())
+			.setSubscriptionTimeout(sentinel.getSubscriptionTimeout())
+			.setRetryAttempts(sentinel.getRetryAttempts())
+			.setSubscriptionsPerConnection(sentinel.getSubscriptionsPerConnection())
+			.setClientName(sentinel.getClientName())
+			.setPingConnectionInterval(sentinel.getPingConnectionInterval())
+			.setLoadBalancer(sentinel.getLoadBalancer().get())
+			.setSlaveConnectionMinimumIdleSize(sentinel.getSlaveConnectionMinimumIdleSize())
+			.setSlaveConnectionPoolSize(sentinel.getSlaveConnectionPoolSize())
+			.setFailedSlaveReconnectionInterval(sentinel.getFailedSlaveReconnectionInterval())
+			.setMasterConnectionMinimumIdleSize(sentinel.getMasterConnectionMinimumIdleSize())
+			.setMasterConnectionPoolSize(sentinel.getMasterConnectionPoolSize())
+			.setReadMode(sentinel.getReadMode())
+			.setSubscriptionMode(sentinel.getSubscriptionMode())
+			.setSubscriptionConnectionMinimumIdleSize(sentinel.getSubscriptionConnectionMinimumIdleSize())
+			.setSubscriptionConnectionPoolSize(sentinel.getSubscriptionConnectionPoolSize())
+			.setDnsMonitoringInterval(sentinel.getDnsMonitoringInterval())
+			.setSentinelUsername(sentinel.getSentinelUsername())
+			.setSentinelPassword(sentinel.getSentinelPassword())
+			.setDatabase(sentinel.getDatabase())
+			.setScanInterval(sentinel.getScanInterval())
+			.setCheckSentinelsList(sentinel.isCheckSentinelsList())
+			.setCheckSlaveStatusWithSyncing(sentinel.isCheckSlaveStatusWithSyncing())
+			.setSentinelsDiscovery(sentinel.isSentinelsDiscovery());
+		return config;
+	}
+
+	private static Config createDefaultConfig(SpringRedissonProperties springRedissonProperties) {
+		Config config = new Config();
+		config.setPassword(springRedissonProperties.getPassword());
+		config.setThreads(springRedissonProperties.getThreads());
+		config.setCodec(springRedissonProperties.getCodec().getCodec());
+		config.setTransportMode(springRedissonProperties.getTransportMode());
+		config.setExecutor(ThreadUtils.newVirtualTaskExecutor());
+		config.setEventLoopGroup(new MultiThreadIoEventLoopGroup(springRedissonProperties.getNettyThreads(),
+				ThreadUtils.newVirtualTaskExecutor(), NioIoHandler.newFactory()));
+		config.setNettyExecutor(ThreadUtils.newVirtualTaskExecutor());
+		config.setReferenceEnabled(springRedissonProperties.isReferenceEnabled());
+		config.setNettyThreads(springRedissonProperties.getNettyThreads());
+		config.setLockWatchdogTimeout(springRedissonProperties.getLockWatchdogTimeout());
+		config.setFairLockWaitTimeout(springRedissonProperties.getFairLockWaitTimeout());
+		config.setLockWatchdogBatchSize(springRedissonProperties.getLockWatchdogBatchSize());
+		config.setCheckLockSyncedSlaves(springRedissonProperties.isCheckLockSyncedSlaves());
+		config.setKeepPubSubOrder(springRedissonProperties.isKeepPubSubOrder());
+		config.setUseScriptCache(springRedissonProperties.isUseScriptCache());
+		config.setMinCleanUpDelay(springRedissonProperties.getMinCleanUpDelay());
+		config.setMaxCleanUpDelay(springRedissonProperties.getMaxCleanUpDelay());
+		config.setCleanUpKeysAmount(springRedissonProperties.getCleanUpKeysAmount());
+		config.setUseThreadClassLoader(springRedissonProperties.isUseThreadClassLoader());
+		config.setReliableTopicWatchdogTimeout(springRedissonProperties.getReliableTopicWatchdogTimeout());
+		config.setSlavesSyncTimeout(springRedissonProperties.getSlavesSyncTimeout());
+		config.setTcpKeepAlive(springRedissonProperties.isTcpKeepAlive());
+		config.setTcpKeepAliveCount(springRedissonProperties.getTcpKeepAliveCount());
+		config.setTcpKeepAliveIdle(springRedissonProperties.getTcpKeepAliveIdle());
+		config.setTcpKeepAliveInterval(springRedissonProperties.getTcpKeepAliveInterval());
+		config.setTcpUserTimeout(springRedissonProperties.getTcpUserTimeout());
+		config.setTcpNoDelay(springRedissonProperties.isTcpNoDelay());
+		return config;
+	}
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/RedissonAutoConfig.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/RedissonAutoConfig.java
@@ -17,19 +17,13 @@
 
 package org.laokou.common.redis.config;
 
-import org.laokou.common.i18n.common.constant.StringConstants;
-import org.laokou.common.i18n.util.ObjectUtils;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author livk
@@ -41,70 +35,13 @@ import java.util.List;
 public class RedissonAutoConfig {
 
 	/**
-	 * Redis普通连接.
-	 */
-	private static final String REDIS_PROTOCOL_PREFIX = "redis://";
-
-	/**
-	 * Redis加密连接.
-	 */
-	private static final String REDISS_PROTOCOL_PREFIX = "rediss://";
-
-	/**
 	 * redisson配置.
-	 * @param properties redis配置文件
+	 * @param springRedissonProperties redisson配置文件
 	 * @return RedissonClient
 	 */
 	@Bean(name = "redisClient", destroyMethod = "shutdown")
-	public RedissonClient redisClient(DataRedisProperties properties) {
-		Config config = new Config();
-		config.setPassword(properties.getPassword());
-		int timeout = (int) properties.getTimeout().toMillis();
-		int connectTimeout = (int) properties.getConnectTimeout().toMillis();
-		boolean isSsl = properties.getSsl().isEnabled();
-		if (ObjectUtils.isNotNull(properties.getSentinel())) {
-			config.useSentinelServers()
-				.setMasterName(properties.getSentinel().getMaster())
-				.addSentinelAddress(convertNodes(isSsl, properties.getSentinel().getNodes()))
-				.setDatabase(properties.getDatabase())
-				.setTimeout(timeout)
-				.setConnectTimeout(connectTimeout);
-		}
-		else if (ObjectUtils.isNotNull(properties.getCluster())) {
-			config.useClusterServers()
-				.addNodeAddress(convertNodes(isSsl, properties.getCluster().getNodes()))
-				.setTimeout(timeout)
-				.setConnectTimeout(connectTimeout);
-		}
-		else {
-			config.useSingleServer()
-				.setAddress(convertAddress(isSsl, properties.getHost(), properties.getPort()))
-				.setDatabase(properties.getDatabase())
-				.setConnectTimeout(connectTimeout)
-				.setTimeout(timeout);
-		}
-		return Redisson.create(config);
-	}
-
-	private String getProtocolPrefix(boolean isSsl) {
-		return isSsl ? REDISS_PROTOCOL_PREFIX : REDIS_PROTOCOL_PREFIX;
-	}
-
-	private String convertAddress(boolean isSsl, String host, int port) {
-		return getProtocolPrefix(isSsl) + host + StringConstants.RISK + port;
-	}
-
-	private String[] convertNodes(boolean isSsl, List<String> nodeList) {
-		List<String> nodes = new ArrayList<>(nodeList.size());
-		for (String node : nodeList) {
-			if (node.startsWith(REDISS_PROTOCOL_PREFIX) || node.startsWith(REDIS_PROTOCOL_PREFIX)) {
-				nodes.add(node);
-			}
-			else {
-				nodes.add(getProtocolPrefix(isSsl) + node);
-			}
-		}
-		return nodes.toArray(String[]::new);
+	public RedissonClient redisClient(SpringRedissonProperties springRedissonProperties) {
+		return Redisson.create(springRedissonProperties.getConfig());
 	}
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/Sha512DigestStringRedisSerializer.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/Sha512DigestStringRedisSerializer.java
@@ -19,10 +19,10 @@ package org.laokou.common.redis.config;
 
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
+import org.laokou.common.core.util.DigestUtils;
 import org.laokou.common.fory.config.ForyFactory;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.util.Assert;
-import org.springframework.util.DigestUtils;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -30,9 +30,9 @@ import java.nio.charset.StandardCharsets;
 /**
  * @author laokou
  */
-public class Md5DigestStringRedisSerializer extends StringRedisSerializer {
+public class Sha512DigestStringRedisSerializer extends StringRedisSerializer {
 
-	public Md5DigestStringRedisSerializer(Charset charset) {
+	public Sha512DigestStringRedisSerializer(Charset charset) {
 		super(charset);
 	}
 
@@ -40,7 +40,7 @@ public class Md5DigestStringRedisSerializer extends StringRedisSerializer {
 	@Override
 	public byte[] serialize(@Nullable String key) {
 		Assert.notNull(key, "Cannot serialize null");
-		return ForyFactory.INSTANCE.serialize(DigestUtils.md5DigestAsHex(key.getBytes(StandardCharsets.UTF_8)));
+		return ForyFactory.INSTANCE.serialize(DigestUtils.digest(key.getBytes(StandardCharsets.UTF_8)));
 	}
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/SpringRedissonProperties.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/SpringRedissonProperties.java
@@ -19,11 +19,19 @@ package org.laokou.common.redis.config;
 
 import lombok.Data;
 import org.laokou.common.i18n.util.StringExtUtils;
+import org.redisson.config.ReadMode;
+import org.redisson.config.ShardedSubscriptionMode;
+import org.redisson.config.SubscriptionMode;
 import org.redisson.config.TransportMode;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -82,6 +90,10 @@ public class SpringRedissonProperties implements InitializingBean {
 
 	private boolean useThreadClassLoader = true;
 
+	private CodecTypeEnum codec = CodecTypeEnum.FORY;
+
+	private Node node;
+
 	@Override
 	public void afterPropertiesSet() {
 		if (StringExtUtils.isEmpty(this.password)) {
@@ -90,6 +102,256 @@ public class SpringRedissonProperties implements InitializingBean {
 		if (StringExtUtils.isEmpty(this.username)) {
 			throw new IllegalStateException("username must not be empty.");
 		}
+		if (ObjectUtils.isEmpty(this.node)) {
+			throw new IllegalStateException("node must not be empty.");
+		}
+	}
+
+	@Data
+	static class Base {
+
+		/**
+		 * If pooled connection not used for a <code>timeout</code> time and current
+		 * connections amount bigger than minimum idle connections pool size, then it will
+		 * closed and removed from pool. Value in milliseconds.
+		 *
+		 */
+		private int idleConnectionTimeout = 10000;
+
+		/**
+		 * Timeout during connecting to any Redis server. Value in milliseconds.
+		 *
+		 */
+		private int connectTimeout = 10000;
+
+		/**
+		 * Redis server response timeout. Starts to countdown when Redis command was
+		 * succesfully sent. Value in milliseconds.
+		 *
+		 */
+		private int timeout = 3000;
+
+		private int subscriptionTimeout = 7500;
+
+		private int retryAttempts = 4;
+
+		/**
+		 * Subscriptions per Redis connection limit.
+		 */
+		private int subscriptionsPerConnection = 5;
+
+		/**
+		 * Name of client connection.
+		 */
+		private String clientName;
+
+		private int pingConnectionInterval = 30000;
+
+	}
+
+	@Data
+	public static class Node {
+
+		private NodeTypeEnum type;
+
+		private Single single;
+
+		private Cluster cluster;
+
+		private Sentinel sentinel;
+
+		private MasterSlave masterSlave;
+
+		private Replicated replicated;
+
+	}
+
+	@Data
+	public static class Single extends Base {
+
+		/**
+		 * Redis server address.
+		 */
+		private String address;
+
+		/**
+		 * Minimum idle subscription connection amount.
+		 */
+		private int subscriptionConnectionMinimumIdleSize = 1;
+
+		/**
+		 * Redis subscription connection maximum pool size.
+		 *
+		 */
+		private int subscriptionConnectionPoolSize = 50;
+
+		/**
+		 * Minimum idle Redis connection amount.
+		 */
+		private int connectionMinimumIdleSize = 24;
+
+		/**
+		 * Redis connection maximum pool size.
+		 */
+		private int connectionPoolSize = 64;
+
+		/**
+		 * Database index used for Redis connection.
+		 */
+		private int database = 0;
+
+		/**
+		 * Interval in milliseconds to check DNS.
+		 */
+		private long dnsMonitoringInterval = 5000;
+
+	}
+
+	@Data
+	public static class Cluster extends BaseMasterSlave {
+
+		/**
+		 * Redis cluster node urls list.
+		 */
+		private List<String> nodeAddresses = new ArrayList<>();
+
+		/**
+		 * Redis cluster scan interval in milliseconds.
+		 */
+		private int scanInterval = 5000;
+
+		private boolean checkSlotsCoverage = true;
+
+		private boolean checkMasterLinkStatus = false;
+
+		private ShardedSubscriptionMode shardedSubscriptionMode = ShardedSubscriptionMode.AUTO;
+
+		private int database = 0;
+
+	}
+
+	@Data
+	public static class Sentinel extends BaseMasterSlave {
+
+		private List<String> sentinelAddresses = new ArrayList<>();
+
+		private String masterName;
+
+		private String sentinelUsername;
+
+		private String sentinelPassword;
+
+		/**
+		 * Database index used for Redis connection.
+		 */
+		private int database = 0;
+
+		/**
+		 * Sentinel scan interval in milliseconds.
+		 */
+		private int scanInterval = 1000;
+
+		private boolean checkSentinelsList = true;
+
+		private boolean checkSlaveStatusWithSyncing = true;
+
+		private boolean sentinelsDiscovery = true;
+
+	}
+
+	@Data
+	static class BaseMasterSlave extends Base {
+
+		/**
+		 * Сonnection load balancer for multiple Redis slave servers.
+		 */
+		private LoadBalancerTypeEnum loadBalancer;
+
+		/**
+		 * Redis 'slave' node minimum idle connection amount for <b>each</b> slave node.
+		 */
+		private int slaveConnectionMinimumIdleSize = 24;
+
+		/**
+		 * Redis 'slave' node maximum connection pool size for <b>each</b> slave node.
+		 */
+		private int slaveConnectionPoolSize = 64;
+
+		private int failedSlaveReconnectionInterval = 3000;
+
+		@Deprecated
+		private int failedSlaveCheckInterval = 180000;
+
+		/**
+		 * Redis 'master' node minimum idle connection amount for <b>each</b> slave node.
+		 */
+		private int masterConnectionMinimumIdleSize = 24;
+
+		/**
+		 * Redis 'master' node maximum connection pool size.
+		 */
+		private int masterConnectionPoolSize = 64;
+
+		private ReadMode readMode = ReadMode.SLAVE;
+
+		private SubscriptionMode subscriptionMode = SubscriptionMode.MASTER;
+
+		/**
+		 * Redis 'slave' node minimum idle subscription (pub/sub) connection amount for
+		 * <b>each</b> slave node.
+		 */
+		private int subscriptionConnectionMinimumIdleSize = 1;
+
+		/**
+		 * Redis 'slave' node maximum subscription (pub/sub) connection pool size for
+		 * <b>each</b> slave node.
+		 */
+		private int subscriptionConnectionPoolSize = 50;
+
+		private long dnsMonitoringInterval = 5000;
+
+	}
+
+	@Data
+	public static class MasterSlave extends BaseMasterSlave {
+
+		/**
+		 * Redis slave servers addresses.
+		 */
+		private Set<String> slaveAddresses = new HashSet<>();
+
+		/**
+		 * Redis master server address.
+		 */
+		private String masterAddress;
+
+		/**
+		 * Database index used for Redis connection.
+		 */
+		private int database = 0;
+
+	}
+
+	@Data
+	public static class Replicated extends BaseMasterSlave {
+
+		/**
+		 * Replication group node urls list.
+		 */
+		private List<String> nodeAddresses = new ArrayList<>();
+
+		/**
+		 * Replication group scan interval in milliseconds.
+		 */
+		private int scanInterval = 1000;
+
+		/**
+		 * Database index used for Redis connection.
+		 */
+		private int database = 0;
+
+		private boolean monitorIPChanges = false;
+
 	}
 
 }

--- a/laokou-common/laokou-common-redis/src/test/java/org/laokou/common/redis/util/ReactiveRedisUtilsTest.java
+++ b/laokou-common/laokou-common-redis/src/test/java/org/laokou/common/redis/util/ReactiveRedisUtilsTest.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.redis.util;
+
+import com.redis.testcontainers.RedisContainer;
+import lombok.Data;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.laokou.common.core.config.HttpMessageConverterConfig;
+import org.laokou.common.testcontainers.util.DockerImageNames;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.config.Config;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test cases for {@link ReactiveRedisUtils} using Testcontainers and JUnit 5.
+ *
+ * @author laokou
+ */
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ReactiveRedisUtilsTest {
+
+	@Container
+	static RedisContainer redisContainer = new RedisContainer(DockerImageNames.redis()).withExposedPorts(6379)
+		.withReuse(true);
+
+	private ReactiveRedisUtils reactiveRedisUtils;
+
+	private ReactiveRedisTemplate<@NonNull String, @NonNull Object> reactiveRedisTemplate;
+
+	@BeforeEach
+	void setUp() {
+		String redisHost = redisContainer.getHost();
+		Integer redisPort = redisContainer.getMappedPort(6379);
+
+		// Configure Lettuce Connection Factory
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisHost, redisPort);
+		connectionFactory.afterPropertiesSet();
+
+		// Configure ReactiveRedisTemplate
+		StringRedisSerializer keySerializer = new StringRedisSerializer();
+		GenericJacksonJsonRedisSerializer valueSerializer = new GenericJacksonJsonRedisSerializer(
+				HttpMessageConverterConfig.getJsonMapper());
+
+		RedisSerializationContext<@NonNull String, @NonNull Object> serializationContext = RedisSerializationContext
+			.<String, Object>newSerializationContext()
+			.key(keySerializer)
+			.value(valueSerializer)
+			.hashKey(keySerializer)
+			.hashValue(valueSerializer)
+			.build();
+
+		reactiveRedisTemplate = new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+
+		// Configure Redisson
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://" + redisHost + ":" + redisPort);
+		RedissonReactiveClient redissonReactiveClient = Redisson.create(config).reactive();
+
+		// Create ReactiveRedisUtils instance
+		reactiveRedisUtils = new ReactiveRedisUtils(reactiveRedisTemplate, redissonReactiveClient);
+	}
+
+	@AfterEach
+	void tearDown() {
+		// Clean up all keys after each test
+		reactiveRedisTemplate.execute(connection -> connection.serverCommands().flushAll())
+			.blockLast(Duration.ofSeconds(5));
+	}
+
+	@Test
+	@Order(1)
+	@DisplayName("Test set and get operations")
+	void testSetAndGet() {
+		String key = "test:key";
+		String value = "test-value";
+
+		// Test set operation
+		StepVerifier.create(reactiveRedisUtils.set(key, value, -1)).verifyComplete();
+
+		// Test get operation
+		StepVerifier.create(reactiveRedisUtils.get(key)).expectNext(value).verifyComplete();
+	}
+
+	@Test
+	@Order(2)
+	@DisplayName("Test set with expiration")
+	void testSetWithExpiration() {
+		String key = "test:expire:key";
+		String value = "expire-value";
+		long expireSeconds = 2;
+
+		// Set with expiration
+		StepVerifier.create(reactiveRedisUtils.set(key, value, expireSeconds)).verifyComplete();
+
+		// Verify key exists
+		StepVerifier.create(reactiveRedisUtils.hasKey(key)).expectNext(true).verifyComplete();
+
+		// Wait for expiration
+		StepVerifier.create(Mono.delay(Duration.ofSeconds(expireSeconds + 1)).then(reactiveRedisUtils.hasKey(key)))
+			.expectNext(false)
+			.verifyComplete();
+	}
+
+	@Test
+	@Order(3)
+	@DisplayName("Test hasKey operation")
+	void testHasKey() {
+		String existingKey = "test:existing";
+		String nonExistingKey = "test:nonexisting";
+
+		// Set a key
+		StepVerifier.create(reactiveRedisUtils.set(existingKey, "value", -1)).verifyComplete();
+
+		// Test existing key
+		StepVerifier.create(reactiveRedisUtils.hasKey(existingKey)).expectNext(true).verifyComplete();
+
+		// Test non-existing key
+		StepVerifier.create(reactiveRedisUtils.hasKey(nonExistingKey)).expectNext(false).verifyComplete();
+	}
+
+	@Test
+	@Order(4)
+	@DisplayName("Test delete operation")
+	void testDelete() {
+		String key = "test:delete:key";
+		String value = "delete-value";
+
+		// Set a key
+		StepVerifier.create(reactiveRedisUtils.set(key, value, -1)).verifyComplete();
+
+		// Verify key exists
+		StepVerifier.create(reactiveRedisUtils.hasKey(key)).expectNext(true).verifyComplete();
+
+		// Delete the key
+		StepVerifier.create(reactiveRedisUtils.delete(key)).expectNext(1L).verifyComplete();
+
+		// Verify key no longer exists
+		StepVerifier.create(reactiveRedisUtils.hasKey(key)).expectNext(false).verifyComplete();
+	}
+
+	@Test
+	@Order(5)
+	@DisplayName("Test hash operations - hGet")
+	void testHashGet() {
+		String key = "test:hash";
+		String field = "field1";
+		String value = "value1";
+
+		// Put a value in hash
+		StepVerifier.create(reactiveRedisUtils.getMap(key).put(field, value)).verifyComplete();
+
+		// Get the value from hash
+		StepVerifier.create(reactiveRedisUtils.hGet(key, field)).expectNext(value).verifyComplete();
+	}
+
+	@Test
+	@Order(6)
+	@DisplayName("Test hash operations - hasHashKey")
+	void testHasHashKey() {
+		String key = "test:hash:exists";
+		String existingField = "existing-field";
+		String nonExistingField = "non-existing-field";
+
+		// Put a value in hash
+		StepVerifier.create(reactiveRedisUtils.getMap(key).put(existingField, "value")).verifyComplete();
+
+		// Test existing field
+		StepVerifier.create(reactiveRedisUtils.hasHashKey(key, existingField)).expectNext(true).verifyComplete();
+
+		// Test non-existing field
+		StepVerifier.create(reactiveRedisUtils.hasHashKey(key, nonExistingField)).expectNext(false).verifyComplete();
+	}
+
+	@Test
+	@Order(7)
+	@DisplayName("Test hash operations - putAll")
+	void testPutAll() {
+		String key = "test:hash:putall";
+		Map<String, Object> map = new HashMap<>();
+		map.put("field1", "value1");
+		map.put("field2", "value2");
+		map.put("field3", "value3");
+
+		// Put all values
+		StepVerifier.create(reactiveRedisUtils.putAll(key, map)).verifyComplete();
+
+		// Verify all fields exist
+		StepVerifier.create(reactiveRedisUtils.hGet(key, "field1")).expectNext("value1").verifyComplete();
+
+		StepVerifier.create(reactiveRedisUtils.hGet(key, "field2")).expectNext("value2").verifyComplete();
+
+		StepVerifier.create(reactiveRedisUtils.hGet(key, "field3")).expectNext("value3").verifyComplete();
+	}
+
+	@Test
+	@Order(8)
+	@DisplayName("Test hash operations - values")
+	void testValues() {
+		String key = "test:hash:values";
+		Map<String, Object> map = new HashMap<>();
+		map.put("field1", "value1");
+		map.put("field2", "value2");
+		map.put("field3", "value3");
+
+		// Put all values
+		StepVerifier.create(reactiveRedisUtils.putAll(key, map)).verifyComplete();
+
+		// Get all values
+		Flux<@NonNull Object> values = reactiveRedisUtils.values(key);
+
+		// Verify values count
+		StepVerifier.create(values.collectList())
+			.expectNextMatches(list -> list.size() == 3 && list.contains("value1") && list.contains("value2")
+					&& list.contains("value3"))
+			.verifyComplete();
+	}
+
+	@Test
+	@Order(9)
+	@DisplayName("Test hash operations - fastPutIfAbsent")
+	void testFastPutIfAbsent() {
+		String key = "test:hash:putifabsent";
+		String field = "field1";
+		String value1 = "value1";
+		String value2 = "value2";
+
+		// First put should succeed
+		StepVerifier.create(reactiveRedisUtils.fastPutIfAbsent(key, field, value1)).expectNext(true).verifyComplete();
+
+		// Verify the value
+		StepVerifier.create(reactiveRedisUtils.hGet(key, field)).expectNext(value1).verifyComplete();
+
+		// Second put should fail (field already exists)
+		StepVerifier.create(reactiveRedisUtils.fastPutIfAbsent(key, field, value2)).expectNext(false).verifyComplete();
+
+		// Verify the value is still the original
+		StepVerifier.create(reactiveRedisUtils.hGet(key, field)).expectNext(value1).verifyComplete();
+	}
+
+	@Test
+	@Order(10)
+	@DisplayName("Test hash operations - putIfAbsent")
+	void testPutIfAbsent() {
+		String key = "test:hash:putifabsent2";
+		String field = "field1";
+		String value1 = "value1";
+		String value2 = "value2";
+
+		// First put should return null (no previous value)
+		StepVerifier.create(reactiveRedisUtils.putIfAbsent(key, field, value1)).verifyComplete();
+
+		// Verify the value
+		StepVerifier.create(reactiveRedisUtils.hGet(key, field)).expectNext(value1).verifyComplete();
+
+		// Second put should return the existing value
+		StepVerifier.create(reactiveRedisUtils.putIfAbsent(key, field, value2)).expectNext(value1).verifyComplete();
+
+		// Verify the value is still the original
+		StepVerifier.create(reactiveRedisUtils.hGet(key, field)).expectNext(value1).verifyComplete();
+	}
+
+	@Test
+	@Order(11)
+	@DisplayName("Test getMap operation")
+	void testGetMap() {
+		String key = "test:map";
+		String field1 = "field1";
+		String value1 = "value1";
+		String field2 = "field2";
+		String value2 = "value2";
+
+		// Get map and perform operations
+		var map = reactiveRedisUtils.getMap(key);
+
+		// Put values
+		StepVerifier.create(map.put(field1, value1)).verifyComplete();
+
+		StepVerifier.create(map.put(field2, value2)).verifyComplete();
+
+		// Get values
+		StepVerifier.create(map.get(field1)).expectNext(value1).verifyComplete();
+
+		StepVerifier.create(map.get(field2)).expectNext(value2).verifyComplete();
+
+		// Check size
+		StepVerifier.create(map.size()).expectNext(2).verifyComplete();
+	}
+
+	@Test
+	@Order(12)
+	@DisplayName("Test complex object storage")
+	void testComplexObjectStorage() {
+		String key = "test:complex:object";
+		TestObject testObject = new TestObject("test-id", "test-name", 100);
+
+		// Set complex object
+		StepVerifier.create(reactiveRedisUtils.set(key, testObject, -1)).verifyComplete();
+
+		// Get complex object
+		StepVerifier.create(reactiveRedisUtils.get(key)).expectNext(testObject).verifyComplete();
+	}
+
+	@Test
+	@Order(13)
+	@DisplayName("Test delete non-existing key")
+	void testDeleteNonExistingKey() {
+		String key = "test:nonexisting:delete";
+
+		// Delete non-existing key should return 0
+		StepVerifier.create(reactiveRedisUtils.delete(key)).expectNext(0L).verifyComplete();
+	}
+
+	@Test
+	@Order(14)
+	@DisplayName("Test concurrent operations")
+	void testConcurrentOperations() {
+		String key = "test:concurrent";
+
+		// Perform multiple concurrent operations
+		Flux<@NonNull Void> operations = Flux.range(1, 10)
+			.flatMap(i -> reactiveRedisUtils.set(key + ":" + i, "value" + i, -1));
+
+		StepVerifier.create(operations).verifyComplete();
+
+		StepVerifier.create(reactiveRedisUtils.get(key + ":1")).expectNext("value1").verifyComplete();
+
+		// Verify all keys exist
+		Flux<@NonNull Boolean> checks = Flux.range(1, 10).flatMap(i -> reactiveRedisUtils.hasKey(key + ":" + i));
+
+		StepVerifier.create(checks).expectNextCount(10).expectComplete().verify();
+	}
+
+	/**
+	 * Test object for complex object storage testing.
+	 */
+	@Data
+	static class TestObject implements Serializable {
+
+		private String id;
+
+		private String name;
+
+		private Integer value;
+
+		public TestObject(String id, String name, Integer value) {
+			this.id = id;
+			this.name = name;
+			this.value = value;
+		}
+
+	}
+
+}

--- a/laokou-common/laokou-common-redis/src/test/java/org/laokou/common/redis/util/RedisUtilsTest.java
+++ b/laokou-common/laokou-common-redis/src/test/java/org/laokou/common/redis/util/RedisUtilsTest.java
@@ -1,0 +1,1079 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.redis.util;
+
+import com.redis.testcontainers.RedisContainer;
+import lombok.Data;
+import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.laokou.common.redis.config.JacksonCodec;
+import org.laokou.common.testcontainers.util.DockerImageNames;
+import org.redisson.Redisson;
+import org.redisson.api.RLock;
+import org.redisson.api.RateType;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.options.LocalCachedMapOptions;
+import org.redisson.api.options.MapOptions;
+import org.redisson.config.Config;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Comprehensive test cases for {@link RedisUtils} using Testcontainers and JUnit 5. This
+ * test suite covers all methods in RedisUtils with various scenarios.
+ *
+ * @author laokou
+ */
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class RedisUtilsTest {
+
+	@Container
+	static RedisContainer redisContainer = new RedisContainer(DockerImageNames.redis()).withExposedPorts(6379)
+		.withReuse(true);
+
+	private RedisUtils redisUtils;
+
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@BeforeEach
+	void setUp() {
+		String redisHost = redisContainer.getHost();
+		Integer redisPort = redisContainer.getMappedPort(6379);
+
+		// Configure Lettuce Connection Factory
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisConfig);
+		connectionFactory.afterPropertiesSet();
+
+		// Configure RedisTemplate
+		redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		GenericJacksonJsonRedisSerializer genericJacksonJsonRedisSerializer = new GenericJacksonJsonRedisSerializer(
+				new JsonMapper());
+		redisTemplate.setValueSerializer(genericJacksonJsonRedisSerializer);
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(genericJacksonJsonRedisSerializer);
+		redisTemplate.afterPropertiesSet();
+
+		// Configure Redisson
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://" + redisHost + ":" + redisPort);
+		config.setCodec(JacksonCodec.INSTANCE);
+		RedissonClient redissonClient = Redisson.create(config);
+
+		// Create RedisUtils instance
+		redisUtils = new RedisUtils(redisTemplate, redissonClient);
+	}
+
+	@AfterEach
+	void tearDown() {
+		// Clean up all keys after each test
+		if (redisTemplate.getConnectionFactory() != null) {
+			redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+		}
+	}
+
+	// ==================== Basic String Operations ====================
+
+	@Test
+	@Order(1)
+	@DisplayName("Test set and get operations with default expiration")
+	void testSetAndGetWithDefaultExpiration() {
+		String key = "test:key:default";
+		String value = "test-value";
+
+		redisUtils.set(key, value);
+
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isEqualTo(value);
+
+		Long expire = redisUtils.getExpire(key);
+		Assertions.assertThat(expire).isGreaterThan(0).isLessThanOrEqualTo(RedisUtils.DEFAULT_EXPIRE);
+	}
+
+	@Test
+	@Order(2)
+	@DisplayName("Test set and get operations with custom expiration")
+	void testSetAndGetWithCustomExpiration() {
+		String key = "test:key:custom";
+		String value = "custom-value";
+		long expireSeconds = 10;
+
+		redisUtils.set(key, value, expireSeconds);
+
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isEqualTo(value);
+
+		Long expire = redisUtils.getExpire(key);
+		Assertions.assertThat(expire).isGreaterThan(0).isLessThanOrEqualTo(expireSeconds);
+	}
+
+	@Test
+	@Order(3)
+	@DisplayName("Test set with no expiration (NOT_EXPIRE)")
+	void testSetWithNoExpiration() {
+		String key = "test:key:noexpire";
+		String value = "no-expire-value";
+
+		redisUtils.set(key, value, RedisUtils.NOT_EXPIRE);
+
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isEqualTo(value);
+
+		Long expire = redisUtils.getExpire(key);
+		Assertions.assertThat(expire).isEqualTo(-1L);
+	}
+
+	@Test
+	@Order(4)
+	@DisplayName("Test setIfAbsent with default expiration")
+	void testSetIfAbsentWithDefaultExpiration() {
+		String key = "test:key:ifabsent";
+		String value1 = "value1";
+		String value2 = "value2";
+
+		boolean firstSet = redisUtils.setIfAbsent(key, value1);
+		Assertions.assertThat(firstSet).isTrue();
+		Assertions.assertThat(redisUtils.get(key)).isEqualTo(value1);
+
+		boolean secondSet = redisUtils.setIfAbsent(key, value2);
+		Assertions.assertThat(secondSet).isFalse();
+		Assertions.assertThat(redisUtils.get(key)).isEqualTo(value1);
+	}
+
+	@Test
+	@Order(5)
+	@DisplayName("Test setIfAbsent with custom expiration")
+	void testSetIfAbsentWithCustomExpiration() {
+		String key = "test:key:ifabsent:custom";
+		String value = "value";
+		long expireSeconds = 5;
+
+		boolean result = redisUtils.setIfAbsent(key, value, expireSeconds);
+		Assertions.assertThat(result).isTrue();
+
+		Long expire = redisUtils.getExpire(key);
+		Assertions.assertThat(expire).isGreaterThan(0).isLessThanOrEqualTo(expireSeconds);
+	}
+
+	@Test
+	@Order(6)
+	@DisplayName("Test get non-existing key returns null")
+	void testGetNonExistingKey() {
+		String key = "test:key:nonexisting";
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isNull();
+	}
+
+	// ==================== Key Operations ====================
+
+	@Test
+	@Order(7)
+	@DisplayName("Test hasKey operation")
+	void testHasKey() {
+		String existingKey = "test:key:exists";
+		String nonExistingKey = "test:key:notexists";
+
+		redisUtils.set(existingKey, "value");
+
+		Assertions.assertThat(redisUtils.hasKey(existingKey)).isTrue();
+		Assertions.assertThat(redisUtils.hasKey(nonExistingKey)).isFalse();
+	}
+
+	@Test
+	@Order(8)
+	@DisplayName("Test delete single key")
+	void testDeleteSingleKey() {
+		String key = "test:key:delete";
+		redisUtils.set(key, "value");
+
+		Assertions.assertThat(redisUtils.hasKey(key)).isTrue();
+
+		boolean deleted = redisUtils.del(key);
+		Assertions.assertThat(deleted).isTrue();
+		Assertions.assertThat(redisUtils.hasKey(key)).isFalse();
+	}
+
+	@Test
+	@Order(9)
+	@DisplayName("Test delete multiple keys")
+	void testDeleteMultipleKeys() {
+		String key1 = "test:key:delete1";
+		String key2 = "test:key:delete2";
+		String key3 = "test:key:delete3";
+
+		redisUtils.set(key1, "value1");
+		redisUtils.set(key2, "value2");
+		redisUtils.set(key3, "value3");
+
+		boolean deleted = redisUtils.del(key1, key2, key3);
+		Assertions.assertThat(deleted).isTrue();
+		Assertions.assertThat(redisUtils.hasKey(key1)).isFalse();
+		Assertions.assertThat(redisUtils.hasKey(key2)).isFalse();
+		Assertions.assertThat(redisUtils.hasKey(key3)).isFalse();
+	}
+
+	@Test
+	@Order(10)
+	@DisplayName("Test delete non-existing key")
+	void testDeleteNonExistingKey() {
+		String key = "test:key:notexists";
+		boolean deleted = redisUtils.del(key);
+		Assertions.assertThat(deleted).isFalse();
+	}
+
+	@Test
+	@Order(11)
+	@DisplayName("Test keys with pattern")
+	void testKeysWithPattern() {
+		redisUtils.set("user:1", "value1");
+		redisUtils.set("user:2", "value2");
+		redisUtils.set("order:1", "value3");
+
+		Set<String> userKeys = redisUtils.keys("user:*");
+		Assertions.assertThat(userKeys).hasSize(2).contains("user:1", "user:2");
+
+		Set<String> orderKeys = redisUtils.keys("order:*");
+		Assertions.assertThat(orderKeys).hasSize(1).contains("order:1");
+	}
+
+	@Test
+	@Order(12)
+	@DisplayName("Test keys without pattern (all keys)")
+	void testKeysWithoutPattern() {
+		redisUtils.set("key1", "value1");
+		redisUtils.set("key2", "value2");
+		redisUtils.set("key3", "value3");
+
+		Set<String> allKeys = redisUtils.keys();
+		Assertions.assertThat(allKeys).hasSizeGreaterThanOrEqualTo(3).contains("key1", "key2", "key3");
+	}
+
+	@Test
+	@Order(13)
+	@DisplayName("Test getExpire for key")
+	void testGetExpire() {
+		String key = "test:key:expire";
+		long expireSeconds = 100;
+
+		redisUtils.set(key, "value", expireSeconds);
+
+		Long expire = redisUtils.getExpire(key);
+		Assertions.assertThat(expire).isGreaterThan(0).isLessThanOrEqualTo(expireSeconds);
+	}
+
+	@Test
+	@Order(14)
+	@DisplayName("Test getKeysSize")
+	void testGetKeysSize() {
+		// Clear all keys first
+		if (redisTemplate.getConnectionFactory() != null) {
+			redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+		}
+
+		redisUtils.set("key1", "value1");
+		redisUtils.set("key2", "value2");
+		redisUtils.set("key3", "value3");
+
+		long size = redisUtils.getKeysSize();
+		Assertions.assertThat(size).isEqualTo(3);
+	}
+
+	// ==================== Hash Operations ====================
+
+	@Test
+	@Order(15)
+	@DisplayName("Test hSet and hGet single field")
+	void testHSetAndHGet() {
+		String key = "test:hash:single";
+		String field = "field1";
+		String value = "value1";
+
+		redisUtils.hSet(key, field, value);
+
+		Object result = redisUtils.hGet(key, field);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(16)
+	@DisplayName("Test hSet with expiration")
+	void testHSetWithExpiration() {
+		String key = "test:hash:expire";
+		String field = "field1";
+		String value = "value1";
+		long expireSeconds = 10;
+
+		redisUtils.hSet(key, field, value, expireSeconds);
+
+		Object result = redisUtils.hGet(key, field);
+		Assertions.assertThat(result).isEqualTo(value);
+
+		Long expire = redisUtils.getExpire(key);
+		Assertions.assertThat(expire).isLessThanOrEqualTo(expireSeconds);
+	}
+
+	@Test
+	@Order(17)
+	@DisplayName("Test hSet with map")
+	void testHSetWithMap() {
+		String key = "test:hash:map";
+		Map<String, Object> map = new HashMap<>();
+		map.put("field1", "value1");
+		map.put("field2", "value2");
+		map.put("field3", "value3");
+		long expireSeconds = 10;
+
+		redisUtils.hSet(key, map, expireSeconds);
+
+		Assertions.assertThat(redisUtils.hGet(key, "field1")).isEqualTo("value1");
+		Assertions.assertThat(redisUtils.hGet(key, "field2")).isEqualTo("value2");
+		Assertions.assertThat(redisUtils.hGet(key, "field3")).isEqualTo("value3");
+	}
+
+	@Test
+	@Order(18)
+	@DisplayName("Test hSetFast operation")
+	void testHSetFast() {
+		String key = "test:hash:fast";
+		String field = "field1";
+		String value = "value1";
+		long expireSeconds = 10;
+
+		redisUtils.hSetFast(key, field, value, expireSeconds);
+
+		Object result = redisUtils.hGet(key, field);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(19)
+	@DisplayName("Test hSetFastAsync operation")
+	void testHSetFastAsync() throws InterruptedException {
+		String key = "test:hash:fastasync";
+		String field = "field1";
+		String value = "value1";
+		long expireSeconds = 10;
+
+		redisUtils.hSetFastAsync(key, field, value, expireSeconds);
+
+		// Wait a bit for async operation to complete
+		Thread.sleep(100);
+
+		Object result = redisUtils.hGet(key, field);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(20)
+	@DisplayName("Test hSetIfAbsent operation")
+	void testHSetIfAbsent() {
+		String key = "test:hash:ifabsent";
+		String field = "field1";
+		String value1 = "value1";
+		String value2 = "value2";
+		long expireSeconds = 10;
+
+		redisUtils.hSetIfAbsent(key, field, value1, expireSeconds);
+		Assertions.assertThat(redisUtils.hGet(key, field)).isEqualTo(value1);
+
+		redisUtils.hSetIfAbsent(key, field, value2, expireSeconds);
+		Assertions.assertThat(redisUtils.hGet(key, field)).isEqualTo(value1);
+	}
+
+	@Test
+	@Order(21)
+	@DisplayName("Test hSetIfAbsentAsync operation")
+	void testHSetIfAbsentAsync() throws InterruptedException {
+		String key = "test:hash:ifabsentasync";
+		String field = "field1";
+		String value = "value1";
+		long expireSeconds = 10;
+
+		redisUtils.hSetIfAbsentAsync(key, field, value, expireSeconds);
+
+		// Wait a bit for async operation to complete
+		Thread.sleep(100);
+
+		Object result = redisUtils.hGet(key, field);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(22)
+	@DisplayName("Test hSetIfAbsentNative operation")
+	void testHSetIfAbsentNative() {
+		String key = "test:hash:ifabsentnative";
+		String field = "field1";
+		String value1 = "value1";
+		String value2 = "value2";
+
+		redisUtils.hSetIfAbsentNative(key, field, value1);
+		Assertions.assertThat(redisUtils.hGetNative(key, field)).isEqualTo(value1);
+
+		redisUtils.hSetIfAbsentNative(key, field, value2);
+		Assertions.assertThat(redisUtils.hGetNative(key, field)).isEqualTo(value1);
+	}
+
+	@Test
+	@Order(23)
+	@DisplayName("Test hGetNative operation")
+	void testHGetNative() {
+		String key = "test:hash:native";
+		String field = "field1";
+		String value = "value1";
+
+		redisTemplate.opsForHash().put(key, field, value);
+
+		Object result = redisUtils.hGetNative(key, field);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(24)
+	@DisplayName("Test hasHashKey operation")
+	void testHasHashKey() {
+		String key = "test:hash:haskey";
+		String existingField = "field1";
+		String nonExistingField = "field2";
+
+		redisUtils.hSet(key, existingField, "value1");
+
+		Assertions.assertThat(redisUtils.hasHashKey(key, existingField)).isTrue();
+		Assertions.assertThat(redisUtils.hasHashKey(key, nonExistingField)).isFalse();
+	}
+
+	@Test
+	@Order(25)
+	@DisplayName("Test hDel single field")
+	void testHDelSingleField() {
+		String key = "test:hash:delfield";
+		String field = "field1";
+
+		redisUtils.hSet(key, field, "value1");
+		Assertions.assertThat(redisUtils.hasHashKey(key, field)).isTrue();
+
+		redisUtils.hDel(key, field);
+		Assertions.assertThat(redisUtils.hasHashKey(key, field)).isFalse();
+	}
+
+	@Test
+	@Order(26)
+	@DisplayName("Test hDelFast multiple fields")
+	void testHDelFast() {
+		String key = "test:hash:delfast";
+
+		redisUtils.hSet(key, "field1", "value1");
+		redisUtils.hSet(key, "field2", "value2");
+		redisUtils.hSet(key, "field3", "value3");
+
+		redisUtils.hDelFast(key, "field1", "field2");
+
+		Assertions.assertThat(redisUtils.hasHashKey(key, "field1")).isFalse();
+		Assertions.assertThat(redisUtils.hasHashKey(key, "field2")).isFalse();
+		Assertions.assertThat(redisUtils.hasHashKey(key, "field3")).isTrue();
+	}
+
+	@Test
+	@Order(27)
+	@DisplayName("Test hDel entire hash")
+	void testHDelEntireHash() {
+		String key = "test:hash:delall";
+
+		redisUtils.hSet(key, "field1", "value1");
+		redisUtils.hSet(key, "field2", "value2");
+
+		Assertions.assertThat(redisUtils.hasKey(key)).isTrue();
+
+		redisUtils.hDel(key);
+
+		Assertions.assertThat(redisUtils.hasKey(key)).isFalse();
+	}
+
+	// ==================== List Operations ====================
+
+	@Test
+	@Order(28)
+	@DisplayName("Test lSet single object")
+	void testLSetSingleObject() {
+		String key = "test:list:single";
+		String value = "value1";
+		long expireSeconds = 10;
+
+		redisUtils.lSet(key, value, expireSeconds);
+
+		List<Object> result = redisUtils.lGetAll(key);
+		Assertions.assertThat(result).hasSize(1).contains(value);
+	}
+
+	@Test
+	@Order(29)
+	@DisplayName("Test lSet list of objects")
+	void testLSetListOfObjects() {
+		String key = "test:list:multiple";
+		List<Object> values = Arrays.asList("value1", "value2", "value3");
+		long expireSeconds = 10;
+
+		redisUtils.lSet(key, values, expireSeconds);
+
+		List<Object> result = redisUtils.lGetAll(key);
+		Assertions.assertThat(result).hasSize(3).containsExactly("value1", "value2", "value3");
+	}
+
+	@Test
+	@Order(30)
+	@DisplayName("Test lGet by index")
+	void testLGetByIndex() {
+		String key = "test:list:index";
+		List<Object> values = Arrays.asList("value1", "value2", "value3");
+
+		redisUtils.lSet(key, values, 10);
+
+		Assertions.assertThat(redisUtils.lGet(key, 0)).isEqualTo("value1");
+		Assertions.assertThat(redisUtils.lGet(key, 1)).isEqualTo("value2");
+		Assertions.assertThat(redisUtils.lGet(key, 2)).isEqualTo("value3");
+	}
+
+	@Test
+	@Order(31)
+	@DisplayName("Test lSize operation")
+	void testLSize() {
+		String key = "test:list:size";
+		List<Object> values = Arrays.asList("value1", "value2", "value3", "value4");
+
+		redisUtils.lSet(key, values, 10);
+
+		int size = redisUtils.lSize(key);
+		Assertions.assertThat(size).isEqualTo(4);
+	}
+
+	@Test
+	@Order(32)
+	@DisplayName("Test lTrim operation")
+	void testLTrim() {
+		String key = "test:list:trim";
+		List<Object> values = Arrays.asList("value1", "value2", "value3", "value4", "value5");
+
+		redisUtils.lSet(key, values, 10);
+
+		redisUtils.lTrim(key, 1, 3);
+
+		List<Object> result = redisUtils.lGetAll(key);
+		Assertions.assertThat(result).hasSize(3).containsExactly("value2", "value3", "value4");
+	}
+
+	@Test
+	@Order(33)
+	@DisplayName("Test lGetAll operation")
+	void testLGetAll() {
+		String key = "test:list:getall";
+		List<Object> values = Arrays.asList("value1", "value2", "value3");
+
+		redisUtils.lSet(key, values, 10);
+
+		List<Object> result = redisUtils.lGetAll(key);
+		Assertions.assertThat(result).isEqualTo(values);
+	}
+
+	// ==================== Atomic Operations ====================
+
+	@Test
+	@Order(34)
+	@DisplayName("Test incrementAndGet operation")
+	void testIncrementAndGet() {
+		String key = "test:atomic:increment";
+
+		long result1 = redisUtils.incrementAndGet(key);
+		Assertions.assertThat(result1).isEqualTo(1);
+
+		long result2 = redisUtils.incrementAndGet(key);
+		Assertions.assertThat(result2).isEqualTo(2);
+
+		long result3 = redisUtils.incrementAndGet(key);
+		Assertions.assertThat(result3).isEqualTo(3);
+	}
+
+	@Test
+	@Order(35)
+	@DisplayName("Test decrementAndGet operation")
+	void testDecrementAndGet() {
+		String key = "test:atomic:decrement";
+
+		long result1 = redisUtils.decrementAndGet(key);
+		Assertions.assertThat(result1).isEqualTo(-1);
+
+		long result2 = redisUtils.decrementAndGet(key);
+		Assertions.assertThat(result2).isEqualTo(-2);
+
+		long result3 = redisUtils.decrementAndGet(key);
+		Assertions.assertThat(result3).isEqualTo(-3);
+	}
+
+	@Test
+	@Order(36)
+	@DisplayName("Test addAndGet operation")
+	void testAddAndGet() {
+		String key = "test:atomic:add";
+
+		long result1 = redisUtils.addAndGet(key, 10);
+		Assertions.assertThat(result1).isEqualTo(10);
+
+		long result2 = redisUtils.addAndGet(key, 5);
+		Assertions.assertThat(result2).isEqualTo(15);
+
+		long result3 = redisUtils.addAndGet(key, -3);
+		Assertions.assertThat(result3).isEqualTo(12);
+	}
+
+	@Test
+	@Order(37)
+	@DisplayName("Test getAtomicValue operation")
+	void testGetAtomicValue() {
+		String key = "test:atomic:value";
+
+		redisUtils.addAndGet(key, 100);
+
+		long value = redisUtils.getAtomicValue(key);
+		Assertions.assertThat(value).isEqualTo(100);
+	}
+
+	// ==================== Lock Operations ====================
+
+	@Test
+	@Order(38)
+	@DisplayName("Test getLock and lock/unlock operations")
+	void testGetLockAndLockUnlock() {
+		String key = "test:lock:basic";
+
+		RLock lock = redisUtils.getLock(key);
+		Assertions.assertThat(lock).isNotNull();
+
+		redisUtils.lock(lock);
+		Assertions.assertThat(redisUtils.isLocked(lock)).isTrue();
+		Assertions.assertThat(redisUtils.isHeldByCurrentThread(lock)).isTrue();
+
+		redisUtils.unlock(lock);
+		Assertions.assertThat(redisUtils.isLocked(lock)).isFalse();
+	}
+
+	@Test
+	@Order(39)
+	@DisplayName("Test lock and unlock with key")
+	void testLockAndUnlockWithKey() {
+		String key = "test:lock:key";
+
+		redisUtils.lock(key);
+		Assertions.assertThat(redisUtils.isLocked(key)).isTrue();
+
+		redisUtils.unlock(key);
+		Assertions.assertThat(redisUtils.isLocked(key)).isFalse();
+	}
+
+	@Test
+	@Order(40)
+	@DisplayName("Test tryLock operation")
+	void testTryLock() throws InterruptedException {
+		String key = "test:lock:try";
+
+		RLock lock = redisUtils.getLock(key);
+
+		boolean acquired = redisUtils.tryLock(lock, 1000);
+		Assertions.assertThat(acquired).isTrue();
+		Assertions.assertThat(redisUtils.isLocked(lock)).isTrue();
+
+		redisUtils.unlock(lock);
+	}
+
+	@Test
+	@Order(41)
+	@DisplayName("Test getFencedLock operation")
+	void testGetFencedLock() {
+		String key = "test:lock:fenced";
+
+		RLock lock = redisUtils.getFencedLock(key);
+		Assertions.assertThat(lock).isNotNull();
+
+		redisUtils.lock(lock);
+		Assertions.assertThat(redisUtils.isLocked(lock)).isTrue();
+
+		redisUtils.unlock(lock);
+	}
+
+	@Test
+	@Order(42)
+	@DisplayName("Test getFairLock operation")
+	void testGetFairLock() {
+		String key = "test:lock:fair";
+
+		RLock lock = redisUtils.getFairLock(key);
+		Assertions.assertThat(lock).isNotNull();
+
+		redisUtils.lock(lock);
+		Assertions.assertThat(redisUtils.isLocked(lock)).isTrue();
+
+		redisUtils.unlock(lock);
+	}
+
+	@Test
+	@Order(43)
+	@DisplayName("Test getReadLock operation")
+	void testGetReadLock() {
+		String key = "test:lock:read";
+
+		RLock readLock = redisUtils.getReadLock(key);
+		Assertions.assertThat(readLock).isNotNull();
+
+		redisUtils.lock(readLock);
+		Assertions.assertThat(redisUtils.isLocked(readLock)).isTrue();
+
+		redisUtils.unlock(readLock);
+	}
+
+	@Test
+	@Order(44)
+	@DisplayName("Test getWriteLock operation")
+	void testGetWriteLock() {
+		String key = "test:lock:write";
+
+		RLock writeLock = redisUtils.getWriteLock(key);
+		Assertions.assertThat(writeLock).isNotNull();
+
+		redisUtils.lock(writeLock);
+		Assertions.assertThat(redisUtils.isLocked(writeLock)).isTrue();
+
+		redisUtils.unlock(writeLock);
+	}
+
+	@Test
+	@Order(45)
+	@DisplayName("Test concurrent lock acquisition")
+	void testConcurrentLockAcquisition() {
+		String key = "test:lock:concurrent";
+		int threadCount = 5;
+		AtomicInteger successCount = new AtomicInteger(0);
+		for (int i = 0; i < threadCount; i++) {
+			CompletableFuture.runAsync(() -> {
+				try {
+					RLock lock = redisUtils.getLock(key);
+					if (redisUtils.tryLock(lock, 100)) {
+						try {
+							successCount.incrementAndGet();
+							Thread.sleep(50);
+						}
+						finally {
+							redisUtils.unlock(lock);
+						}
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			}).join();
+		}
+		Assertions.assertThat(successCount.get()).isGreaterThan(0);
+	}
+
+	// ==================== Rate Limiter Operations ====================
+
+	@Test
+	@Order(46)
+	@DisplayName("Test rateLimiter operation")
+	void testRateLimiter() {
+		String key = "test:ratelimiter";
+		long replenishRate = 5;
+		Duration rateInterval = Duration.ofSeconds(1);
+		Duration ttlInterval = Duration.ofSeconds(10);
+
+		// First few requests should succeed
+		for (int i = 0; i < replenishRate; i++) {
+			boolean allowed = redisUtils.rateLimiter(key, RateType.OVERALL, replenishRate, rateInterval, ttlInterval);
+			Assertions.assertThat(allowed).isTrue();
+		}
+
+		// Next request should fail (rate limit exceeded)
+		boolean allowed = redisUtils.rateLimiter(key, RateType.OVERALL, replenishRate, rateInterval, ttlInterval);
+		Assertions.assertThat(allowed).isFalse();
+	}
+
+	// ==================== Map Cache Operations ====================
+
+	@Test
+	@Order(47)
+	@DisplayName("Test getMapCacheNative operation")
+	void testGetMapCacheNative() {
+		MapOptions<String, String> options = MapOptions.name("test:mapcache");
+
+		var mapCache = redisUtils.getMapCacheNative(options);
+		Assertions.assertThat(mapCache).isNotNull();
+
+		mapCache.put("key1", "value1");
+		Assertions.assertThat(mapCache.get("key1")).isEqualTo("value1");
+	}
+
+	@Test
+	@Order(48)
+	@DisplayName("Test getLocalCachedMap operation")
+	void testGetLocalCachedMap() {
+		LocalCachedMapOptions<String, String> options = LocalCachedMapOptions.name("test:localcache");
+
+		var localCachedMap = redisUtils.getLocalCachedMap(options);
+		Assertions.assertThat(localCachedMap).isNotNull();
+
+		localCachedMap.put("key1", "value1");
+		Assertions.assertThat(localCachedMap.get("key1")).isEqualTo("value1");
+	}
+
+	// ==================== Redis Info Operations ====================
+
+	@Test
+	@Order(49)
+	@DisplayName("Test getInfo operation")
+	void testGetInfo() {
+		Map<String, String> info = redisUtils.getInfo();
+		Assertions.assertThat(info).isNotNull().isNotEmpty();
+		Assertions.assertThat(info).containsKey("redis_version");
+	}
+
+	@Test
+	@Order(50)
+	@DisplayName("Test getCommandStatus operation")
+	void testGetCommandStatus() {
+		// Execute some commands first
+		redisUtils.set("test:key", "value");
+		redisUtils.get("test:key");
+
+		List<Map<String, String>> commandStatus = redisUtils.getCommandStatus();
+		Assertions.assertThat(commandStatus).isNotNull().isNotEmpty();
+	}
+
+	// ==================== Script Execution ====================
+
+	@Test
+	@Order(51)
+	@DisplayName("Test execute Redis script with string length")
+	void testExecuteScript() {
+		String key = "test:script:key";
+		String value = "test-value";
+
+		// Set a value first
+		redisUtils.set(key, value);
+
+		// Lua script to get string length (returns a number, not "OK")
+		String scriptText = "return redis.call('strlen', KEYS[1])";
+		DefaultRedisScript<@NonNull Long> script = new DefaultRedisScript<>(scriptText, Long.class);
+
+		Long result = redisUtils.execute(script, Collections.singletonList(key));
+		Assertions.assertThat(result).isGreaterThan(0L);
+	}
+
+	@Test
+	@Order(52)
+	@DisplayName("Test execute Redis script with numeric result")
+	void testExecuteScriptWithNumericResult() {
+		String key = "test:script:counter";
+
+		// Initialize counter
+		redisUtils.set(key, 0);
+
+		// Lua script to increment
+		String scriptText = "return redis.call('incr', KEYS[1])";
+		DefaultRedisScript<@NonNull Long> script = new DefaultRedisScript<>(scriptText, Long.class);
+
+		Long result = redisUtils.execute(script, Collections.singletonList(key));
+		Assertions.assertThat(result).isEqualTo(1L);
+	}
+
+	// ==================== Complex Object Storage ====================
+
+	@Test
+	@Order(53)
+	@DisplayName("Test complex object storage and retrieval")
+	void testComplexObjectStorage() {
+		String key = "test:object:complex";
+		TestUser user = new TestUser("user123", "John Doe", 30, "john@example.com");
+
+		redisUtils.set(key, user);
+
+		Object result = redisUtils.get(key);
+		// Note: Without type information in Jackson config, objects are deserialized as
+		// LinkedHashMap
+		Assertions.assertThat(result).isInstanceOf(Map.class);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> retrievedUser = (Map<String, Object>) result;
+		Assertions.assertThat(retrievedUser.get("id")).isEqualTo(user.getId());
+		Assertions.assertThat(retrievedUser.get("name")).isEqualTo(user.getName());
+		Assertions.assertThat(retrievedUser.get("age")).isEqualTo(user.getAge());
+		Assertions.assertThat(retrievedUser.get("email")).isEqualTo(user.getEmail());
+	}
+
+	@Test
+	@Order(54)
+	@DisplayName("Test complex object in hash")
+	void testComplexObjectInHash() {
+		String key = "test:hash:object";
+		String field = "user1";
+		TestUser user = new TestUser("user456", "Jane Smith", 25, "jane@example.com");
+
+		redisUtils.hSet(key, field, user);
+
+		Object result = redisUtils.hGet(key, field);
+		// Note: Without type information in Jackson config, objects are deserialized as
+		// LinkedHashMap
+		Assertions.assertThat(result).isInstanceOf(Map.class);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> retrievedUser = (Map<String, Object>) result;
+		Assertions.assertThat(retrievedUser.get("id")).isEqualTo(user.getId());
+		Assertions.assertThat(retrievedUser.get("name")).isEqualTo(user.getName());
+	}
+
+	@Test
+	@Order(55)
+	@DisplayName("Test complex object in list")
+	void testComplexObjectInList() {
+		String key = "test:list:object";
+		TestUser user1 = new TestUser("user1", "Alice", 28, "alice@example.com");
+		TestUser user2 = new TestUser("user2", "Bob", 32, "bob@example.com");
+
+		List<Object> users = Arrays.asList(user1, user2);
+		redisUtils.lSet(key, users, 10);
+
+		List<Object> result = redisUtils.lGetAll(key);
+		Assertions.assertThat(result).hasSize(2);
+		// Note: Without type information in Jackson config, objects are deserialized as
+		// LinkedHashMap
+		Assertions.assertThat(result.get(0)).isInstanceOf(Map.class);
+		Assertions.assertThat(result.get(1)).isInstanceOf(Map.class);
+	}
+
+	// ==================== Edge Cases and Error Scenarios ====================
+
+	@Test
+	@Order(56)
+	@DisplayName("Test null value handling")
+	void testNullValueHandling() {
+		String key = "test:null:value";
+
+		redisUtils.set(key, null);
+
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	@Order(57)
+	@DisplayName("Test empty string handling")
+	void testEmptyStringHandling() {
+		String key = "test:empty:string";
+		String value = "";
+
+		redisUtils.set(key, value);
+
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(58)
+	@DisplayName("Test large value storage")
+	void testLargeValueStorage() {
+		String key = "test:large:value";
+		StringBuilder largeValue = new StringBuilder();
+		largeValue.append("This is a test string. ".repeat(10000));
+		redisUtils.set(key, largeValue.toString());
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isEqualTo(largeValue.toString());
+	}
+
+	@Test
+	@Order(59)
+	@DisplayName("Test special characters in key")
+	void testSpecialCharactersInKey() {
+		String key = "test:special:key:with:colons:and-dashes_and_underscores";
+		String value = "special-value";
+
+		redisUtils.set(key, value);
+
+		Object result = redisUtils.get(key);
+		Assertions.assertThat(result).isEqualTo(value);
+	}
+
+	@Test
+	@Order(60)
+	@DisplayName("Test expiration constants")
+	void testExpirationConstants() {
+		Assertions.assertThat(RedisUtils.DEFAULT_EXPIRE).isEqualTo(60 * 60 * 24);
+		Assertions.assertThat(RedisUtils.ONE_HOUR_EXPIRE).isEqualTo(60 * 60);
+		Assertions.assertThat(RedisUtils.FIVE_MINUTE_EXPIRE).isEqualTo(5 * 60);
+		Assertions.assertThat(RedisUtils.NOT_EXPIRE).isEqualTo(-1L);
+	}
+
+	// ==================== Test Helper Classes ====================
+
+	/**
+	 * Test user object for complex object storage testing.
+	 */
+	@Data
+	static class TestUser implements Serializable {
+
+		private String id;
+
+		private String name;
+
+		private Integer age;
+
+		private String email;
+
+		public TestUser(String id, String name, Integer age, String email) {
+			this.id = id;
+			this.name = name;
+			this.age = age;
+			this.email = email;
+		}
+
+	}
+
+}

--- a/laokou-common/laokou-common-secret/src/main/java/org/laokou/common/secret/util/SecretUtils.java
+++ b/laokou-common/laokou-common-secret/src/main/java/org/laokou/common/secret/util/SecretUtils.java
@@ -17,7 +17,7 @@
 
 package org.laokou.common.secret.util;
 
-import org.springframework.util.DigestUtils;
+import org.laokou.common.core.util.DigestUtils;
 
 import java.nio.charset.StandardCharsets;
 
@@ -49,7 +49,7 @@ public final class SecretUtils {
 	 */
 	public static String sign(String appKey, String appSecret, String nonce, String timestamp, String params) {
 		String str = appKey.concat(appSecret).concat(nonce).concat(timestamp).concat(params);
-		return DigestUtils.md5DigestAsHex(str.getBytes(StandardCharsets.UTF_8));
+		return new String(DigestUtils.digest(str.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 	}
 
 }

--- a/laokou-common/laokou-common-testcontainers/pom.xml
+++ b/laokou-common/laokou-common-testcontainers/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>testcontainers-postgresql</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.redis</groupId>
+      <artifactId>testcontainers-redis</artifactId>
+      <version>2.2.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-elasticsearch</artifactId>
       <exclusions>

--- a/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java
+++ b/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java
@@ -29,6 +29,14 @@ public final class DockerImageNames {
 	private DockerImageNames() {
 	}
 
+	public static DockerImageName redis() {
+		return redis(LATEST);
+	}
+
+	public static DockerImageName redis(String tag) {
+		return DockerImageName.parse("redis").withTag(tag);
+	}
+
 	public static DockerImageName elasticsearch(String tag) {
 		return DockerImageName.parse("koushenhai/elasticsearch9")
 			.asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch")


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `DigestUtils` utility class supporting SHA-512 and other digest algorithms

- Refactor Redisson configuration with comprehensive YAML properties support

- Rename `CodecEnum` to `CodecTypeEnum` and add `LoadBalancerTypeEnum`, `NodeTypeEnum`

- Create extensive test suites for Redis operations with Testcontainers

- Update code style: rename `IP_REGION` to `ipRegion` following camelCase convention


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DigestUtils<br/>SHA-512 Support"] --> B["Redisson Config<br/>Refactoring"]
  B --> C["SpringRedissonProperties<br/>YAML Configuration"]
  C --> D["NodeTypeEnum<br/>LoadBalancerTypeEnum"]
  E["Redis Test Suite<br/>Testcontainers"] --> F["RedisUtilsTest<br/>ReactiveRedisUtilsTest"]
  G["Code Style<br/>Improvements"] --> H["IP_REGION to ipRegion<br/>camelCase"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>DigestUtils.java</strong><dd><code>New digest utility class with SHA-512 support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-2680e46650a5d7d3a0ad730f316f8b9aa3d95b992e4f5209f130527d65b910c8">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CodecTypeEnum.java</strong><dd><code>Rename CodecEnum to CodecTypeEnum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-4adf1a441ce5eba230e332ff79a4abf5ed654b9826fe9ecaa2dfa85987086b9d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoadBalancerTypeEnum.java</strong><dd><code>New enum for Redis load balancer types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-102e77345eeaca602bd33d894f285d6c69c5411f228de68a81c34df77994b634">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeTypeEnum.java</strong><dd><code>New enum supporting multiple Redis node types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-61c6b3df6a4ae91de38e3b25f1984b03f79ddb49588c040fa9712766525eace0">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SpringRedissonProperties.java</strong><dd><code>Comprehensive YAML configuration for Redisson</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-58d023dadf35469058c43c62f3bdc32d40325f484b67ea1ca8421ead24b530d7">+261/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RedissonAutoConfig.java</strong><dd><code>Simplify auto-config using SpringRedissonProperties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-245126256ac78e0ee77de94e499f5ef794e8dac36d035bb6c0042a943b4f1254">+3/-66</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ForyRedisSerializer.java</strong><dd><code>Switch from MD5 to SHA-512 digest serializer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-5f33b55a9cae1a9e8c567e2ba63ab59a10766c0feed83b6f1f6a5bd52834b977">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Sha512DigestStringRedisSerializer.java</strong><dd><code>Rename and update to use custom DigestUtils</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-317cb895f6b8140fba9eac5e07a793b52eff5b103c59e0791a3e8c6fb7c6a68d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JacksonCodec.java</strong><dd><code>Change visibility from package-private to public</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-c277915308e14198bb216a62ddffaced5ecd079ac335e54c18aa00e278f1d39f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SecretUtils.java</strong><dd><code>Update to use custom DigestUtils instead of Spring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-9b93e3a2e4fd509dc60f87d80749020180b76f86fdfb0d5abd33eddeea4892a5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DockerImageNames.java</strong><dd><code>Add Redis Docker image helper methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-5c7d5619ee29ca0cb399a15c32daed137a50e24f344779289600c752dbd9985a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>DigestUtilsTest.java</strong><dd><code>Comprehensive test cases for DigestUtils</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-3cf0ca29fd19bf1b5450a2e90b50fd069b3ea81c8de97111f467b327823ff5b1">+192/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RedisUtilsTest.java</strong><dd><code>Comprehensive Redis operations test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-00e5612f957a4e74b642760fbb064d1538603c160b8dc49211ab401c98fa903a">+1079/-0</a></td>

</tr>

<tr>
  <td><strong>ReactiveRedisUtilsTest.java</strong><dd><code>Reactive Redis operations test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-7394ddb73fb70a49b2cd738683e9d55c82a271f884e712f59b9c6cfe7390e315">+391/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AddressUtils.java</strong><dd><code>Rename IP_REGION to ipRegion for code style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-91918e90634fb8b45f635e9b53ededea5d10ba11987dee0b0074898529b83d4a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pom.xml</strong><dd><code>Add test dependencies for Testcontainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-2f65681bb0151dc2c27bf2f5177a187f5be18dda519be64a9c032c72902aabe8">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pom.xml</strong><dd><code>Add Redis Testcontainers dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-4668960e7b298784b411fe18d9055c9d700265f61228a84584fcce1ffe77be68">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>maven.yml</strong><dd><code>Include Redis module in code coverage reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5426/files#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

引入了新的摘要（digest）工具，并将与 Redis 相关的组件迁移为使用该工具，同时重构 Redisson 配置并新增了完善的 Redis 测试支持。

增强内容：
- 新增核心 `DigestUtils` 帮助类，支持 SHA-512 等算法，并将其接入 Redis 以及密钥（secret）相关工具中。
- 重构 Redisson 自动配置，以使用更丰富的 `SpringRedissonProperties` 模型，并支持可插拔的节点类型和负载均衡器类型。
- 暴露公共的 `JacksonCodec`，并扩展 `DockerImageNames`，添加 Redis 容器辅助工具以供共享使用。
- 统一 IP 区域工具的命名为 camelCase，并将 Redis 编解码器枚举重命名为 `CodecTypeEnum`。

构建（Build）：
- 在 Redis 模块的 Maven 配置中添加通用测试依赖和 Redis Testcontainers 依赖。

CI：
- 在 Maven GitHub Actions 的覆盖率上传中包含 Redis 模块的 Jacoco 报告。

测试（Tests）：
- 新增全面的 `DigestUtilsTest` 测试套件，覆盖多种算法和边界情况。
- 创建基于 Testcontainers Redis 的大规模 `RedisUtils` 和 `ReactiveRedisUtils` 集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new digest utility and migrate Redis-related components to use it while overhauling Redisson configuration and adding extensive Redis testing support.

Enhancements:
- Add a core DigestUtils helper with SHA-512 and other algorithm support and wire it into Redis and secret utilities.
- Refactor Redisson auto-configuration to use a rich SpringRedissonProperties model with pluggable node and load balancer types.
- Expose a public JacksonCodec and extend DockerImageNames with Redis container helpers for shared usage.
- Standardize IP region utility naming to camelCase and rename the Redis codec enum to CodecTypeEnum.

Build:
- Add common test and Redis Testcontainers dependencies to the Redis modules' Maven configuration.

CI:
- Include the Redis module's Jacoco report in the Maven GitHub Actions coverage upload.

Tests:
- Add a comprehensive DigestUtilsTest suite for multiple algorithms and edge cases.
- Create extensive RedisUtils and ReactiveRedisUtils integration tests backed by Testcontainers Redis.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added digest hashing utility supporting SHA-512, SHA-256, and MD5 algorithms
  * Enhanced Redis configuration supporting Single, Cluster, and Sentinel deployment modes
  * New load balancer type configurations for Redis
  * Added Docker image helpers for containerized testing

* **Refactor**
  * Improved enum naming for better clarity
  * Simplified Redis client initialization logic
  * Updated digest algorithm for serialization

* **Tests**
  * Comprehensive test suites for Redis utilities and digest operations
  * Container-based integration testing for Redis functionality

* **Chores**
  * Added testcontainers dependencies for Redis testing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->