### PR TITLE
fix: 修复grpc测试用例报错【nacos改为consul】

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -74,6 +74,7 @@ jobs:
             ./laokou-common/laokou-common-mybatis-plus/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-starrocks/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-ftp/target/site/jacoco/jacoco.xml,
+            ./laokou-common/laokou-common-grpc/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-redis/target/site/jacoco/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build the Docker image

--- a/laokou-common/laokou-common-grpc/pom.xml
+++ b/laokou-common/laokou-common-grpc/pom.xml
@@ -15,8 +15,16 @@
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
-      <artifactId>laokou-common-nacos</artifactId>
+      <artifactId>laokou-common-core</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.grpc</groupId>
@@ -48,9 +56,21 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-consul-discovery</artifactId>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jetty</artifactId>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-grpc/src/test/resources/application.yml
+++ b/laokou-common/laokou-common-grpc/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8975
+  port: 8979
 spring:
   application:
     name: laokou-common-grpc
@@ -14,30 +14,3 @@ spring:
            address: discovery://laokou-common-grpc
            enable-keep-alive: true
            idle-timeout: 60s
-  config:
-    import:
-      # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】
-      - optional:nacos:laokou-common-grpc.yaml?refreshEnabled=true&group=DEFAULT_GROUP
-  cloud:
-    nacos:
-      config:
-        enabled: true
-        server-addr: 127.0.0.1:8848
-        username: nacos
-        password: nacos
-        namespace: public
-        group: DEFAULT_GROUP
-        import-check:
-          enabled: false
-      discovery:
-        enabled: true
-        server-addr: 127.0.0.1:8848
-        username: nacos
-        password: nacos
-        namespace: public
-        group: DEFAULT_GROUP
-        metadata:
-          grpc_port: 9097
-      username: nacos
-      password: nacos
-      server-addr: 127.0.0.1:8848

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java
@@ -21,14 +21,14 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.nacos.util.ConfigUtils;
 import org.laokou.common.testcontainers.container.NacosContainer;
 import org.laokou.common.testcontainers.util.DockerImageNames;
 import org.springframework.util.DigestUtils;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
 import java.util.Properties;
@@ -36,21 +36,13 @@ import java.util.Properties;
 /**
  * @author laokou
  */
+@Testcontainers
 class ConfigUtilsTest {
 
 	private ConfigService configService;
 
+	@Container
 	static final NacosContainer nacos = new NacosContainer(DockerImageNames.nacos("v3.1.0"), 38848, 39848);
-
-	@BeforeAll
-	static void beforeAll() {
-		nacos.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		nacos.stop();
-	}
 
 	@BeforeEach
 	void setUp() throws NacosException {

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
@@ -24,13 +24,13 @@ import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.selector.NamingSelector;
 import com.alibaba.nacos.client.naming.selector.NamingSelectorFactory;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.nacos.util.NamingUtils;
 import org.laokou.common.testcontainers.container.NacosContainer;
 import org.laokou.common.testcontainers.util.DockerImageNames;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -40,22 +40,14 @@ import java.util.Properties;
 /**
  * @author laokou
  */
+@Testcontainers
 // @formatter:off
 class NamingUtilsTest {
 
 	private NamingService namingService;
 
+	@Container
 	static final NacosContainer nacos = new NacosContainer(DockerImageNames.nacos("v3.1.0"), 18848,  19848);
-
-	@BeforeAll
-	static void beforeAll() {
-		nacos.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		nacos.stop();
-	}
 
 	@BeforeEach
 	void setUp()throws NacosException {

--- a/laokou-common/laokou-common-testcontainers/pom.xml
+++ b/laokou-common/laokou-common-testcontainers/pom.xml
@@ -51,6 +51,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>consul</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
       <version>${project.version}</version>

--- a/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java
+++ b/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java
@@ -29,6 +29,10 @@ public final class DockerImageNames {
 	private DockerImageNames() {
 	}
 
+	public static DockerImageName consul() {
+		return DockerImageName.parse("consul").withTag("1.14");
+	}
+
 	public static DockerImageName redis() {
 		return redis(LATEST);
 	}


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace Nacos with Consul for service discovery in gRPC tests

- Refactor test setup using Testcontainers annotations instead of manual lifecycle management

- Update gRPC module dependencies to support Consul discovery

- Add Consul Docker image utility and update CI/CD coverage reporting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Nacos-based Discovery"] -->|"Replace with"| B["Consul-based Discovery"]
  C["Manual Test Lifecycle"] -->|"Refactor to"| D["@Testcontainers Annotations"]
  E["Nacos Dependency"] -->|"Change to"| F["Consul Dependency"]
  B --> G["Updated Test Configuration"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcClientTest.java</strong><dd><code>Migrate gRPC test from Nacos to Consul discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcClientTest.java

<ul><li>Replaced NacosContainer with ConsulContainer for service discovery<br> <li> Converted manual @BeforeAll/@AfterAll lifecycle methods to <br>@Testcontainers annotation<br> <li> Updated DynamicPropertySource to configure Consul properties instead <br>of Nacos<br> <li> Removed unused imports and main method from nested GrpcTest class</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-490f991dffb51741edb237191ed52e34984e2af03cc30dc58e36507f6542dd19">+16/-34</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConfigUtilsTest.java</strong><dd><code>Refactor ConfigUtilsTest to use Testcontainers annotations</code></dd></summary>
<hr>

laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/ConfigUtilsTest.java

<ul><li>Added @Testcontainers annotation to class<br> <li> Converted NacosContainer from manual lifecycle to @Container <br>annotation<br> <li> Removed @BeforeAll and @AfterAll methods</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-c9a615779646e2b0d070c4d9ade3b71677308ff6a5c8212d5c20a2f27f4f24d6">+4/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NamingUtilsTest.java</strong><dd><code>Refactor NamingUtilsTest to use Testcontainers annotations</code></dd></summary>
<hr>

laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java

<ul><li>Added @Testcontainers annotation to class<br> <li> Converted NacosContainer from manual lifecycle to @Container <br>annotation<br> <li> Removed @BeforeAll and @AfterAll methods</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-5b1ecb5a9d0a74e059f23d65515b76c0218bd3957b137edbfc1f2e4cf098b9d5">+4/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DockerImageNames.java</strong><dd><code>Add Consul Docker image utility method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java

<ul><li>Added new <code>consul()</code> method to provide Consul Docker image configuration<br> <li> Returns DockerImageName for Consul version 1.14</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-5c7d5619ee29ca0cb399a15c32daed137a50e24f344779289600c752dbd9985a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update gRPC module dependencies for Consul support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/pom.xml

<ul><li>Changed dependency from <code>laokou-common-nacos</code> to <code>laokou-common-core</code><br> <li> Added <code>spring-cloud-starter</code> and <code>spring-cloud-commons</code> dependencies<br> <li> Added <code>spring-cloud-starter-consul-discovery</code> for test scope<br> <li> Added <code>spring-boot-starter-jetty</code> for test scope</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-b93f7f1efce77d2306197ab4cfd4536ff94338c2256c7fab4ae9517ac0c2c4b4">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Add Consul testcontainers dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/pom.xml

<ul><li>Added <code>org.testcontainers:consul</code> dependency for Consul container <br>support</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-4668960e7b298784b411fe18d9055c9d700265f61228a84584fcce1ffe77be68">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application.yml</strong><dd><code>Remove Nacos config and update server port</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/resources/application.yml

<ul><li>Changed server port from 8975 to 8979<br> <li> Removed all Nacos configuration (config import, cloud.nacos settings)<br> <li> Kept gRPC server and client configuration intact</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-eb2fa4f9af46e7db20ad17c57b9f210cce63475d885b98e37938922df38270d9">+1/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>maven.yml</strong><dd><code>Include gRPC module in code coverage reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven.yml

- Added gRPC module jacoco coverage report path to codecov upload


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5441/files#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced test infrastructure with improved Testcontainers integration for better local testing capabilities.
  * Updated service discovery configuration for testing environments.
  * Improved CI/CD pipeline for more comprehensive code coverage reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->