### PR TITLE
Dev

### DIFF
--- a/KEdge-Gateway/sh/arm_aarch64_network.sh
+++ b/KEdge-Gateway/sh/arm_aarch64_network.sh
@@ -66,8 +66,8 @@ local ipDns=$4
 nohup edge-gateway-network $ETH0 static "$ipAddr" "$ipGateway" "$ipDns" >/dev/null 2>&1 &
 }
 
-# 连接WIFI
-connect_wlan0() {
+# 连接WIFI并保存配置
+connect_wlan0_to_save() {
 # 删除配置文件
 sudo rm -f /etc/NetworkManager/system-connections/*wifi*
 sudo rm -f /etc/NetworkManager/system-connections/*wlan*
@@ -75,6 +75,11 @@ systemctl restart NetworkManager
 local ssid=$2
 local pwd=$3
 sudo nmcli con add type wifi con-name "default-wlan0" ssid "$ssid" wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$pwd"
+}
+
+# 连接WIFI
+connect_wifi() {
+sudo nmcli device connect $WLAN0
 }
 
 # 查看MAC地址【以太网】
@@ -158,8 +163,11 @@ case "$1" in
   connect_eth0_static)
     connect_eth0_static "$@"
     ;;
+  connect_wlan0_to_save)
+    connect_wlan0_to_save "$@"
+    ;;
   connect_wlan0)
-    connect_wlan0 "$@"
+    connect_wlan0
     ;;
   show_eth0_ip_gateway)
     show_eth0_ip_gateway

--- a/KEdge-Gateway/sh/arm_aarch64_network.sh
+++ b/KEdge-Gateway/sh/arm_aarch64_network.sh
@@ -66,6 +66,26 @@ local ipDns=$4
 nohup edge-gateway-network $ETH0 static "$ipAddr" "$ipGateway" "$ipDns" >/dev/null 2>&1 &
 }
 
+# 连接以太网
+connect_eth0() {
+sudo nmcli device connect $ETH0
+}
+
+# 断开以太网连接
+disconnect_eth0() {
+sudo nmcli device disconnect $ETH0
+}
+
+# 连接4G
+connect_usb0() {
+sudo nmcli device connect $USB0
+}
+
+# 断开4G
+disconnect_usb0() {
+sudo nmcli device disconnect $USB0
+}
+
 # 连接WIFI并保存配置
 connect_wlan0_to_save() {
 # 删除配置文件
@@ -78,8 +98,13 @@ sudo nmcli con add type wifi con-name "default-wlan0" ssid "$ssid" wifi-sec.key-
 }
 
 # 连接WIFI
-connect_wifi() {
+connect_wlan0() {
 sudo nmcli device connect $WLAN0
+}
+
+# 断开WIFI连接
+disconnect_wlan0() {
+sudo nmcli device disconnect $WLAN0
 }
 
 # 查看MAC地址【以太网】
@@ -163,11 +188,26 @@ case "$1" in
   connect_eth0_static)
     connect_eth0_static "$@"
     ;;
+  connect_eth0)
+  	connect_eth0
+  	;;
+  disconnect_eth0)
+  	disconnect_eth0
+  	;;
+  connect_usb0)
+  	connect_usb0
+  	;;
+  disconnect_usb0)
+  	disconnect_usb0
+  	;;
   connect_wlan0_to_save)
     connect_wlan0_to_save "$@"
     ;;
   connect_wlan0)
     connect_wlan0
+    ;;
+  disconnect_wlan0)
+    disconnect_wlan0
     ;;
   show_eth0_ip_gateway)
     show_eth0_ip_gateway

--- a/laokou-common/laokou-common-trace/pom.xml
+++ b/laokou-common/laokou-common-trace/pom.xml
@@ -41,11 +41,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.laokou</groupId>
-      <artifactId>laokou-common-log4j2</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
## Summary by Sourcery

在 ARM 网关上为以太网、Wi‑Fi 和 4G 添加网络管理命令，并简化 trace 模块的依赖。

新功能：
- 在 ARM 网关脚本中添加 CLI 函数，用于连接和断开以太网、Wi‑Fi 和 4G 设备。
- 引入一个 Wi‑Fi 连接命令，在连接前重新创建并保存默认配置。

增强：
- 从 trace 模块中移除 `laokou-common-log4j2` 依赖，以精简其依赖集合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add network management commands for Ethernet, Wi‑Fi, and 4G on ARM gateway and simplify trace module dependencies.

New Features:
- Add CLI functions to connect and disconnect Ethernet, Wi‑Fi, and 4G devices on the ARM gateway script.
- Introduce a Wi‑Fi connection command that recreates and saves default configuration before connecting.

Enhancements:
- Remove the laokou-common-log4j2 dependency from the trace module to streamline its dependency set.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network connectivity management with support for Ethernet, cellular (4G), and wireless (WLAN) interface controls.

* **Chores**
  * Removed unused dependency from the trace module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->