### PR TITLE
fix: maven构建失败

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -151,7 +151,7 @@ image::doc/image/老寇IoT云平台业务架构图.png[架构图,align=center]
 |Spring Framework            |7.0.3
 |Spring Security             |7.0.2
 |Spring gRPC                 |1.0.0
-|Spring Data                 |2025.1.0
+|Spring Data                 |2025.1.2
 |Spring Cloud                |2025.1.0
 |Spring Cloud Alibaba        |2025.1.0.0
 |Spring Boot Admin           |3.5.6

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的I
 |   Spring Framework   |    7.0.3    |
 |   Spring Security    |    7.0.2    |
 |     Spring gRPC      |    1.0.0    |
-|     Spring Data      |  2025.1.0   |
+|     Spring Data      |  2025.1.2   |
 |     Spring Cloud     |  2025.1.0   |
 | Spring Cloud Alibaba | 2025.1.0.0  |
 |  Spring Boot Admin   |    3.5.6    |

--- a/laokou-common/laokou-common-log4j2/src/main/java/org/laokou/common/log4j2/config/TtlThreadContextMap.java
+++ b/laokou-common/laokou-common-log4j2/src/main/java/org/laokou/common/log4j2/config/TtlThreadContextMap.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.TriConsumer;
 
+import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -36,11 +37,11 @@ import java.util.Objects;
  */
 public class TtlThreadContextMap implements ThreadContextMap, ReadOnlyStringMap {
 
-	private final ThreadLocal<Object[]> localState;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
-	public TtlThreadContextMap() {
-		localState = new TransmittableThreadLocal<>();
-	}
+	private final transient ThreadLocal<Object[]> localState = TransmittableThreadLocal
+		.withInitial(() -> new Object[0]);
 
 	@Override
 	public void put(final String key, final String value) {


### PR DESCRIPTION
## Summary by Sourcery

修复日志上下文映射初始化以兼容 Maven 构建，并更新文档中记录的 Spring Data 版本。

Bug 修复：
- 调整 `TtlThreadContextMap` 以使用可序列化、延迟初始化的 `TransmittableThreadLocal` 状态，从而解决 Maven 构建问题。

文档：
- 更新 README 以反映 Spring Data 2025.1.2 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix logging context map initialization to be compatible with Maven build and update documented Spring Data version.

Bug Fixes:
- Adjust TtlThreadContextMap to use a serializable, lazily initialized TransmittableThreadLocal state to resolve Maven build issues.

Documentation:
- Update README to reflect the Spring Data 2025.1.2 version.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spring Data version from 2025.1.0 to 2025.1.2 in documentation.

* **Refactor**
  * Enhanced serialization handling in core logging components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->