### PR TITLE
Dev

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -74,6 +74,7 @@ jobs:
             ./laokou-common/laokou-common-mybatis-plus/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-sftp/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-grpc/target/site/jacoco/jacoco.xml,
+            ./laokou-common/laokou-common-modbus4j/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-redis/target/site/jacoco/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build the Docker image

--- a/laokou-common/laokou-common-modbus4j/pom.xml
+++ b/laokou-common/laokou-common-modbus4j/pom.xml
@@ -33,6 +33,13 @@
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-testcontainers</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>

--- a/laokou-common/laokou-common-testcontainers/docker/Dockerfile
+++ b/laokou-common/laokou-common-testcontainers/docker/Dockerfile
@@ -1,0 +1,34 @@
+# Modbus TCP/UDP Server Simulator
+# Based on pymodbus library
+# Supports both TCP and UDP protocols
+
+FROM python:3.11-slim
+
+LABEL maintainer="laokou"
+LABEL description="Modbus TCP/UDP Server Simulator using pymodbus"
+LABEL version="1.0"
+
+# Set working directory
+WORKDIR /app
+
+# Install pymodbus
+RUN pip install --no-cache-dir pymodbus==3.6.4
+
+# Copy the server script
+COPY modbus_server.py /app/
+
+# Expose Modbus port (502 is standard, 5020 is common alternative)
+EXPOSE 502
+EXPOSE 5020
+
+# Set environment variables
+ENV MODBUS_PROTOCOL=tcp
+ENV MODBUS_HOST=0.0.0.0
+ENV MODBUS_PORT=502
+
+# Default command - can be overridden with docker run arguments
+# Examples:
+#   TCP: docker run -p 502:502 modbus-sim --protocol tcp --port 502
+#   UDP: docker run -p 502:502/udp modbus-sim --protocol udp --port 502
+ENTRYPOINT ["python", "modbus_server.py"]
+CMD ["--protocol", "tcp", "--host", "0.0.0.0", "--port", "502"]

--- a/laokou-common/laokou-common-testcontainers/docker/README.md
+++ b/laokou-common/laokou-common-testcontainers/docker/README.md
@@ -1,0 +1,50 @@
+# Modbus TCP/UDP Server Docker Image
+
+基于 pymodbus 库构建的 Modbus 服务器模拟器，支持 TCP 和 UDP 协议。
+
+## 构建镜像
+
+```bash
+cd laokou-common/laokou-common-testcontainers/docker
+sudo docker login
+sudo docker build -t laokou/modbus-sim:1.0 .
+sudo docker tag laokou/modbus-sim:1.0 koushenhai/modbus-sim
+sudo docker push koushenhai/modbus-sim:latest
+```
+
+## 运行容器
+
+### TCP 模式（默认）
+```bash
+docker run -d --name modbus-tcp -p 502:502 laokou/modbus-sim:1.0
+```
+
+### UDP 模式
+```bash
+docker run -d --name modbus-udp -p 502:502/udp laokou/modbus-sim:1.0 --protocol udp --port 502
+```
+
+### 自定义端口
+```bash
+# TCP on port 5020
+docker run -d --name modbus-tcp -p 5020:5020 laokou/modbus-sim:1.0 --protocol tcp --port 5020
+
+# UDP on port 5020
+docker run -d --name modbus-udp -p 5020:5020/udp laokou/modbus-sim:1.0 --protocol udp --port 5020
+```
+
+## 数据块配置
+
+| 类型 | 数量 | 初始值 |
+|------|------|--------|
+| Coils | 100 | 全部为 True |
+| Discrete Inputs | 100 | 交替 True/False |
+| Input Registers | 100 | 0-99 |
+| Holding Registers | 100 | 100-199 |
+
+## 测试
+
+```bash
+# 使用 modbus 客户端工具测试
+# 例如使用 modpoll 或 pymodbus-console
+```

--- a/laokou-common/laokou-common-testcontainers/docker/modbus_server.py
+++ b/laokou-common/laokou-common-testcontainers/docker/modbus_server.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Modbus UDP Server Simulator using pymodbus.
+Supports both TCP and UDP protocols based on command line arguments.
+
+Usage:
+    python modbus_server.py --protocol tcp --port 502
+    python modbus_server.py --protocol udp --port 502
+"""
+
+import argparse
+import logging
+from pymodbus.datastore import ModbusSequentialDataBlock, ModbusSlaveContext, ModbusServerContext
+from pymodbus.server import StartTcpServer, StartUdpServer
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def create_datastore():
+    """
+    Create a Modbus datastore with sample data.
+    
+    Modbus data types:
+    - Coils (di): Read/Write discrete outputs (bits), address 0x0001-0xFFFF
+    - Discrete Inputs (co): Read-only discrete inputs (bits), address 0x0001-0xFFFF  
+    - Input Registers (ir): Read-only 16-bit registers, address 0x0001-0xFFFF
+    - Holding Registers (hr): Read/Write 16-bit registers, address 0x0001-0xFFFF
+    """
+    # Initialize data blocks with sample values
+    # 100 coils starting at address 0, all set to True (1)
+    coils = ModbusSequentialDataBlock(0, [True] * 100)
+    
+    # 100 discrete inputs starting at address 0, alternating values
+    discrete_inputs = ModbusSequentialDataBlock(0, [i % 2 == 0 for i in range(100)])
+    
+    # 100 input registers starting at address 0, values 0-99
+    input_registers = ModbusSequentialDataBlock(0, list(range(100)))
+    
+    # 100 holding registers starting at address 0, values 100-199
+    holding_registers = ModbusSequentialDataBlock(0, list(range(100, 200)))
+    
+    # Create slave context with all data blocks
+    store = ModbusSlaveContext(
+        di=discrete_inputs,  # Discrete Inputs
+        co=coils,            # Coils
+        hr=holding_registers, # Holding Registers
+        ir=input_registers    # Input Registers
+    )
+    
+    # Create server context (single slave, slave ID 1)
+    context = ModbusServerContext(slaves=store, single=True)
+    
+    return context
+
+
+def run_server(protocol: str, host: str, port: int):
+    """
+    Start the Modbus server with the specified protocol.
+    
+    Args:
+        protocol: 'tcp' or 'udp'
+        host: Host address to bind to
+        port: Port number to listen on
+    """
+    context = create_datastore()
+    
+    log.info(f"Starting Modbus {protocol.upper()} server on {host}:{port}")
+    log.info("Data blocks initialized:")
+    log.info("  - Coils: 100 items (all True)")
+    log.info("  - Discrete Inputs: 100 items (alternating)")
+    log.info("  - Input Registers: 100 items (values 0-99)")
+    log.info("  - Holding Registers: 100 items (values 100-199)")
+    
+    if protocol.lower() == 'tcp':
+        StartTcpServer(
+            context=context,
+            address=(host, port)
+        )
+    elif protocol.lower() == 'udp':
+        StartUdpServer(
+            context=context,
+            address=(host, port)
+        )
+    else:
+        raise ValueError(f"Unknown protocol: {protocol}. Use 'tcp' or 'udp'.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Modbus Server Simulator')
+    parser.add_argument(
+        '--protocol', '-p',
+        type=str,
+        default='tcp',
+        choices=['tcp', 'udp'],
+        help='Protocol to use: tcp or udp (default: tcp)'
+    )
+    parser.add_argument(
+        '--host', '-H',
+        type=str,
+        default='0.0.0.0',
+        help='Host address to bind to (default: 0.0.0.0)'
+    )
+    parser.add_argument(
+        '--port', '-P',
+        type=int,
+        default=502,
+        help='Port number to listen on (default: 502)'
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        run_server(args.protocol, args.host, args.port)
+    except KeyboardInterrupt:
+        log.info("Server stopped by user")
+    except Exception as e:
+        log.error(f"Server error: {e}")
+        raise
+
+
+if __name__ == '__main__':
+    main()

--- a/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/container/ModbusContainer.java
+++ b/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/container/ModbusContainer.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.testcontainers.container;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.InternetProtocol;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+/**
+ * Modbus TCP/UDP 服务器容器，用于测试 Modbus 通信协议。
+ * <p>
+ * 支持的镜像:
+ * <ul>
+ * <li>iotechsys/pymodbus-sim - TCP only, port 5020</li>
+ * <li>laokou/modbus-sim - TCP and UDP, port 502 (需自行构建)</li>
+ * </ul>
+ * </p>
+ *
+ * @author laokou
+ */
+public class ModbusContainer extends GenericContainer<ModbusContainer> {
+
+	/**
+	 * Modbus 标准端口。
+	 */
+	public static final int MODBUS_STANDARD_PORT = 502;
+
+	/**
+	 * pymodbus-sim 默认端口。
+	 */
+	public static final int PYMODBUS_PORT = 5020;
+
+	private final int port;
+
+	private Integer fixedUdpPort = null;
+
+	/**
+	 * 使用 pymodbus-sim 镜像创建 Modbus TCP 容器（端口 5020）。
+	 * @param dockerImageName Docker 镜像名称
+	 */
+	public ModbusContainer(DockerImageName dockerImageName) {
+		this(dockerImageName, PYMODBUS_PORT);
+	}
+
+	/**
+	 * 使用指定的 Docker 镜像和端口创建 Modbus 容器。
+	 * @param dockerImageName Docker 镜像名称
+	 * @param port Modbus 端口
+	 */
+	public ModbusContainer(DockerImageName dockerImageName, int port) {
+		super(dockerImageName);
+		this.port = port;
+		this.withExposedPorts(port);
+		this.setWaitStrategy(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(60)));
+	}
+
+	/**
+	 * 创建 TCP Modbus 容器。
+	 * @param dockerImageName 镜像名称
+	 * @param port 端口
+	 * @return ModbusContainer
+	 */
+	public static ModbusContainer tcp(DockerImageName dockerImageName, int port) {
+		ModbusContainer container = new ModbusContainer(dockerImageName, port);
+		container.withCommand("--protocol", "tcp", "--port", String.valueOf(port));
+		return container;
+	}
+
+	/**
+	 * 创建 UDP Modbus 容器。
+	 * <p>
+	 * 注意：UDP 不能使用 forListeningPort 等待策略，使用日志等待策略。
+	 * </p>
+	 * @param dockerImageName 镜像名称
+	 * @param port 端口
+	 * @return ModbusContainer
+	 */
+	public static ModbusContainer udp(DockerImageName dockerImageName, int port) {
+		ModbusContainer container = new ModbusContainer(dockerImageName, port);
+		// UDP 不能使用 forListeningPort，使用日志输出等待策略
+		container
+			.setWaitStrategy(Wait.forLogMessage(".*Starting Modbus.*", 1).withStartupTimeout(Duration.ofSeconds(60)));
+		// UDP 使用固定端口
+		container.addFixedExposedPort(port, port, InternetProtocol.UDP);
+		container.fixedUdpPort = port;
+		container.withCommand("--protocol", "udp", "--port", String.valueOf(port));
+		return container;
+	}
+
+	/**
+	 * 获取 Modbus TCP 映射端口。
+	 * @return 映射后的端口号
+	 */
+	public Integer getModbusTcpPort() {
+		return this.getMappedPort(port);
+	}
+
+	/**
+	 * 获取 Modbus 端口。 UDP 使用固定端口，TCP 使用动态映射端口。
+	 * @return 端口号
+	 */
+	public Integer getModbusPort() {
+		if (fixedUdpPort != null) {
+			return fixedUdpPort;
+		}
+		return this.getMappedPort(port);
+	}
+
+}

--- a/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java
+++ b/laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java
@@ -83,12 +83,25 @@ public final class DockerImageNames {
 		return postgresql(LATEST);
 	}
 
-	public static DockerImageName starrocks(String tag) {
-		return DockerImageName.parse("starrocks/allin1-ubuntu").withTag(tag);
+	public static DockerImageName pymodbus(String tag) {
+		return DockerImageName.parse("iotechsys/pymodbus-sim").withTag(tag);
 	}
 
-	public static DockerImageName starrocks() {
-		return starrocks(LATEST);
+	public static DockerImageName pymodbus() {
+		return pymodbus("1.0");
+	}
+
+	/**
+	 * 自定义 Modbus TCP/UDP 服务器镜像.
+	 * @param tag 镜像标签
+	 * @return DockerImageName
+	 */
+	public static DockerImageName modbusSim(String tag) {
+		return DockerImageName.parse("koushenhai/modbus-sim").withTag(tag);
+	}
+
+	public static DockerImageName modbusSim() {
+		return modbusSim(LATEST);
 	}
 
 }


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Refactored Modbus test suite using Testcontainers for TCP/UDP protocols

- Added comprehensive test cases for all Modbus operations (coils, registers, inputs)

- Created ModbusContainer wrapper for Docker-based Modbus server simulation

- Added custom Modbus server Docker image with pymodbus library support

- Integrated test coverage reporting for modbus4j module


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ModbusTest<br/>Refactored"] -->|uses| B["ModbusContainer<br/>New Wrapper"]
  B -->|manages| C["Docker Containers<br/>TCP/UDP"]
  C -->|runs| D["pymodbus-sim<br/>iotechsys"]
  C -->|runs| E["modbus-sim<br/>Custom Image"]
  A -->|tests| F["TCP Protocol<br/>4 operations"]
  A -->|tests| G["UDP Protocol<br/>4 operations"]
  A -->|tests| H["RTU/ASCII<br/>Disabled"]
  B -->|configured by| I["DockerImageNames<br/>Updated"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModbusTest.java</strong><dd><code>Refactor to Testcontainers-based Modbus test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-modbus4j/src/test/java/org/laokou/common/modbus4j/ModbusTest.java

<ul><li>Replaced Spring Boot test configuration with Testcontainers-based <br>approach<br> <li> Removed dependency injection and added manual initialization in <br><code>@BeforeEach</code><br> <li> Expanded test coverage from 4 generic tests to 12 protocol-specific <br>tests<br> <li> Added TCP tests (4 operations), UDP tests (4 operations), and disabled <br>RTU/ASCII tests<br> <li> Implemented helper methods for TCP/UDP configuration and Modbus <br>instance creation<br> <li> Added test ordering with <code>@Order</code> annotation and descriptive <br><code>@DisplayName</code> annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-c51507d9ee6def6e48ae76cf84623fae82bca600a3d038e34e4d1e648d24dd73">+288/-47</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModbusContainer.java</strong><dd><code>New ModbusContainer for Docker-based Modbus testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/container/ModbusContainer.java

<ul><li>New container class extending GenericContainer for Modbus TCP/UDP <br>server simulation<br> <li> Supports both pymodbus-sim (port 5020) and custom modbus-sim (port <br>502) images<br> <li> Provides factory methods for TCP and UDP container creation with <br>protocol-specific configuration<br> <li> Implements port mapping with fixed UDP ports and dynamic TCP port <br>mapping<br> <li> Configures wait strategies appropriate for each protocol (listening <br>port for TCP, log message for UDP)</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-302621d6b4282717cd10ba59b6337656511aba5e4d64d432c3094482aa712979">+127/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DockerImageNames.java</strong><dd><code>Add Modbus Docker image name utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/src/main/java/org/laokou/common/testcontainers/util/DockerImageNames.java

<ul><li>Replaced <code>starrocks()</code> methods with <code>pymodbus()</code> methods for <br>iotechsys/pymodbus-sim image<br> <li> Added <code>modbusSim()</code> methods for custom koushenhai/modbus-sim Docker <br>image<br> <li> Updated image references to support Modbus protocol testing <br>infrastructure</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-5c7d5619ee29ca0cb399a15c32daed137a50e24f344779289600c752dbd9985a">+17/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>modbus_server.py</strong><dd><code>New Modbus server simulator Python script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/docker/modbus_server.py

<ul><li>New Python script implementing Modbus TCP/UDP server using pymodbus <br>library<br> <li> Initializes datastore with 100 coils, discrete inputs, input <br>registers, and holding registers<br> <li> Supports both TCP and UDP protocols via command-line arguments<br> <li> Provides sample data for testing (coils all True, discrete inputs <br>alternating, registers with sequential values)<br> <li> Includes comprehensive logging and error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-19af58da8d8fce36b10bd43402d18bd7a3bfff6159f60c8991cc704b34e6f910">+124/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Add testcontainers dependency to modbus4j module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-modbus4j/pom.xml

<ul><li>Added dependency on <code>laokou-common-testcontainers</code> module for test scope<br> <li> Enables Testcontainers integration for Modbus protocol testing</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-2a26ac34a9eb44a410aa704bc7592c9a00066fb3d9c9adac54065d9f516f3128">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>New Dockerfile for Modbus server simulator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/docker/Dockerfile

<ul><li>New Dockerfile for custom Modbus TCP/UDP server simulator based on <br>Python 3.11<br> <li> Installs pymodbus 3.6.4 library for protocol implementation<br> <li> Exposes ports 502 (standard) and 5020 (alternative) for Modbus <br>communication<br> <li> Configurable via environment variables and command-line arguments for <br>protocol selection</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-87c87f67e14be14d69b740526e56b687f2b4b99357d8e9777a732dc6d9a03149">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>maven.yml</strong><dd><code>Add modbus4j module to coverage reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven.yml

<ul><li>Added <code>laokou-common-modbus4j</code> module to code coverage reporting <br>pipeline<br> <li> Includes jacoco.xml report path for test coverage metrics</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documentation for Modbus Docker image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-testcontainers/docker/README.md

<ul><li>Documentation for building and running custom Modbus Docker image<br> <li> Instructions for TCP and UDP container deployment with various port <br>configurations<br> <li> Data block configuration reference table for test expectations<br> <li> Build and push commands for Docker registry</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5487/files#diff-321a991ca3516c93d51ceba63f7b2ac04bda2a5d513e01a2e7b3405e00971560">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Migrated Modbus testing to containerized server simulation, improving test reliability and coverage across TCP and UDP protocols.
  * Added dedicated test cases for individual Modbus operations (Read Holding Registers, Read Coils, Read Input Registers, Read Discrete Inputs).

* **Chores**
  * Updated CI/CD pipeline codecov reporting configuration.
  * Enhanced testing infrastructure dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->