### PR TITLE
fix: 项目运行报错

### DIFF
--- a/laokou-cloud/laokou-gateway/pom.xml
+++ b/laokou-cloud/laokou-gateway/pom.xml
@@ -58,6 +58,12 @@
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-redis</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-el</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>

--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
@@ -82,9 +82,9 @@ class GatewayApp implements CommandLineRunner {
 
 	@Override
 	public void run(@NotNull String... args) {
-		// 执行同步路由任务【30s后自动释放内存】
+		// 执行同步路由任务【10s后自动释放内存】
 		virtualThreadExecutor.execute(() -> nacosRouteDefinitionRepository.syncRouter()
-			.take(Duration.ofSeconds(30))
+			.take(Duration.ofSeconds(10))
 			.subscribeOn(Schedulers.boundedElastic())
 			.subscribe());
 	}

--- a/laokou-cloud/laokou-gateway/src/main/resources/application-dev.yml
+++ b/laokou-cloud/laokou-gateway/src/main/resources/application-dev.yml
@@ -29,6 +29,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   config:
     import:
       # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】

--- a/laokou-cloud/laokou-gateway/src/main/resources/application-prod.yml
+++ b/laokou-cloud/laokou-gateway/src/main/resources/application-prod.yml
@@ -29,6 +29,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   config:
     import:
       # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】

--- a/laokou-cloud/laokou-gateway/src/main/resources/application-test.yml
+++ b/laokou-cloud/laokou-gateway/src/main/resources/application-test.yml
@@ -29,6 +29,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   config:
     import:
       # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】

--- a/laokou-common/laokou-common-nacos/pom.xml
+++ b/laokou-common/laokou-common-nacos/pom.xml
@@ -33,22 +33,10 @@
     <dependency>
       <groupId>com.alibaba.cloud</groupId>
       <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.alibaba.nacos</groupId>
-          <artifactId>nacos-client</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.alibaba.cloud</groupId>
       <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.alibaba.nacos</groupId>
-          <artifactId>nacos-client</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -75,20 +63,6 @@
           <artifactId>log4j-to-slf4j</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.alibaba.nacos</groupId>
-      <artifactId>nacos-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.alibaba.nacos</groupId>
-      <artifactId>nacos-common</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
@@ -118,11 +92,6 @@
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-reactor</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.alibaba.nacos</groupId>
-      <artifactId>nacos-client</artifactId>
-      <version>${nacos.version}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application-dev.yml
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application-dev.yml
@@ -50,6 +50,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   kafka:
     bootstrap-servers: kafka:9092
     consumer:

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application-prod.yml
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application-prod.yml
@@ -50,6 +50,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   kafka:
     bootstrap-servers: kafka:9092
     consumer:

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application-test.yml
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application-test.yml
@@ -50,6 +50,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   kafka:
     bootstrap-servers: kafka:9092
     consumer:

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application-dev.yml
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application-dev.yml
@@ -72,6 +72,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   kafka:
     bootstrap-servers: kafka:9092
     consumer:

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application-prod.yml
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application-prod.yml
@@ -72,6 +72,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   kafka:
     bootstrap-servers: kafka:9092
     consumer:

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application-test.yml
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application-test.yml
@@ -72,6 +72,12 @@ spring:
           max-wait: -1 #连接池最大阻塞等待时间（使用负值表示没有限制）
           max-idle: 500 #连接池最大空闲连接
           min-idle: 200 #连接池最小空间连接
+  redisson:
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
+    password: ${spring.data.redis.password}
   kafka:
     bootstrap-servers: kafka:9092
     consumer:

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!--mybatis-plus版本 -->
     <mybatis-plus.version>3.5.16</mybatis-plus.version>
     <!--nacos版本-->
-    <nacos.version>3.1.0</nacos.version>
+    <nacos.version>3.1.1</nacos.version>
     <!--micrometer-tracing-bom版本-->
     <micrometer-tracing.version>1.6.1</micrometer-tracing.version>
     <!--opentelemetry版本-->


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reduced router sync timeout from 30s to 10s in gateway

- Fixed Redis route retrieval using entryIterator with null filtering

- Added Redisson configuration across all environments

- Updated Nacos version to 3.1.1 and removed redundant dependencies

- Fixed import statement from javax to jakarta annotation

- Excluded tomcat-embed-el dependency from redis module


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gateway Router Sync"] -->|"Reduced timeout 30s to 10s"| B["Improved Performance"]
  C["Redis Route Retrieval"] -->|"Fixed entryIterator usage"| D["Stable Route Loading"]
  E["Configuration"] -->|"Added Redisson config"| F["Enhanced Redis Support"]
  G["Dependencies"] -->|"Updated Nacos & cleanup"| H["Resolved Conflicts"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>GatewayApp.java</strong><dd><code>Reduced router sync timeout duration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-a18d4e0c7ed68eec3b814b446ce6e8cebd9f80081fb29d33f28492ecd3f71339">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NacosRouteDefinitionRepository.java</strong><dd><code>Fixed Redis route retrieval and import statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-b947eef8181a3e827b90dddf5e8e47d9bc43a0955b5d1f34900fbe346c2175b0">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>pom.xml</strong><dd><code>Excluded tomcat-embed-el dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-0451cef837989f7f8b2702be740ddb42846b74671e83ce9868f4f82d2851185d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pom.xml</strong><dd><code>Removed redundant Nacos dependency exclusions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-5bf5c92588900d9e733aac85370cac56f0417ad847a2597ffaed2b2b5a226faf">+0/-31</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pom.xml</strong><dd><code>Updated Nacos version to 3.1.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>application-dev.yml</strong><dd><code>Added Redisson configuration for dev environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-2dec95ba22c810dddff9b6ea28be5827d78dc8eba2b53869101bc0168ce7b6f7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-prod.yml</strong><dd><code>Added Redisson configuration for prod environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-57d46e85b25bc9e2ad1b7532e77d31b8ca549c29ddc3aa1a98c80337f8a16b2f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-test.yml</strong><dd><code>Added Redisson configuration for test environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-e3c4a8887f8367d714b0bb4edb90a6afaf6d76d09dc9b248e44e3471883daa1f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-dev.yml</strong><dd><code>Added Redisson configuration for admin dev</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-32ab104c473dc71040bf08524b2c852ac717811224d97cfcc941f881dbfab447">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-prod.yml</strong><dd><code>Added Redisson configuration for admin prod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-f49758978c3b7c81cff3983b47e770c2ae6ddb6aa511c57e1b5c1518e4fc429f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-test.yml</strong><dd><code>Added Redisson configuration for admin test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-d9406eb6bcdfd38cce627414220f8f49c976ce51056b384700dd8989ee0563a7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-dev.yml</strong><dd><code>Added Redisson configuration for auth dev</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-f0d747dd5b0c08d2044b8d15855fc0d54aa6e1936e701af0ff3c714a9b6af955">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-prod.yml</strong><dd><code>Added Redisson configuration for auth prod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-f663066276e0587146590cd380ef6f650064554ceea4a580403f1b5bba1b5eae">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-test.yml</strong><dd><code>Added Redisson configuration for auth test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5469/files#diff-c01fa962bbacf7671166666a311114fba74fbd6a33ba7ac305cf260d5207f48d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redisson distributed caching support configuration across gateway, admin, and auth services for improved distributed operations.

* **Chores**
  * Updated Nacos version to 3.1.1.
  * Optimized route synchronization timeout from 30 seconds to 10 seconds for faster gateway response.
  * Cleaned up dependency management by removing redundant Nacos explicit declarations and adjusting transitive dependency exclusions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->