### PR TITLE
Dev

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,6 +72,6 @@ jobs:
         </settings>
         EOF
     - name: Build with Maven
-      run: mvn clean package -P dev -DskipTests
+      run: mvn clean package -P dev -DskipTests -U
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.31.9

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,7 @@ jobs:
           </settings>
           EOF
       - name: Build with Maven Mvnd
-        run: mvnd clean install -P dev
+        run: mvnd clean install -P dev -U
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.5.2
         env:

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessorTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.annotation;
+
+import lombok.Getter;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.grpc.client.GrpcClientFactory;
+
+/**
+ * @author laokou
+ */
+class GrpcClientBeanPostProcessorTest {
+
+	private GrpcClientBeanPostProcessor postProcessor;
+
+	private final String mockClient = "mockClient";
+
+	@BeforeEach
+	void setUp() {
+		GrpcClientFactory grpcClientFactory = Mockito.mock(GrpcClientFactory.class);
+		DiscoveryClient discoveryClient = Mockito.mock(DiscoveryClient.class);
+		postProcessor = new GrpcClientBeanPostProcessor(grpcClientFactory, discoveryClient);
+
+		Mockito
+			.when(grpcClientFactory.getClient(ArgumentMatchers.eq("discovery://laokou-auth"),
+					ArgumentMatchers.eq(String.class), ArgumentMatchers.any()))
+			.thenReturn(mockClient);
+	}
+
+	@Test
+	void testFieldInjection() {
+		FieldBean bean = new FieldBean();
+		postProcessor.postProcessBeforeInitialization(bean, "fieldBean");
+		Assertions.assertThat(bean.getClient()).isEqualTo(mockClient);
+	}
+
+	@Test
+	void testMethodInjection() {
+		MethodBean bean = new MethodBean();
+		postProcessor.postProcessBeforeInitialization(bean, "methodBean");
+		Assertions.assertThat(bean.getClient()).isEqualTo(mockClient);
+	}
+
+	@Test
+	void testSuperclassInjection() {
+		SubBean bean = new SubBean();
+		postProcessor.postProcessBeforeInitialization(bean, "subBean");
+		Assertions.assertThat(bean.getClient()).isEqualTo(mockClient);
+	}
+
+	@Getter
+	static class FieldBean {
+
+		@GrpcClient(serviceId = "laokou-auth")
+		private String client;
+
+	}
+
+	@Getter
+	static class MethodBean {
+
+		private String client;
+
+		@GrpcClient(serviceId = "laokou-auth")
+		public void setClient(String client) {
+			this.client = client;
+		}
+
+	}
+
+	@Getter
+	static class BaseBean {
+
+		@GrpcClient(serviceId = "laokou-auth")
+		protected String client;
+
+	}
+
+	static class SubBean extends BaseBean {
+
+	}
+
+}

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryGrpcChannelFactoryTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryGrpcChannelFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.config;
+
+import io.grpc.ChannelCredentials;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.netty.NettyChannelBuilder;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.grpc.client.ClientInterceptorsConfigurer;
+
+import java.util.Collections;
+
+/**
+ * @author laokou
+ */
+class DiscoveryGrpcChannelFactoryTest {
+
+	private DiscoveryGrpcChannelFactory factory;
+
+	@BeforeEach
+	void setUp() {
+		ClientInterceptorsConfigurer configurer = Mockito.mock(ClientInterceptorsConfigurer.class);
+		factory = new DiscoveryGrpcChannelFactory(Collections.emptyList(), configurer);
+	}
+
+	@Test
+	void testSupports() {
+		Assertions.assertThat(factory.supports("discovery:laokou-auth")).isTrue();
+		Assertions.assertThat(factory.supports("static:localhost")).isFalse();
+		Assertions.assertThat(factory.supports("dns:localhost")).isFalse();
+	}
+
+	@Test
+	void testNewChannelBuilder() {
+		String target = "laokou-auth";
+		ChannelCredentials credentials = InsecureChannelCredentials.create();
+		NettyChannelBuilder builder = factory.newChannelBuilder(target, credentials);
+		Assertions.assertThat(builder).isNotNull();
+	}
+
+}

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverProviderTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverProviderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.config;
+
+import io.grpc.NameResolver;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * @author laokou
+ */
+class DiscoveryNameResolverProviderTest {
+
+	private DiscoveryNameResolverProvider provider;
+
+	@BeforeEach
+	void setUp() {
+		DiscoveryClient discoveryClient = Mockito.mock(DiscoveryClient.class);
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		provider = new DiscoveryNameResolverProvider(discoveryClient, executorService);
+	}
+
+	@Test
+	void testIsAvailable() {
+		Assertions.assertThat(provider.isAvailable()).isTrue();
+	}
+
+	@Test
+	void testPriority() {
+		Assertions.assertThat(provider.priority()).isEqualTo(6);
+	}
+
+	@Test
+	void testGetDefaultScheme() {
+		Assertions.assertThat(provider.getDefaultScheme()).isEqualTo("discovery");
+	}
+
+	@Test
+	void testNewNameResolver() {
+		URI uri = URI.create("discovery://laokou-auth");
+		NameResolver.Args args = Mockito.mock(NameResolver.Args.class);
+		Mockito.when(args.getServiceConfigParser()).thenReturn(Mockito.mock(NameResolver.ServiceConfigParser.class));
+
+		NameResolver resolver = provider.newNameResolver(uri, args);
+		Assertions.assertThat(resolver).isExactlyInstanceOf(DiscoveryNameResolver.class);
+		Assertions.assertThat(resolver.getServiceAuthority()).isEqualTo("laokou-auth");
+	}
+
+	@Test
+	void testOnHeartbeatEvent() {
+		URI uri = URI.create("discovery://laokou-auth");
+		NameResolver.Args args = Mockito.mock(NameResolver.Args.class);
+		Mockito.when(args.getServiceConfigParser()).thenReturn(Mockito.mock(NameResolver.ServiceConfigParser.class));
+
+		// Register a resolver
+		provider.newNameResolver(uri, args);
+
+		HeartbeatEvent event = new HeartbeatEvent(new Object(), "test");
+		provider.onHeartbeatEvent(event);
+
+		// verify triggers discoveryClient.getInstances eventually
+		// Since we can't easily poll the internal state of the resolver, we verify that
+		// it doesn't crash
+		// and we've invoked the event handler.
+	}
+
+}

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.config;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * @author laokou
+ */
+class DiscoveryNameResolverTest {
+
+	private DiscoveryClient discoveryClient;
+
+	private NameResolver.Listener2 listener;
+
+	private DiscoveryNameResolver resolver;
+
+	private final String serviceId = "laokou-auth";
+
+	@BeforeEach
+	void setUp() {
+		discoveryClient = Mockito.mock(DiscoveryClient.class);
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		NameResolver.Args args = Mockito.mock(NameResolver.Args.class);
+		listener = Mockito.mock(NameResolver.Listener2.class);
+
+		Mockito.when(args.getServiceConfigParser()).thenReturn(Mockito.mock(NameResolver.ServiceConfigParser.class));
+
+		resolver = new DiscoveryNameResolver(serviceId, discoveryClient, executorService, args);
+	}
+
+	@Test
+	void testGetServiceAuthority() {
+		Assertions.assertThat(resolver.getServiceAuthority()).isEqualTo(serviceId);
+	}
+
+	@Test
+	void testStartAndResolve() throws InterruptedException {
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("grpc_port", "9091");
+		ServiceInstance instance = new DefaultServiceInstance(serviceId + "-1", serviceId, "localhost", 9090, false,
+				metadata);
+		Mockito.when(discoveryClient.getInstances(serviceId)).thenReturn(List.of(instance));
+
+		resolver.start(listener);
+
+		// Wait for async execution
+		Thread.sleep(200);
+
+		ArgumentCaptor<NameResolver.ResolutionResult> resultCaptor = ArgumentCaptor
+			.forClass(NameResolver.ResolutionResult.class);
+		Mockito.verify(listener).onResult(resultCaptor.capture());
+
+		NameResolver.ResolutionResult result = resultCaptor.getValue();
+		List<EquivalentAddressGroup> list = result.getAddressesOrError().getValue();
+		Assertions.assertThat(list).hasSize(1);
+		Assertions.assertThat(list.getFirst().getAddresses().getFirst().toString()).contains("9091");
+	}
+
+	@Test
+	void testResolveNoInstances() throws InterruptedException {
+		Mockito.when(discoveryClient.getInstances(serviceId)).thenReturn(Collections.emptyList());
+
+		resolver.start(listener);
+
+		// Wait for async execution
+		Thread.sleep(200);
+
+		Mockito.verify(listener).onError(Mockito.any());
+	}
+
+	@Test
+	void testRefresh() throws InterruptedException {
+		Mockito.when(discoveryClient.getInstances(serviceId)).thenReturn(Collections.emptyList());
+		resolver.start(listener);
+		Thread.sleep(100);
+
+		resolver.refresh();
+		Thread.sleep(100);
+
+		// verify called twice (start and refresh)
+		Mockito.verify(discoveryClient, Mockito.times(2)).getInstances(serviceId);
+	}
+
+	@Test
+	void testRefreshFromExternal() throws InterruptedException {
+		Mockito.when(discoveryClient.getInstances(serviceId)).thenReturn(Collections.emptyList());
+		resolver.start(listener);
+		Thread.sleep(100);
+
+		resolver.refreshFromExternal();
+		Thread.sleep(100);
+
+		Mockito.verify(discoveryClient, Mockito.times(2)).getInstances(serviceId);
+	}
+
+}


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add comprehensive gRPC test suite with four test classes

- Test GrpcClientBeanPostProcessor for field, method, and superclass injection

- Test DiscoveryGrpcChannelFactory scheme support and channel builder creation

- Test DiscoveryNameResolverProvider availability, priority, and name resolver creation

- Test DiscoveryNameResolver service resolution, instance discovery, and refresh functionality

- Add Maven dependency update flag (-U) to CI/CD workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] --> B["GrpcClientBeanPostProcessor"]
  A --> C["DiscoveryGrpcChannelFactory"]
  A --> D["DiscoveryNameResolverProvider"]
  A --> E["DiscoveryNameResolver"]
  B --> B1["Field Injection"]
  B --> B2["Method Injection"]
  B --> B3["Superclass Injection"]
  C --> C1["Scheme Support"]
  C --> C2["Channel Builder"]
  D --> D1["Availability & Priority"]
  D --> D2["Name Resolver Creation"]
  E --> E1["Service Resolution"]
  E --> E2["Instance Discovery"]
  E --> E3["Refresh Functionality"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcClientBeanPostProcessorTest.java</strong><dd><code>GrpcClientBeanPostProcessor injection tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessorTest.java

<ul><li>New test class for GrpcClientBeanPostProcessor with 103 lines<br> <li> Tests field injection, method injection, and superclass field <br>injection scenarios<br> <li> Uses Mockito to mock GrpcClientFactory and DiscoveryClient <br>dependencies<br> <li> Verifies that @GrpcClient annotation correctly injects gRPC client <br>instances</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5444/files#diff-84ec3f7bb1cd9f98ade8136fb2c6d57fe84cd7cfa7a71b7beb87f5f2c2826b27">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryGrpcChannelFactoryTest.java</strong><dd><code>DiscoveryGrpcChannelFactory scheme and builder tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryGrpcChannelFactoryTest.java

<ul><li>New test class for DiscoveryGrpcChannelFactory with 59 lines<br> <li> Tests scheme support validation for discovery, static, and dns schemes<br> <li> Tests NettyChannelBuilder creation with InsecureChannelCredentials<br> <li> Mocks ClientInterceptorsConfigurer dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5444/files#diff-7f3dbb1def2e881e382ff16361b2473a31932e93507ed48b324f83621673a0fa">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryNameResolverProviderTest.java</strong><dd><code>DiscoveryNameResolverProvider availability and resolver tests</code></dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverProviderTest.java

<ul><li>New test class for DiscoveryNameResolverProvider with 90 lines<br> <li> Tests availability, priority level (6), and default scheme (discovery)<br> <li> Tests NameResolver creation from URI and HeartbeatEvent handling<br> <li> Verifies resolver instantiation and service authority extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5444/files#diff-b3f3aa821cd17baa751a76fa643aa14200bb7a831b59a50e92ff3a95857a3f83">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryNameResolverTest.java</strong><dd><code>DiscoveryNameResolver resolution and refresh tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverTest.java

<ul><li>New test class for DiscoveryNameResolver with 128 lines<br> <li> Tests service authority retrieval and async name resolution with <br>service instances<br> <li> Tests error handling when no instances are discovered<br> <li> Tests refresh and refreshFromExternal methods for resolver updates</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5444/files#diff-831a39a7ee8b5e694dadd588cca3947055ed91dff3ee3f1386ac73ff570fd661">+128/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codeql.yml</strong><dd><code>Add Maven dependency update flag to CodeQL workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/codeql.yml

<ul><li>Add Maven dependency update flag (-U) to build command<br> <li> Changes from <code>mvn clean package -P dev -DskipTests</code> to <code>mvn clean package </code><br><code>-P dev -DskipTests -U</code><br> <li> Ensures latest dependencies are fetched during CodeQL analysis</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5444/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>maven.yml</strong><dd><code>Add Maven dependency update flag to Maven workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven.yml

<ul><li>Add Maven dependency update flag (-U) to build command<br> <li> Changes from <code>mvnd clean install -P dev</code> to <code>mvnd clean install -P dev -U</code><br> <li> Ensures latest dependencies are fetched during Maven build</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5444/files#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

添加全面的 gRPC 发现与客户端注入测试套件，并更新 Maven 构建工作流，以在 CI 构建期间刷新依赖。

CI：
- 更新 CodeQL 工作流中的 Maven 构建命令，使用 `-U` 参数以便在分析期间刷新依赖。
- 更新 Maven 工作流（`mvnd`）构建命令，包含 `-U` 参数以始终获取最新依赖。

Tests：
- 为 `GrpcClientBeanPostProcessor` 添加测试，覆盖字段、方法以及父类中 `@GrpcClient` 注入的场景。
- 为 `DiscoveryGrpcChannelFactory` 添加测试，覆盖对受支持发现 scheme 的检测以及 Netty 通道构建器的创建。
- 为 `DiscoveryNameResolverProvider` 添加测试，覆盖可用性、优先级、默认 scheme、名称解析器创建以及心跳处理。
- 为 `DiscoveryNameResolver` 添加测试，覆盖服务 authority、成功与失败的解析以及刷新行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a comprehensive gRPC discovery and client injection test suite and update Maven build workflows to refresh dependencies during CI builds.

CI:
- Update CodeQL workflow Maven build to use the -U flag so dependencies are refreshed during analysis.
- Update Maven workflow (mvnd) build command to include the -U flag to always fetch latest dependencies.

Tests:
- Add tests for GrpcClientBeanPostProcessor covering field, method, and superclass @GrpcClient injection scenarios.
- Add tests for DiscoveryGrpcChannelFactory covering supported discovery scheme detection and Netty channel builder creation.
- Add tests for DiscoveryNameResolverProvider covering availability, priority, default scheme, name resolver creation, and heartbeat handling.
- Add tests for DiscoveryNameResolver covering service authority, successful and failing resolution, and refresh behavior.

</details>

CI：
- 更新 CodeQL 和 Maven 工作流，在运行 Maven 构建时使用 `-U` 参数以刷新依赖。

测试：
- 为 `GrpcClientBeanPostProcessor` 添加测试，覆盖字段、方法以及父类上的 `@GrpcClient` 注入。
- 为 `DiscoveryGrpcChannelFactory` 添加测试，用于验证支持的 scheme 以及 channel builder 的创建。
- 为 `DiscoveryNameResolverProvider` 添加测试，覆盖可用性、优先级、scheme、名称解析器创建以及心跳处理。
- 为 `DiscoveryNameResolver` 添加测试，覆盖服务 authority、解析成功与失败场景，以及刷新行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加全面的 gRPC 发现与客户端注入测试套件，并更新 Maven 构建工作流，以在 CI 构建期间刷新依赖。

CI：
- 更新 CodeQL 工作流中的 Maven 构建命令，使用 `-U` 参数以便在分析期间刷新依赖。
- 更新 Maven 工作流（`mvnd`）构建命令，包含 `-U` 参数以始终获取最新依赖。

Tests：
- 为 `GrpcClientBeanPostProcessor` 添加测试，覆盖字段、方法以及父类中 `@GrpcClient` 注入的场景。
- 为 `DiscoveryGrpcChannelFactory` 添加测试，覆盖对受支持发现 scheme 的检测以及 Netty 通道构建器的创建。
- 为 `DiscoveryNameResolverProvider` 添加测试，覆盖可用性、优先级、默认 scheme、名称解析器创建以及心跳处理。
- 为 `DiscoveryNameResolver` 添加测试，覆盖服务 authority、成功与失败的解析以及刷新行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a comprehensive gRPC discovery and client injection test suite and update Maven build workflows to refresh dependencies during CI builds.

CI:
- Update CodeQL workflow Maven build to use the -U flag so dependencies are refreshed during analysis.
- Update Maven workflow (mvnd) build command to include the -U flag to always fetch latest dependencies.

Tests:
- Add tests for GrpcClientBeanPostProcessor covering field, method, and superclass @GrpcClient injection scenarios.
- Add tests for DiscoveryGrpcChannelFactory covering supported discovery scheme detection and Netty channel builder creation.
- Add tests for DiscoveryNameResolverProvider covering availability, priority, default scheme, name resolver creation, and heartbeat handling.
- Add tests for DiscoveryNameResolver covering service authority, successful and failing resolution, and refresh behavior.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build workflows to refresh dependencies during pipeline execution.

* **Tests**
  * Added comprehensive unit test coverage for gRPC client bean injection, channel factory creation, and service discovery resolver functionality to improve code reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->