### PR TITLE
style: 优化laokou-common-grpc模块代码

### DIFF
--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessor.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessor.java
@@ -21,7 +21,6 @@ import org.jspecify.annotations.NonNull;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.grpc.client.GrpcClientFactory;
 import org.springframework.util.ReflectionUtils;
@@ -32,8 +31,7 @@ import java.lang.reflect.Method;
 /**
  * @author laokou
  */
-public record GrpcClientBeanPostProcessor(GrpcClientFactory grpcClientFactory,
-		DiscoveryClient discoveryClient) implements BeanPostProcessor {
+public record GrpcClientBeanPostProcessor(GrpcClientFactory grpcClientFactory) implements BeanPostProcessor {
 
 	@Override
 	public Object postProcessBeforeInitialization(@NonNull Object bean, @NonNull String beanName)

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolverProvider.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolverProvider.java
@@ -60,7 +60,7 @@ public final class DiscoveryNameResolverProvider extends NameResolverProvider {
 	@Override
 	public NameResolver newNameResolver(URI uri, NameResolver.Args args) {
 		DiscoveryNameResolver discoveryNameResolver = new DiscoveryNameResolver(uri.getHost(), discoveryClient,
-				executorService, args);
+				executorService);
 		discoveryNameResolvers.add(discoveryNameResolver);
 		return discoveryNameResolver;
 	}

--- a/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/GrpcClientConfig.java
+++ b/laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/GrpcClientConfig.java
@@ -42,7 +42,7 @@ public class GrpcClientConfig {
 			DiscoveryClient discoveryClient, ExecutorService virtualThreadExecutor) {
 		NameResolverRegistry.getDefaultRegistry()
 			.register(new DiscoveryNameResolverProvider(discoveryClient, virtualThreadExecutor));
-		return new GrpcClientBeanPostProcessor(grpcClientFactory, discoveryClient);
+		return new GrpcClientBeanPostProcessor(grpcClientFactory);
 	}
 
 	@Bean

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcServerService.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcServerService.java
@@ -18,8 +18,7 @@
 package org.laokou.common.grpc;
 
 import io.grpc.stub.StreamObserver;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.grpc.proto.HelloWorldProto;
 import org.laokou.common.grpc.proto.SimpleGrpc;
 import org.springframework.grpc.server.service.GrpcService;
@@ -27,10 +26,9 @@ import org.springframework.grpc.server.service.GrpcService;
 /**
  * @author laokou
  */
+@Slf4j
 @GrpcService
 public class GrpcServerService extends SimpleGrpc.SimpleImplBase {
-
-	private static final Log log = LogFactory.getLog(GrpcServerService.class);
 
 	@Override
 	public void sayHello(HelloWorldProto.HelloRequest req,

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessorTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessorTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.grpc.client.GrpcClientFactory;
 
 /**
@@ -38,8 +37,7 @@ class GrpcClientBeanPostProcessorTest {
 	@BeforeEach
 	void setUp() {
 		GrpcClientFactory grpcClientFactory = Mockito.mock(GrpcClientFactory.class);
-		DiscoveryClient discoveryClient = Mockito.mock(DiscoveryClient.class);
-		postProcessor = new GrpcClientBeanPostProcessor(grpcClientFactory, discoveryClient);
+		postProcessor = new GrpcClientBeanPostProcessor(grpcClientFactory);
 
 		Mockito
 			.when(grpcClientFactory.getClient(ArgumentMatchers.eq("discovery://laokou-auth"),

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverProviderTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverProviderTest.java
@@ -80,11 +80,6 @@ class DiscoveryNameResolverProviderTest {
 
 		HeartbeatEvent event = new HeartbeatEvent(new Object(), "test");
 		provider.onHeartbeatEvent(event);
-
-		// verify triggers discoveryClient.getInstances eventually
-		// Since we can't easily poll the internal state of the resolver, we verify that
-		// it doesn't crash
-		// and we've invoked the event handler.
 	}
 
 }

--- a/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverTest.java
+++ b/laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverTest.java
@@ -57,7 +57,7 @@ class DiscoveryNameResolverTest {
 
 		Mockito.when(args.getServiceConfigParser()).thenReturn(Mockito.mock(NameResolver.ServiceConfigParser.class));
 
-		resolver = new DiscoveryNameResolver(serviceId, discoveryClient, executorService, args);
+		resolver = new DiscoveryNameResolver(serviceId, discoveryClient, executorService);
 	}
 
 	@Test


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove unused `DiscoveryClient` dependency from `GrpcClientBeanPostProcessor`

- Eliminate service config resolution logic from `DiscoveryNameResolver`

- Remove `Args` parameter from `DiscoveryNameResolver` constructor

- Replace Apache Commons logging with Lombok `@Slf4j` annotation

- Clean up unused imports and simplify code structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GrpcClientBeanPostProcessor"] -->|remove DiscoveryClient| B["Simplified Constructor"]
  C["DiscoveryNameResolver"] -->|remove Args parameter| D["Cleaner Constructor"]
  C -->|remove service config logic| E["Simplified Resolution"]
  F["GrpcServerService"] -->|replace Commons logging| G["Lombok @Slf4j"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcClientBeanPostProcessor.java</strong><dd><code>Remove unused DiscoveryClient dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessor.java

<ul><li>Remove unused <code>DiscoveryClient</code> import<br> <li> Remove <code>discoveryClient</code> parameter from record constructor<br> <li> Simplify bean post processor to only require <code>GrpcClientFactory</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-b8d44208d3f528e949b7bf237dd78f38a6836868b93e8e98715af8425e00cd75">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryNameResolver.java</strong><dd><code>Remove service config resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolver.java

<ul><li>Remove unused imports: <code>JacksonUtils</code> and <code>StringExtUtils</code><br> <li> Remove <code>serviceConfigParser</code> field from class<br> <li> Remove <code>Args</code> parameter from constructor<br> <li> Remove <code>resolveServiceConfig()</code> and <code>getServiceConfig()</code> methods<br> <li> Simplify <code>resolveInternal()</code> by removing service config setting</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-b2d6917e7e7db2ff3920750d545294d67d8ff1f48c0520ec86fa6ac9aa29a489">+1/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryNameResolverProvider.java</strong><dd><code>Update resolver instantiation call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/DiscoveryNameResolverProvider.java

<ul><li>Remove <code>args</code> parameter from <code>DiscoveryNameResolver</code> instantiation<br> <li> Simplify constructor call to only pass required dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-a4d1c881bc4900e86347871bd26c4bb6fa1678d54489594281b38312874046ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GrpcClientConfig.java</strong><dd><code>Update bean post processor instantiation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/main/java/org/laokou/common/grpc/config/GrpcClientConfig.java

<ul><li>Remove <code>discoveryClient</code> parameter from <code>GrpcClientBeanPostProcessor</code> <br>instantiation<br> <li> Simplify bean creation to only pass <code>grpcClientFactory</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-4b7766b0f6c68b40c4b48fa23b94c589c707cfc81aa3a6a6828b48ba9e8c1c34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GrpcServerService.java</strong><dd><code>Replace Commons logging with Lombok</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/GrpcServerService.java

<ul><li>Replace Apache Commons <code>LogFactory</code> with Lombok <code>@Slf4j</code> annotation<br> <li> Remove manual logger field initialization<br> <li> Simplify logging setup using annotation-based approach</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-fcfe957a1d4b40e72ef118c1122d47d4bfa8cddd65ea2c3536807ceabf0caaee">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrpcClientBeanPostProcessorTest.java</strong><dd><code>Update test for simplified constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/annotation/GrpcClientBeanPostProcessorTest.java

<ul><li>Remove <code>DiscoveryClient</code> mock creation<br> <li> Update test to instantiate <code>GrpcClientBeanPostProcessor</code> with only <br><code>GrpcClientFactory</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-84ec3f7bb1cd9f98ade8136fb2c6d57fe84cd7cfa7a71b7beb87f5f2c2826b27">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryNameResolverProviderTest.java</strong><dd><code>Clean up test comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverProviderTest.java

<ul><li>Remove unnecessary comments about resolver state verification<br> <li> Simplify test by removing explanatory comments</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-b3f3aa821cd17baa751a76fa643aa14200bb7a831b59a50e92ff3a95857a3f83">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscoveryNameResolverTest.java</strong><dd><code>Update resolver test instantiation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-grpc/src/test/java/org/laokou/common/grpc/config/DiscoveryNameResolverTest.java

<ul><li>Remove <code>args</code> parameter from <code>DiscoveryNameResolver</code> instantiation<br> <li> Update test setup to match simplified constructor signature</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5460/files#diff-831a39a7ee8b5e694dadd588cca3947055ed91dff3ee3f1386ac73ff570fd661">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified gRPC service discovery architecture by removing redundant dependencies and streamlining resolver configuration. Internal improvements focused on code maintainability with no impact to existing functionality.

* **Tests**
  * Updated test suite to align with architectural changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->