### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/Sha512DigestStringRedisSerializer.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/Sha512DigestStringRedisSerializer.java
@@ -21,8 +21,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.laokou.common.core.util.DigestUtils;
 import org.laokou.common.fory.config.ForyFactory;
+import org.laokou.common.i18n.util.StringExtUtils;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.util.Assert;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -39,7 +39,9 @@ public class Sha512DigestStringRedisSerializer extends StringRedisSerializer {
 	@NotNull
 	@Override
 	public byte[] serialize(@Nullable String key) {
-		Assert.notNull(key, "Cannot serialize null");
+		if (StringExtUtils.isEmpty(key)) {
+			return new byte[0];
+		}
 		return ForyFactory.INSTANCE.serialize(DigestUtils.digest(key.getBytes(StandardCharsets.UTF_8)));
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <!--spotbugs-maven-plugin版本-->
     <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     <!--native-maven-plugin版本-->
-    <native-maven-plugin.version>0.11.3</native-maven-plugin.version>
+    <native-maven-plugin.version>0.11.2</native-maven-plugin.version>
     <!--versions-maven-plugin版本-->
     <versions-maven-plugin.version>2.20.1</versions-maven-plugin.version>
     <!--asciidoctor-maven-plugin版本-->


### PR DESCRIPTION
## Summary by Sourcery

在自定义序列化器中优雅地处理空的 Redis key，并调整原生 Maven 插件版本。

Bug 修复：
- 当尝试序列化空的 Redis key 字符串时，不再抛出错误，而是返回一个空的字节数组。

构建：
- 在父 POM 中将 `native-maven-plugin` 的版本从 0.11.3 降级到 0.11.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty Redis keys gracefully in custom serializer and adjust native Maven plugin version.

Bug Fixes:
- Return an empty byte array instead of failing when attempting to serialize an empty Redis key string.

Build:
- Downgrade the native-maven-plugin version from 0.11.3 to 0.11.2 in the parent POM.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for empty or null input in serialization operations.

* **Chores**
  * Updated Maven plugin dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->