### PR TITLE
feat: netty开启io_uring

### DIFF
--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/util/SystemUtils.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/util/SystemUtils.java
@@ -37,8 +37,12 @@ public final class SystemUtils {
 		return System.getProperty("os.name").contains("Windows");
 	}
 
+	public static boolean isLinux() {
+		return System.getProperty("os.name").contains("Linux");
+	}
+
 	public static boolean isArchLinux() {
-		if (System.getProperty("os.name").equalsIgnoreCase("linux")) {
+		if (isLinux()) {
 			return Files.exists(Path.of("/etc/arch-release"));
 		}
 		return false;

--- a/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/SystemUtilsTest.java
+++ b/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/SystemUtilsTest.java
@@ -22,18 +22,44 @@ import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.util.SystemUtils;
 
 /**
+ * SystemUtils测试类.
+ *
  * @author laokou
  */
 class SystemUtilsTest {
 
 	@Test
-	void test_windows() {
-		if (SystemUtils.isWindows()) {
-			Assertions.assertThat(SystemUtils.isWindows()).isTrue();
-		}
-		else {
-			Assertions.assertThat(SystemUtils.isWindows()).isFalse();
+	void testIsWindows() {
+		String osName = System.getProperty("os.name");
+		boolean expected = osName.contains("Windows");
+		Assertions.assertThat(SystemUtils.isWindows()).isEqualTo(expected);
+	}
+
+	@Test
+	void testIsLinux() {
+		String osName = System.getProperty("os.name");
+		boolean expected = osName.contains("Linux");
+		Assertions.assertThat(SystemUtils.isLinux()).isEqualTo(expected);
+	}
+
+	@Test
+	void testIsArchLinux() {
+		// isArchLinux返回true的前提是isLinux为true
+		if (!SystemUtils.isLinux()) {
 			Assertions.assertThat(SystemUtils.isArchLinux()).isFalse();
+		}
+		// 如果是Linux系统，验证方法不抛异常
+		Assertions.assertThatNoException().isThrownBy(SystemUtils::isArchLinux);
+	}
+
+	@Test
+	void testMutualExclusive() {
+		// Windows和Linux互斥（但可能两者都不是，如macOS）
+		if (SystemUtils.isWindows()) {
+			Assertions.assertThat(SystemUtils.isLinux()).isFalse();
+		}
+		if (SystemUtils.isLinux()) {
+			Assertions.assertThat(SystemUtils.isWindows()).isFalse();
 		}
 	}
 

--- a/laokou-common/laokou-common-rpc/pom.xml
+++ b/laokou-common/laokou-common-rpc/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.laokou</groupId>
+    <artifactId>laokou-common</artifactId>
+    <version>4.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>laokou-common-rpc</artifactId>
+  <version>4.0.1-SNAPSHOT</version>
+
+</project>

--- a/laokou-common/laokou-common-websocket/pom.xml
+++ b/laokou-common/laokou-common-websocket/pom.xml
@@ -28,6 +28,17 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!--io_uring传输(Linux)-->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-io_uring</artifactId>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-io_uring</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>

--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/Server.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/Server.java
@@ -27,7 +27,7 @@ public interface Server {
 	 * @param clientId 客户端ID
 	 * @param payload 消息内容
 	 */
-	void send(Long clientId, Object payload) throws InterruptedException;
+	void send(Long clientId, Object payload);
 
 	/**
 	 * 启动.

--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/SpringWebSocketServerProperties.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/SpringWebSocketServerProperties.java
@@ -131,4 +131,9 @@ public class SpringWebSocketServerProperties {
 	 */
 	private String keyCertPrivateKeyPath = "classpath:private.key";
 
+	/**
+	 * 是否启用io_uring(仅Linux生效).
+	 */
+	private boolean useIoUring = true;
+
 }

--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/WebSocketServerHandler.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/WebSocketServerHandler.java
@@ -59,7 +59,7 @@ public class WebSocketServerHandler extends ChannelInboundHandlerAdapter {
 	 * @param msg 消息
 	 */
 	@Override
-	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
 		boolean release = true;
 		// @formatter:off
 		try {
@@ -87,7 +87,7 @@ public class WebSocketServerHandler extends ChannelInboundHandlerAdapter {
 	}
 
 	@Override
-	public void handlerRemoved(ChannelHandlerContext ctx) throws InterruptedException {
+	public void handlerRemoved(ChannelHandlerContext ctx) {
 		String channelId = ctx.channel().id().asLongText();
 		log.info("【WebSocket-Server】 => 断开连接：{}", channelId);
 		WebSocketSessionManager.remove(ctx.channel());
@@ -118,7 +118,7 @@ public class WebSocketServerHandler extends ChannelInboundHandlerAdapter {
 		}
 	}
 
-	private void read(ChannelHandlerContext ctx, TextWebSocketFrame frame) throws InterruptedException {
+	private void read(ChannelHandlerContext ctx, TextWebSocketFrame frame) {
 		Channel channel = ctx.channel();
 		String str = frame.text();
 		if (StringExtUtils.isEmpty(str)) {

--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/model/WebSocketTypeEnum.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/model/WebSocketTypeEnum.java
@@ -42,8 +42,7 @@ public enum WebSocketTypeEnum {
 
 	CONNECT("connect", "建立连接") {
 		@Override
-		public void handle(UserExtDetails userExtDetails, WebSocketMessageCO co, Channel channel)
-				throws InterruptedException {
+		public void handle(UserExtDetails userExtDetails, WebSocketMessageCO co, Channel channel) {
 			Long clientId = userExtDetails.getId();
 			log.info("【WebSocket-Server】 => 已建立连接，通道ID：{}，用户ID：{}", channel.id().asLongText(), clientId);
 			WebSocketSessionManager.add(clientId, channel);
@@ -80,7 +79,6 @@ public enum WebSocketTypeEnum {
 		return EnumParser.parse(WebSocketTypeEnum.class, WebSocketTypeEnum::getCode, code);
 	}
 
-	public abstract void handle(UserExtDetails userExtDetails, WebSocketMessageCO co, Channel channel)
-			throws InterruptedException;
+	public abstract void handle(UserExtDetails userExtDetails, WebSocketMessageCO co, Channel channel);
 
 }

--- a/laokou-common/pom.xml
+++ b/laokou-common/pom.xml
@@ -111,6 +111,7 @@
     <module>laokou-common-testcontainers</module>
     <module>laokou-common-mongodb</module>
     <module>laokou-common-grpc</module>
+    <module>laokou-common-rpc</module>
   </modules>
 
 </project>


### PR DESCRIPTION
## Summary by Sourcery

在受支持的 Linux 系统上为 WebSocket 服务器新增可选的基于 io_uring 的 Netty 传输层，优化 WebSocket 会话管理和相关 API，扩展操作系统检测工具，并准备一个新的通用 RPC 模块。

New Features:
- 为 WebSocket 服务器引入可选的基于 io_uring 的 Netty 传输层与服务器通道选择机制，通过配置与运行时能力检查进行控制。
- 暴露一个配置开关，用于在 Linux 上启用或禁用 WebSocket 服务器对 io_uring 的使用。
- 新增 `laokou-common-rpc` 模块，作为未来 RPC 相关功能的占位模块。

Enhancements:
- 重构 `WebSocketSessionManager`，使用带反向索引的并发 Map，实现无锁、常数时间的通道添加/移除操作，并对外提供在线客户端数和通道数统计。
- 简化 WebSocket 服务器处理器和类型枚举相关 API，从方法签名中移除受检异常。
- 扩展 `SystemUtils` 增加对 Linux 的检测，并在 Arch Linux 检测中复用该逻辑。

Build:
- 在 WebSocket 模块中为 Linux x86_64 和 aarch_64 添加 Netty io_uring 原生传输依赖。
- 在 `laokou-common` 父 POM 中注册新的 `laokou-common-rpc` 模块。

Tests:
- 扩展 `SystemUtils` 的测试，覆盖 Windows、Linux、Arch Linux 的行为，以及 Windows 和 Linux 检测之间的互斥性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional io_uring-based Netty transport for the WebSocket server on supported Linux systems, refine WebSocket session management and APIs, extend OS detection utilities, and prepare a new common RPC module.

New Features:
- Introduce an optional io_uring-based Netty transport and server channel selection for the WebSocket server, controlled by configuration and runtime capability checks.
- Expose a configuration flag to enable or disable io_uring usage for the WebSocket server on Linux.
- Add a new laokou-common-rpc module as a placeholder for future RPC-related functionality.

Enhancements:
- Refactor WebSocketSessionManager to use concurrent maps with reverse indexing for lock-free, constant-time channel add/remove operations, and to expose online client and channel counts.
- Simplify WebSocket server handler and type enum APIs by removing checked exceptions from method signatures.
- Extend SystemUtils with Linux detection and reuse it in Arch Linux checks.

Build:
- Add Netty io_uring native transport dependencies for Linux x86_64 and aarch_64 in the WebSocket module.
- Register the new laokou-common-rpc module in the laokou-common parent POM.

Tests:
- Expand SystemUtils tests to cover Windows, Linux, Arch Linux behavior and mutual exclusivity between Windows and Linux detection.

</details>

新功能：
- 为 WebSocket 服务器新增可选的基于 io_uring 的 Netty 传输和服务器通道选择，通过配置和 Linux 能力检测进行控制。
- 暴露配置开关，用于在受支持的 Linux 系统上启用或禁用 WebSocket 服务器的 io_uring 使用。
- 引入新的 `laokou-common-rpc` 模块，作为未来与 RPC 相关功能的占位脚手架。

增强：
- 重构 `WebSocketSessionManager`，使用带反向索引的并发 map，实现无锁、常数时间的通道添加/删除操作，并对外提供在线客户端数和通道数。
- 简化 WebSocket 服务器处理器、会话管理和类型处理相关的 API，从方法签名中移除不必要的受检异常。
- 扩展 `SystemUtils`，增加 Linux 检测，并改进对 Arch Linux 的检查以复用 Linux 断言逻辑。

构建：
- 在 WebSocket 模块中为 Linux x86_64 和 aarch_64 添加 Netty io_uring 原生传输依赖。

测试：
- 扩展 `SystemUtils` 测试，用于覆盖 Windows、Linux、Arch Linux 的行为，以及 Windows 与 Linux 检测之间的互斥性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在受支持的 Linux 系统上为 WebSocket 服务器新增可选的基于 io_uring 的 Netty 传输层，优化 WebSocket 会话管理和相关 API，扩展操作系统检测工具，并准备一个新的通用 RPC 模块。

New Features:
- 为 WebSocket 服务器引入可选的基于 io_uring 的 Netty 传输层与服务器通道选择机制，通过配置与运行时能力检查进行控制。
- 暴露一个配置开关，用于在 Linux 上启用或禁用 WebSocket 服务器对 io_uring 的使用。
- 新增 `laokou-common-rpc` 模块，作为未来 RPC 相关功能的占位模块。

Enhancements:
- 重构 `WebSocketSessionManager`，使用带反向索引的并发 Map，实现无锁、常数时间的通道添加/移除操作，并对外提供在线客户端数和通道数统计。
- 简化 WebSocket 服务器处理器和类型枚举相关 API，从方法签名中移除受检异常。
- 扩展 `SystemUtils` 增加对 Linux 的检测，并在 Arch Linux 检测中复用该逻辑。

Build:
- 在 WebSocket 模块中为 Linux x86_64 和 aarch_64 添加 Netty io_uring 原生传输依赖。
- 在 `laokou-common` 父 POM 中注册新的 `laokou-common-rpc` 模块。

Tests:
- 扩展 `SystemUtils` 的测试，覆盖 Windows、Linux、Arch Linux 的行为，以及 Windows 和 Linux 检测之间的互斥性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional io_uring-based Netty transport for the WebSocket server on supported Linux systems, refine WebSocket session management and APIs, extend OS detection utilities, and prepare a new common RPC module.

New Features:
- Introduce an optional io_uring-based Netty transport and server channel selection for the WebSocket server, controlled by configuration and runtime capability checks.
- Expose a configuration flag to enable or disable io_uring usage for the WebSocket server on Linux.
- Add a new laokou-common-rpc module as a placeholder for future RPC-related functionality.

Enhancements:
- Refactor WebSocketSessionManager to use concurrent maps with reverse indexing for lock-free, constant-time channel add/remove operations, and to expose online client and channel counts.
- Simplify WebSocket server handler and type enum APIs by removing checked exceptions from method signatures.
- Extend SystemUtils with Linux detection and reuse it in Arch Linux checks.

Build:
- Add Netty io_uring native transport dependencies for Linux x86_64 and aarch_64 in the WebSocket module.
- Register the new laokou-common-rpc module in the laokou-common parent POM.

Tests:
- Expand SystemUtils tests to cover Windows, Linux, Arch Linux behavior and mutual exclusivity between Windows and Linux detection.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added io_uring support for WebSocket servers on Linux to improve performance.
  * Introduced configurable option to enable/disable io_uring in server properties.

* **Refactor**
  * Simplified WebSocket session management with improved internal tracking.
  * Removed unnecessary checked exceptions from WebSocket API methods for cleaner error handling.

* **Tests**
  * Enhanced OS detection test suite with new test cases for platform-specific behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->