### PR TITLE
docs: 修复readme

### DIFF
--- a/KEdge-Gateway/sh/arm_aarch64_network.sh
+++ b/KEdge-Gateway/sh/arm_aarch64_network.sh
@@ -24,7 +24,6 @@ USB0="usb0"
 WLAN0="wlan0"
 
 # 启用连接【以太网】
-# 启用连接【以太网】
 enable_eth0() {
 sudo ip link set $ETH0 up
 }

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ image:https://gitee.com/laokouyun/KCloud-Platform-IoT/badge/fork.svg?theme=dark[
 image:https://gitcode.com/KouShenhai_/KCloud-Platform-IoT/star/badge.svg?theme=dark[GitCode star,link=https://gitcode.com/KouShenhai_/KCloud-Platform-IoT]
 image:https://atomgit.com/KouShenhai_/KCloud-Platform-IoT/star/2025top.svg?theme=dark[GitCode star,link=https://gitcode.com/KouShenhai_/KCloud-Platform-IoT]
 
-image:https://img.shields.io/static/v1?label=Spring%20Framework&message=7.0.2&color=green[Spring Framework,link=https://spring.io/projects/spring-framework]
+image:https://img.shields.io/static/v1?label=Spring%20Framework&message=7.0.3&color=green[Spring Framework,link=https://spring.io/projects/spring-framework]
 image:https://img.shields.io/static/v1?label=Spring%20Security&message=7.0.2&color=green[Spring Security,link=https://spring.io/projects/spring-security]
 image:https://img.shields.io/static/v1?label=Spring%20Boot&message=4.0.1&color=green[Spring Boot,link=https://spring.io/projects/spring-boot]
 image:https://img.shields.io/static/v1?label=Spring%20Cloud&message=2025.1.0&color=green[Spring Cloud,link=https://spring.io/projects/spring-cloud]
@@ -148,7 +148,7 @@ image::doc/image/老寇IoT云平台业务架构图.png[架构图,align=center]
 |组件                         |版本
 
 |Spring Boot                 |4.0.1
-|Spring Framework            |7.0.2
+|Spring Framework            |7.0.3
 |Spring Security             |7.0.2
 |Spring gRPC                 |1.0.0
 |Spring Data                 |2025.1.0

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的I
 <a href="https://gitcode.com/KouShenhai_/KCloud-Platform-IoT" target="_blank"><img src="https://gitcode.com/KouShenhai_/KCloud-Platform-IoT/star/badge.svg?theme=dark" alt="GitCode star"/></a>
 <a href="https://gitcode.com/KouShenhai_/KCloud-Platform-IoT" target="_blank"><img src="https://atomgit.com/KouShenhai_/KCloud-Platform-IoT/star/2025top.svg?theme=dark" alt="GitCode star"/></a>
 
-<a href="https://spring.io/projects/spring-framework" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Framework&message=7.0.2&color=green" alt="Spring Framework"/></a>
+<a href="https://spring.io/projects/spring-framework" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Framework&message=7.0.3&color=green" alt="Spring Framework"/></a>
 <a href="https://spring.io/projects/spring-authorization-server" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Security&message=7.0.2&color=green" alt="Spring Security"/></a>
 <a href="https://spring.io/projects/spring-boot" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Boot&message=4.0.1&color=green" alt="Spring Boot"/></a>
 <a href="https://spring.io/projects/spring-cloud" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Cloud&message=2025.1.0&color=green" alt="Spring Cloud"/></a>
@@ -137,7 +137,7 @@ KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的I
 |          组件          |     版本      |
 |:--------------------:|:-----------:|
 |     Spring Boot      |    4.0.1    |
-|   Spring Framework   |    7.0.2    |
+|   Spring Framework   |    7.0.3    |
 |   Spring Security    |    7.0.2    |
 |     Spring gRPC      |    1.0.0    |
 |     Spring Data      |  2025.1.0   |

--- a/archive/docs/01.指南/03.快速上手/04.更新日志.md
+++ b/archive/docs/01.指南/03.快速上手/04.更新日志.md
@@ -12,7 +12,7 @@ permalink: /pages/b04951/
 
 🚀 升级Spring Boot版本到4.0.0
 
-🚀 升级Spring Framework版本到7.0.2
+🚀 升级Spring Framework版本到7.0.3
 
 🚀 升级Spring Security版本到7.0.2
 


### PR DESCRIPTION
## Summary by Sourcery

在文档中更新 Spring Framework 版本引用，并清理 ARM aarch64 网关网络脚本中多余的注释。

增强：
- 从 ARM aarch64 边缘网关网络 shell 脚本中移除重复的以太网启用注释。

文档：
- 更新 README 徽章和版本表，将引用的 Spring Framework 版本从 7.0.2 改为 7.0.3。
- 调整归档文档路径及相关的 README 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Spring Framework version references in documentation and clean up a redundant comment in the ARM aarch64 gateway network script.

Enhancements:
- Remove a duplicate Ethernet enablement comment from the ARM aarch64 edge gateway network shell script.

Documentation:
- Update README badges and version table to reference Spring Framework 7.0.3 instead of 7.0.2.
- Adjust archived documentation paths and associated README resources.

</details>

增强内容：
- 移除边缘网关 ARM aarch64 网络 shell 脚本中多余的注释行。

文档：
- 将 README 徽章和版本表中的 Spring Framework 版本更新为 7.0.3。
- 调整归档文档路径及相关 README 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在文档中更新 Spring Framework 版本引用，并清理 ARM aarch64 网关网络脚本中多余的注释。

增强：
- 从 ARM aarch64 边缘网关网络 shell 脚本中移除重复的以太网启用注释。

文档：
- 更新 README 徽章和版本表，将引用的 Spring Framework 版本从 7.0.2 改为 7.0.3。
- 调整归档文档路径及相关的 README 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Spring Framework version references in documentation and clean up a redundant comment in the ARM aarch64 gateway network script.

Enhancements:
- Remove a duplicate Ethernet enablement comment from the ARM aarch64 edge gateway network shell script.

Documentation:
- Update README badges and version table to reference Spring Framework 7.0.3 instead of 7.0.2.
- Adjust archived documentation paths and associated README resources.

</details>

</details>