### PR TITLE
Dev

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.laokou</groupId>
+  <artifactId>gateway</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>gateway</name>
+
+  <properties>
+    <quarkus.version>3.15.1</quarkus.version>
+    <vertx.version>5.0.6</vertx.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-dependencies</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+quarkus:
+  application:
+    name: gateway

--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
@@ -21,7 +21,6 @@ import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
-import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.i18n.util.SslUtils;
 import org.laokou.gateway.repository.NacosRouteDefinitionRepository;
 import org.springframework.boot.CommandLineRunner;
@@ -57,6 +56,8 @@ class GatewayApp implements CommandLineRunner {
 
 	private final NacosRouteDefinitionRepository nacosRouteDefinitionRepository;
 
+	private final ExecutorService virtualThreadExecutor;
+
 	// @formatter:off
 	static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
 		StopWatch stopWatch = new StopWatch("Gateway应用程序");
@@ -81,11 +82,9 @@ class GatewayApp implements CommandLineRunner {
 	@Override
 	public void run(@NotNull String... args) {
 		// 执行同步路由任务
-		try (ExecutorService virtualThreadExecutor = ThreadUtils.newVirtualTaskExecutor()){
-			virtualThreadExecutor.execute(() -> nacosRouteDefinitionRepository.syncRouter()
-				.subscribeOn(Schedulers.boundedElastic())
-				.subscribe());
-		}
+		virtualThreadExecutor.execute(() -> nacosRouteDefinitionRepository.syncRouter()
+			.subscribeOn(Schedulers.boundedElastic())
+			.subscribe());
 	}
 	// @formatter:on
 

--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/repository/NacosRouteDefinitionRepository.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/repository/NacosRouteDefinitionRepository.java
@@ -25,7 +25,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.fory.config.ForyFactory;
 import org.laokou.common.i18n.common.constant.StringConstants;
 import org.laokou.common.i18n.common.exception.SystemException;
@@ -81,13 +80,13 @@ public class NacosRouteDefinitionRepository implements RouteDefinitionRepository
 
 	private final ExecutorService virtualThreadExecutor;
 
-	public NacosRouteDefinitionRepository(NacosConfigManager nacosConfigManager,
-			ReactiveRedisUtils reactiveRedisUtils) {
+	public NacosRouteDefinitionRepository(NacosConfigManager nacosConfigManager, ReactiveRedisUtils reactiveRedisUtils,
+			ExecutorService virtualThreadExecutor) {
 		this.dataId = "router.json";
 		this.group = nacosConfigManager.getNacosConfigProperties().getGroup();
 		this.configService = nacosConfigManager.getConfigService();
 		this.reactiveMap = reactiveRedisUtils.getMap(RedisKeyUtils.getRouteDefinitionHashKey());
-		this.virtualThreadExecutor = ThreadUtils.newVirtualTaskExecutor();
+		this.virtualThreadExecutor = virtualThreadExecutor;
 	}
 
 	@PostConstruct

--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/repository/handler/UnsubscribeEventHandler.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/repository/handler/UnsubscribeEventHandler.java
@@ -31,7 +31,7 @@ import java.time.Duration;
 @Component
 public class UnsubscribeEventHandler {
 
-	@Async
+	@Async("virtualThreadExecutor")
 	@EventListener
 	public void onUnsubscribeEvent(NacosRouteDefinitionRepository.UnsubscribeEvent evt) throws InterruptedException {
 		Thread.sleep(Duration.ofSeconds(90));

--- a/laokou-common/laokou-common-core/pom.xml
+++ b/laokou-common/laokou-common-core/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>laokou-common-core</artifactId>
   <version>4.0.1-SNAPSHOT</version>
   <name>laokou-common-core</name>
-  <description>一个企业级微服务架构的云服务多租户IoT平台</description>
+  <description>一个企业级微服务架构的云服务多租户IoT平台【核心模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>
   <developers>
     <developer>
@@ -44,7 +44,7 @@
     </developer>
   </developers>
   <scm>
-    <tag>kcloud-platform-iot-4.0.0.RELEASE</tag>
+    <tag>kcloud-platform-iot-4.0.1.RELEASE</tag>
     <url>https://github.com/KouShenhai/KCloud-Platform-IoT</url>
     <connection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</connection>
     <developerConnection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</developerConnection>

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/AsyncConfig.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/AsyncConfig.java
@@ -19,12 +19,12 @@ package org.laokou.common.core.config;
 
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
-import org.laokou.common.core.util.ThreadUtils;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * @author laokou
@@ -34,10 +34,12 @@ import java.util.concurrent.Executor;
 @RequiredArgsConstructor
 public class AsyncConfig implements AsyncConfigurer {
 
+	private final ExecutorService virtualThreadExecutor;
+
 	@Nullable
 	@Override
 	public Executor getAsyncExecutor() {
-		return ThreadUtils.newVirtualTaskExecutor();
+		return virtualThreadExecutor;
 	}
 
 }

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/SpringTaskExecutorConfig.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/SpringTaskExecutorConfig.java
@@ -18,12 +18,14 @@
 package org.laokou.common.core.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.laokou.common.core.util.ThreadUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.time.Duration;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * 异步配置.
@@ -33,6 +35,11 @@ import java.util.concurrent.Executor;
 @Slf4j
 @Configuration
 class SpringTaskExecutorConfig {
+
+	@Bean(name = "virtualThreadExecutor", destroyMethod = "close")
+	public ExecutorService virtualThreadExecutor() {
+		return ThreadUtils.newVirtualTaskExecutor();
+	}
 
 	@Bean
 	public Executor bootstrapExecutor() {

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/GrpcClientConfig.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/GrpcClientConfig.java
@@ -20,7 +20,6 @@ package org.laokou.common.grpc.config;
 import io.grpc.NameResolverRegistry;
 import io.grpc.netty.NettyChannelBuilder;
 import org.jspecify.annotations.NonNull;
-import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.grpc.annotation.GrpcClientBeanPostProcessor;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +29,7 @@ import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
 import org.springframework.grpc.client.GrpcClientFactory;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 /**
  * @author laokou
@@ -39,9 +39,9 @@ public class GrpcClientConfig {
 
 	@Bean
 	GrpcClientBeanPostProcessor grpcClientBeanPostProcessor(GrpcClientFactory grpcClientFactory,
-			DiscoveryClient discoveryClient) {
+			DiscoveryClient discoveryClient, ExecutorService virtualThreadExecutor) {
 		NameResolverRegistry.getDefaultRegistry()
-			.register(new DiscoveryNameResolverProvider(discoveryClient, ThreadUtils.newVirtualTaskExecutor()));
+			.register(new DiscoveryNameResolverProvider(discoveryClient, virtualThreadExecutor));
 		return new GrpcClientBeanPostProcessor(grpcClientFactory, discoveryClient);
 	}
 

--- a/laokou-common/laokou-common-i18n/pom.xml
+++ b/laokou-common/laokou-common-i18n/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>laokou-common-i18n</artifactId>
   <version>4.0.1-SNAPSHOT</version>
   <name>laokou-common-i18n</name>
-  <description>一个企业级微服务架构的云服务多租户IoT平台</description>
+  <description>一个企业级微服务架构的云服务多租户IoT平台【I18N国际化模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>
   <developers>
     <developer>
@@ -44,7 +44,7 @@
     </developer>
   </developers>
   <scm>
-    <tag>kcloud-platform-iot-4.0.0.RELEASE</tag>
+    <tag>kcloud-platform-iot-4.0.1.RELEASE</tag>
     <url>https://github.com/KouShenhai/KCloud-Platform-IoT</url>
     <connection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</connection>
     <developerConnection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</developerConnection>
@@ -57,7 +57,6 @@
       <comments>A business-friendly OSS license</comments>
     </license>
   </licenses>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/RedissonAutoConfig.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/RedissonAutoConfig.java
@@ -25,6 +25,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * @author livk
  * @author laokou
@@ -40,8 +42,9 @@ public class RedissonAutoConfig {
 	 * @return RedissonClient
 	 */
 	@Bean(name = "redisClient", destroyMethod = "shutdown")
-	public RedissonClient redisClient(SpringRedissonProperties springRedissonProperties) {
-		return Redisson.create(springRedissonProperties.getConfig());
+	public RedissonClient redisClient(SpringRedissonProperties springRedissonProperties,
+			ExecutorService virtualThreadExecutor) {
+		return Redisson.create(springRedissonProperties.getConfig(virtualThreadExecutor));
 	}
 
 }

--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/SpringRedissonProperties.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/config/SpringRedissonProperties.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -344,8 +345,8 @@ public class SpringRedissonProperties implements InitializingBean {
 
 	}
 
-	public Config getConfig() {
-		return this.node.type.getConfig(this);
+	public Config getConfig(ExecutorService virtualThreadExecutor) {
+		return this.node.type.getConfig(virtualThreadExecutor, this);
 	}
 
 }

--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/WebSocketServerConfig.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/WebSocketServerConfig.java
@@ -21,10 +21,11 @@ import com.alibaba.cloud.nacos.ConditionalOnNacosDiscoveryEnabled;
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.NacosServiceManager;
 import io.netty.channel.ChannelHandler;
-import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.security.config.OAuth2OpaqueTokenIntrospector;
 import org.springframework.boot.web.server.autoconfigure.ServerProperties;
 import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.ExecutorService;
 
 // @formatter:off
 /**
@@ -33,8 +34,8 @@ import org.springframework.context.annotation.Bean;
 public class WebSocketServerConfig {
 
     @Bean(name = "webSocketServer", initMethod = "start", destroyMethod = "stop")
-	public Server webSocketServer(ChannelHandler webSocketServerChannelInitializer, SpringWebSocketServerProperties springWebSocketServerProperties) {
-		return new WebSocketServer(webSocketServerChannelInitializer, springWebSocketServerProperties, ThreadUtils.newVirtualTaskExecutor());
+	public Server webSocketServer(ChannelHandler webSocketServerChannelInitializer, SpringWebSocketServerProperties springWebSocketServerProperties , ExecutorService virtualThreadExecutor) {
+		return new WebSocketServer(webSocketServerChannelInitializer, springWebSocketServerProperties, virtualThreadExecutor);
     }
 
 	@Bean("webSocketServerChannelInitializer")

--- a/laokou-common/pom.xml
+++ b/laokou-common/pom.xml
@@ -31,7 +31,7 @@
   <version>4.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>laokou-common</name>
-  <description>一个企业级微服务架构的云服务多租户IoT平台</description>
+  <description>一个企业级微服务架构的云服务多租户IoT平台【公共模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>
   <developers>
     <developer>
@@ -46,7 +46,7 @@
     </developer>
   </developers>
   <scm>
-    <tag>kcloud-platform-iot-4.0.0.RELEASE</tag>
+    <tag>kcloud-platform-iot-4.0.1.RELEASE</tag>
     <url>https://github.com/KouShenhai/KCloud-Platform-IoT</url>
     <connection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</connection>
     <developerConnection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</developerConnection>

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/CaptchaSendCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/CaptchaSendCmdExe.java
@@ -38,7 +38,7 @@ public class CaptchaSendCmdExe {
 
 	private final DomainEventPublisher kafkaDomainEventPublisher;
 
-	@Async
+	@Async("virtualThreadExecutor")
 	@CommandLog
 	public void executeVoid(CaptchaSendCmd cmd) {
 		CaptchaCO co = cmd.getCo();

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/LoginLogSaveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/LoginLogSaveCmdExe.java
@@ -39,7 +39,7 @@ public class LoginLogSaveCmdExe {
 
 	private final TransactionalUtils transactionalUtils;
 
-	@Async
+	@Async("virtualThreadExecutor")
 	@CommandLog
 	public void executeVoid(LoginLogSaveCmd cmd) {
 		try {

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/NoticeLogSaveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/NoticeLogSaveCmdExe.java
@@ -40,7 +40,7 @@ public class NoticeLogSaveCmdExe {
 
 	private final TransactionalUtils transactionalUtils;
 
-	@Async
+	@Async("virtualThreadExecutor")
 	@CommandLog
 	public void executeVoid(NoticeLogSaveCmd cmd) {
 		NoticeLogCO co = cmd.getCo();

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
@@ -56,7 +56,7 @@ public class TokenRemoveCmdExe {
 	 * 执行退出登录.
 	 * @param cmd 退出登录参数
 	 */
-	@Async
+	@Async("virtualThreadExecutor")
 	@CommandLog
 	public void executeVoid(TokenRemoveCmd cmd) {
 		String token = cmd.getToken();

--- a/laokou-service/laokou-generator/laokou-generator-start/src/test/java/org/laokou/generator/TableTest.java
+++ b/laokou-service/laokou-generator/laokou-generator-start/src/test/java/org/laokou/generator/TableTest.java
@@ -20,7 +20,6 @@ package org.laokou.generator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.i18n.util.JacksonUtils;
 import org.laokou.generator.ability.GeneratorDomainService;
 import org.laokou.generator.gatewayimpl.database.TableColumnMapper;
@@ -35,6 +34,7 @@ import org.springframework.test.context.TestConstructor;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * @author laokou
@@ -50,6 +50,8 @@ class TableTest {
 	private final TableColumnMapper tableColumnMapper;
 
 	private final GeneratorDomainService generatorDomainService;
+
+	private final ExecutorService virtualThreadExecutor;
 
 	@Test
 	void test_table() {
@@ -170,7 +172,7 @@ class TableTest {
 			// 已注释代码生成【跑CI已注释】
 			// 已注释代码生成【跑CI已注释】
 			// generatorDomainService.generateCode(generatorA);
-		}, ThreadUtils.newVirtualTaskExecutor())).forEach(CompletableFuture::join);
+		}, virtualThreadExecutor)).forEach(CompletableFuture::join);
 	}
 
 }

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/config/StorageConfig.java
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/src/main/java/org/laokou/logstash/config/StorageConfig.java
@@ -17,7 +17,6 @@
 
 package org.laokou.logstash.config;
 
-import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.elasticsearch.template.ElasticsearchDocumentTemplate;
 import org.laokou.common.elasticsearch.template.ElasticsearchIndexTemplate;
 import org.laokou.logstash.support.TraceLogElasticsearchStorage;
@@ -28,6 +27,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * @author laokou
  */
@@ -37,9 +38,9 @@ public class StorageConfig {
 	@Bean("traceLogStorage")
 	@ConditionalOnProperty(prefix = "storage", matchIfMissing = true, name = "type", havingValue = "ELASTICSEARCH")
 	public TraceLogStorage traceLogElasticsearchStorage(ElasticsearchDocumentTemplate elasticsearchDocumentTemplate,
-			ElasticsearchIndexTemplate elasticsearchIndexTemplate) {
+			ElasticsearchIndexTemplate elasticsearchIndexTemplate, ExecutorService virtualThreadExecutor) {
 		return new TraceLogElasticsearchStorage(elasticsearchDocumentTemplate, elasticsearchIndexTemplate,
-				ThreadUtils.newVirtualTaskExecutor());
+				virtualThreadExecutor);
 	}
 
 	@Bean("traceLogStorage")

--- a/laokou-service/laokou-oss/laokou-oss-app/src/main/java/org/laokou/oss/command/OssLogSaveCmdExe.java
+++ b/laokou-service/laokou-oss/laokou-oss-app/src/main/java/org/laokou/oss/command/OssLogSaveCmdExe.java
@@ -41,7 +41,7 @@ public class OssLogSaveCmdExe {
 
 	private final TransactionalUtils transactionalUtils;
 
-	@Async
+	@Async("virtualThreadExecutor")
 	@CommandLog
 	public void executeVoid(OssLogSaveCmd cmd) {
 		try {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor virtual thread executor to use Spring bean dependency injection

- Remove direct ThreadUtils.newVirtualTaskExecutor() calls throughout codebase

- Create centralized ExecutorService bean in SpringTaskExecutorConfig

- Update @Async annotations to reference virtualThreadExecutor bean explicitly

- Add Quarkus-based edge gateway module with basic configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ThreadUtils.newVirtualTaskExecutor()"] -->|Replaced with| B["Spring Bean: virtualThreadExecutor"]
  B -->|Injected into| C["AsyncConfig"]
  B -->|Injected into| D["GatewayApp"]
  B -->|Injected into| E["NacosRouteDefinitionRepository"]
  B -->|Injected into| F["RedissonAutoConfig"]
  B -->|Injected into| G["WebSocketServerConfig"]
  B -->|Injected into| H["Multiple @Async methods"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>SpringTaskExecutorConfig.java</strong><dd><code>Add virtualThreadExecutor bean factory method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-5a173b2742e2242d8f6349ca0fa802d34eea2bfc250c7061dd85f10cfeb2315f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AsyncConfig.java</strong><dd><code>Inject virtualThreadExecutor bean instead of creating locally</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-7353c80007daec9cdac0aa2d14798c12ca37cb1c060d84f6d8ebef869610c5ea">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GatewayApp.java</strong><dd><code>Inject virtualThreadExecutor and remove try-with-resources</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-a18d4e0c7ed68eec3b814b446ce6e8cebd9f80081fb29d33f28492ecd3f71339">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NacosRouteDefinitionRepository.java</strong><dd><code>Inject virtualThreadExecutor via constructor parameter</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-b947eef8181a3e827b90dddf5e8e47d9bc43a0955b5d1f34900fbe346c2175b0">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UnsubscribeEventHandler.java</strong><dd><code>Update @Async to reference virtualThreadExecutor bean</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-44b902a0a9189688f77c28342f4c03aa7e6cb42edd9c5ae3638a0153fef09c6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeTypeEnum.java</strong><dd><code>Pass virtualThreadExecutor parameter through config methods</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-61c6b3df6a4ae91de38e3b25f1984b03f79ddb49588c040fa9712766525eace0">+25/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RedissonAutoConfig.java</strong><dd><code>Inject virtualThreadExecutor into redisClient bean</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-245126256ac78e0ee77de94e499f5ef794e8dac36d035bb6c0042a943b4f1254">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SpringRedissonProperties.java</strong><dd><code>Update getConfig method signature to accept ExecutorService</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-58d023dadf35469058c43c62f3bdc32d40325f484b67ea1ca8421ead24b530d7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GrpcClientConfig.java</strong><dd><code>Inject virtualThreadExecutor into gRPC client configuration</code></dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-4b7766b0f6c68b40c4b48fa23b94c589c707cfc81aa3a6a6828b48ba9e8c1c34">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WebSocketServerConfig.java</strong><dd><code>Inject virtualThreadExecutor into WebSocket server bean</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-62a37a5ca28162a546898851997e572f97cc6a97644554d960d568992e4175c9">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CaptchaSendCmdExe.java</strong><dd><code>Update @Async to reference virtualThreadExecutor bean</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-3c375f06fa660e969308c3819a388963e2dcf2bcbd5129b6c9400f8611916171">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoginLogSaveCmdExe.java</strong><dd><code>Update @Async to reference virtualThreadExecutor bean</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-ee0ec6bf2aee52140e775b7a2d54380d77dbbb23875afea6eb6ff21826466af8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NoticeLogSaveCmdExe.java</strong><dd><code>Update @Async to reference virtualThreadExecutor bean</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-1505ecc383dbb88eabba136ccbf947cdd2a719cde77425db582108d73626d286">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TokenRemoveCmdExe.java</strong><dd><code>Update @Async to reference virtualThreadExecutor bean</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-b62d8d27bf4fe702a3f43864b7f6552415607ebf521c0f2484e684479c3886e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OssLogSaveCmdExe.java</strong><dd><code>Update @Async to reference virtualThreadExecutor bean</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-3eb9c5c66b4039b7435798c2dfa39e7ea1b1cbedb6d445839e160382be3a20c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StorageConfig.java</strong><dd><code>Inject virtualThreadExecutor into storage configuration</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-c217cf6b6952ea58a3bca80d8444f5776b48ecae1fe8686c22778ba0bf5b7924">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TableTest.java</strong><dd><code>Inject virtualThreadExecutor and use in test class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-cb2f5e5695fcdf7a89999a4fdd9fa03a8b0a0ebee90bfb12edd2840e558d1a70">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pom.xml</strong><dd><code>Add new Quarkus-based edge gateway module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-f0f912d9ca26c50e0e246b37d0f5ad5ec0c258e15e94f837b2458c46c2bfc6ad">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>application.yml</strong><dd><code>Add Quarkus application configuration for gateway</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-12e00aae05a182e88878deee7090d3d81732fea981fb5d4a3ffd1058da5deead">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>pom.xml</strong><dd><code>Update description and SCM tag version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-2da5648e656037d13bc21b4672b5b786ec04078b922b53f9d54f4da67a12db25">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pom.xml</strong><dd><code>Update description and SCM tag version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-3a6736f9d0236ce17a0d0ce3868679a382f179f1070886452f097f308e24de21">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pom.xml</strong><dd><code>Update description and SCM tag version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5448/files#diff-97ceb142f3d5a642aa61842da28ae96cb9b0f8eed91af220c163cce1bb849c26">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

引入集中管理的虚拟线程执行器 bean，并迁移异步和基础设施组件以使用该执行器，同时新增一个基于 Quarkus 的网关模块并更新各模块的元数据。

New Features:
- 添加一个由 Spring 管理的 `virtualThreadExecutor` bean，供整个应用复用。
- 新增一个基于 Quarkus 的网关模块，包含基础配置和依赖 BOM。

Enhancements:
- 重构异步配置和多个服务（网关启动、Redis/Redisson、gRPC 客户端、WebSocket 服务器、日志存储以及生成器测试），通过注入并复用共享的 `virtualThreadExecutor`，替代在本地创建执行器。
- 更新 Redisson 配置以接受注入的 `ExecutorService`，并在不同节点类型的配置中进行传递。
- 调整多个模块的 POM 描述，使其与各自的角色（core、common、i18n）保持一致，并将 SCM 标签从 4.0.0 升级到 4.0.1。

Build:
- 引入一个独立的网关 Maven 模块，使用 Quarkus 和 Vert.x 的 BOM 进行配置。
- 更新 common 模块的 POM 元数据和 SCM 标签到 4.0.1 发布线。

Documentation:
- 在多个 POM 文件中明确模块描述，以指示其具体职责（core、common、i18n）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized virtual thread executor bean and migrate asynchronous and infrastructure components to use it, while adding a new Quarkus-based gateway module and updating module metadata.

New Features:
- Add a Spring-managed virtualThreadExecutor bean for reuse across the application.
- Add a new Quarkus-based gateway module with basic configuration and dependency BOMs.

Enhancements:
- Refactor async configuration and various services (gateway startup, Redis/Redisson, gRPC client, WebSocket server, log storage, and generator tests) to inject and reuse the shared virtualThreadExecutor instead of creating local executors.
- Update Redisson configuration to accept an injected ExecutorService and propagate it through node type-specific configurations.
- Align multiple module POM descriptions with their specific roles (core, common, i18n) and bump SCM tags from 4.0.0 to 4.0.1.

Build:
- Introduce a standalone gateway Maven module configured with Quarkus and Vert.x BOMs.
- Update common module POM metadata and SCM tags to the 4.0.1 release line.

Documentation:
- Clarify module descriptions in various POM files to indicate their specific responsibilities (core, common, i18n).

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added a new Gateway module for enhanced routing and request handling.

* **Improvements**
  - Optimized internal resource management for improved performance and efficiency.

* **Chores**
  - Version bumped to 4.0.1
  - Updated module descriptions and metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->