### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-security/pom.xml
+++ b/laokou-common/laokou-common-security/pom.xml
@@ -58,6 +58,27 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-test</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.3.5</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-testcontainers</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/BytesToOAuth2AuthorizationRequestConverter.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/BytesToOAuth2AuthorizationRequestConverter.java
@@ -34,6 +34,7 @@
 package org.laokou.common.security.config.convertor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
@@ -50,7 +51,7 @@ import tools.jackson.databind.json.JsonMapper;
 @ReadingConverter
 public final class BytesToOAuth2AuthorizationRequestConverter implements Converter<byte[], OAuth2AuthorizationRequest> {
 
-	private final JacksonJsonRedisSerializer<OAuth2AuthorizationRequest> serializer;
+	private final JacksonJsonRedisSerializer<@NonNull OAuth2AuthorizationRequest> serializer;
 
 	public BytesToOAuth2AuthorizationRequestConverter() {
 		ObjectMapper objectMapper = JsonMapper.builder()

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/ClaimsHolderMixin.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/ClaimsHolderMixin.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 
@@ -52,7 +53,7 @@ import java.util.Map;
 abstract class ClaimsHolderMixin {
 
 	@JsonCreator
-	ClaimsHolderMixin(@JsonProperty("claims") Map<String, Object> claims) {
+	ClaimsHolderMixin(@NonNull @JsonProperty("claims") Map<String, Object> claims) {
 	}
 
 }

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/ClaimsHolderToBytesConverter.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/ClaimsHolderToBytesConverter.java
@@ -34,6 +34,7 @@
 package org.laokou.common.security.config.convertor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.laokou.common.security.config.entity.OAuth2AuthorizationGrantAuthorization;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.WritingConverter;
@@ -49,9 +50,9 @@ import tools.jackson.databind.json.JsonMapper;
  */
 @WritingConverter
 public final class ClaimsHolderToBytesConverter
-		implements Converter<OAuth2AuthorizationGrantAuthorization.ClaimsHolder, byte[]> {
+		implements Converter<OAuth2AuthorizationGrantAuthorization.@NonNull ClaimsHolder, byte[]> {
 
-	private final JacksonJsonRedisSerializer<OAuth2AuthorizationGrantAuthorization.ClaimsHolder> serializer;
+	private final JacksonJsonRedisSerializer<OAuth2AuthorizationGrantAuthorization.@NonNull ClaimsHolder> serializer;
 
 	public ClaimsHolderToBytesConverter() {
 		ObjectMapper objectMapper = JsonMapper.builder()

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestToBytesConverter.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestToBytesConverter.java
@@ -34,6 +34,7 @@
 package org.laokou.common.security.config.convertor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
@@ -48,9 +49,10 @@ import tools.jackson.databind.json.JsonMapper;
  * @author laokou
  */
 @WritingConverter
-public final class OAuth2AuthorizationRequestToBytesConverter implements Converter<OAuth2AuthorizationRequest, byte[]> {
+public final class OAuth2AuthorizationRequestToBytesConverter
+		implements Converter<@NonNull OAuth2AuthorizationRequest, byte[]> {
 
-	private final JacksonJsonRedisSerializer<OAuth2AuthorizationRequest> serializer;
+	private final JacksonJsonRedisSerializer<@NonNull OAuth2AuthorizationRequest> serializer;
 
 	public OAuth2AuthorizationRequestToBytesConverter() {
 		ObjectMapper objectMapper = JsonMapper.builder()

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenToBytesConverter.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenToBytesConverter.java
@@ -34,6 +34,7 @@
 package org.laokou.common.security.config.convertor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
@@ -48,9 +49,9 @@ import tools.jackson.databind.json.JsonMapper;
  */
 @WritingConverter
 public final class UsernamePasswordAuthenticationTokenToBytesConverter
-		implements Converter<UsernamePasswordAuthenticationToken, byte[]> {
+		implements Converter<@NonNull UsernamePasswordAuthenticationToken, byte[]> {
 
-	private final JacksonJsonRedisSerializer<UsernamePasswordAuthenticationToken> serializer;
+	private final JacksonJsonRedisSerializer<@NonNull UsernamePasswordAuthenticationToken> serializer;
 
 	public UsernamePasswordAuthenticationTokenToBytesConverter() {
 		ObjectMapper objectMapper = JsonMapper.builder()

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2ModelMapperTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2ModelMapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * OAuth2ModelMapper测试类.
+ *
+ * @author laokou
+ */
+class OAuth2ModelMapperTest {
+
+	@Test
+	void test_custom_grant_type_username_password() {
+		// Then
+		Assertions.assertThat(OAuth2ModelMapper.USERNAME_PASSWORD).isNotNull();
+		Assertions.assertThat(OAuth2ModelMapper.USERNAME_PASSWORD.getValue()).isEqualTo("username_password");
+	}
+
+	@Test
+	void test_custom_grant_type_test() {
+		// Then
+		Assertions.assertThat(OAuth2ModelMapper.TEST).isNotNull();
+		Assertions.assertThat(OAuth2ModelMapper.TEST.getValue()).isEqualTo("test");
+	}
+
+	@Test
+	void test_custom_grant_type_mail() {
+		// Then
+		Assertions.assertThat(OAuth2ModelMapper.MAIL).isNotNull();
+		Assertions.assertThat(OAuth2ModelMapper.MAIL.getValue()).isEqualTo("mail");
+	}
+
+	@Test
+	void test_custom_grant_type_mobile() {
+		// Then
+		Assertions.assertThat(OAuth2ModelMapper.MOBILE).isNotNull();
+		Assertions.assertThat(OAuth2ModelMapper.MOBILE.getValue()).isEqualTo("mobile");
+	}
+
+	@Test
+	void test_custom_grant_types_are_different() {
+		// Then
+		Assertions.assertThat(OAuth2ModelMapper.USERNAME_PASSWORD)
+			.isNotEqualTo(OAuth2ModelMapper.TEST)
+			.isNotEqualTo(OAuth2ModelMapper.MAIL)
+			.isNotEqualTo(OAuth2ModelMapper.MOBILE);
+	}
+
+	@Test
+	void test_custom_grant_types_not_equal_to_standard_types() {
+		// Then
+		Assertions.assertThat(OAuth2ModelMapper.USERNAME_PASSWORD)
+			.isNotEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.isNotEqualTo(AuthorizationGrantType.CLIENT_CREDENTIALS)
+			.isNotEqualTo(AuthorizationGrantType.REFRESH_TOKEN);
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+
+/**
+ * OAuth2OpaqueTokenIntrospector测试类.
+ *
+ * @author laokou
+ */
+@ExtendWith(MockitoExtension.class)
+class OAuth2OpaqueTokenIntrospectorTest {
+
+	@Mock
+	private OAuth2AuthorizationService authorizationService;
+
+	@Test
+	void test_introspect_throws_exception_when_authorization_is_null() {
+		// Given
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService);
+		Mockito.when(authorizationService.findByToken("invalid-token", OAuth2TokenType.ACCESS_TOKEN)).thenReturn(null);
+
+		// Then
+		Assertions.assertThatThrownBy(() -> introspector.introspect("invalid-token")).isNotNull();
+	}
+
+	@Test
+	void test_introspect_throws_exception_when_accessToken_is_null() {
+		// Given
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService);
+		RegisteredClient registeredClient = createRegisteredClient();
+		OAuth2Authorization authorization = OAuth2Authorization.withRegisteredClient(registeredClient)
+			.principalName("user")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.build();
+		Mockito.when(authorizationService.findByToken("token-without-access", OAuth2TokenType.ACCESS_TOKEN))
+			.thenReturn(authorization);
+
+		// Then
+		Assertions.assertThatThrownBy(() -> introspector.introspect("token-without-access")).isNotNull();
+	}
+
+	@Test
+	void test_record_constructor() {
+		// When
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService);
+
+		// Then
+		Assertions.assertThat(introspector.authorizationService()).isEqualTo(authorizationService);
+	}
+
+	private RegisteredClient createRegisteredClient() {
+		return RegisteredClient.withId("client-1")
+			.clientId("my-client")
+			.clientSecret("secret")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+			.redirectUri("https://example.com/callback")
+			.scope("openid")
+			.clientSettings(ClientSettings.builder().build())
+			.tokenSettings(TokenSettings.builder().build())
+			.build();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2ResourceServerPropertiesTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2ResourceServerPropertiesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * OAuth2ResourceServerProperties测试类.
+ *
+ * @author laokou
+ */
+class OAuth2ResourceServerPropertiesTest {
+
+	@Test
+	void test_default_enabled_is_true() {
+		// Given
+		OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+
+		// Then
+		Assertions.assertThat(properties.isEnabled()).isTrue();
+	}
+
+	@Test
+	void test_default_requestMatcher_is_not_null() {
+		// Given
+		OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+
+		// Then
+		Assertions.assertThat(properties.getRequestMatcher()).isNotNull();
+		Assertions.assertThat(properties.getRequestMatcher().getIgnorePatterns()).isNotNull().isEmpty();
+	}
+
+	@Test
+	void test_setEnabled() {
+		// Given
+		OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+
+		// When
+		properties.setEnabled(false);
+
+		// Then
+		Assertions.assertThat(properties.isEnabled()).isFalse();
+	}
+
+	@Test
+	void test_setIgnorePatterns() {
+		// Given
+		OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+		Map<String, Set<String>> ignorePatterns = new HashMap<>();
+		Set<String> services = new HashSet<>();
+		services.add("laokou-admin");
+		ignorePatterns.put("/actuator/**", services);
+
+		// When
+		properties.getRequestMatcher().setIgnorePatterns(ignorePatterns);
+
+		// Then
+		Assertions.assertThat(properties.getRequestMatcher().getIgnorePatterns()).hasSize(1);
+		Assertions.assertThat(properties.getRequestMatcher().getIgnorePatterns().get("/actuator/**"))
+			.contains("laokou-admin");
+	}
+
+	@Test
+	void test_requestMatcher_default_ignorePatterns_is_empty_map() {
+		// Given
+		OAuth2ResourceServerProperties.RequestMatcher requestMatcher = new OAuth2ResourceServerProperties.RequestMatcher();
+
+		// Then
+		Assertions.assertThat(requestMatcher.getIgnorePatterns()).isNotNull().isEmpty();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentServiceTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentServiceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.laokou.common.security.config.entity.OAuth2UserConsent;
+import org.laokou.common.security.config.repository.OAuth2UserConsentRepository;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * RedisOAuth2AuthorizationConsentService测试类.
+ *
+ * @author laokou
+ */
+@ExtendWith(MockitoExtension.class)
+class RedisOAuth2AuthorizationConsentServiceTest {
+
+	@Mock
+	private OAuth2UserConsentRepository userConsentRepository;
+
+	private RedisOAuth2AuthorizationConsentService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new RedisOAuth2AuthorizationConsentService(userConsentRepository);
+	}
+
+	@Test
+	void test_constructor_throws_exception_when_repository_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> new RedisOAuth2AuthorizationConsentService(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("UserConsentRepository cannot be null");
+	}
+
+	@Test
+	void test_save_authorizationConsent() {
+		// Given
+		OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent.withId("client-1", "user-1")
+			.authority(new SimpleGrantedAuthority("SCOPE_read"))
+			.build();
+
+		// When
+		service.save(consent);
+
+		// Then
+		Mockito.verify(userConsentRepository).save(Mockito.any(OAuth2UserConsent.class));
+	}
+
+	@Test
+	void test_remove_authorizationConsent() {
+		// Given
+		OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent.withId("client-1", "user-1")
+			.authority(new SimpleGrantedAuthority("SCOPE_read"))
+			.build();
+
+		// When
+		service.remove(consent);
+
+		// Then
+		Mockito.verify(userConsentRepository).deleteByRegisteredClientIdAndPrincipalName("client-1", "user-1");
+	}
+
+	@Test
+	void test_findById_returns_null_when_not_found() {
+		// Given
+		Mockito.when(userConsentRepository.findByRegisteredClientIdAndPrincipalName("client-1", "user-1"))
+			.thenReturn(null);
+
+		// When
+		OAuth2AuthorizationConsent result = service.findById("client-1", "user-1");
+
+		// Then
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void test_findById_returns_consent_when_found() {
+		// Given
+		Set<org.springframework.security.core.GrantedAuthority> authorities = new HashSet<>();
+		authorities.add(new SimpleGrantedAuthority("SCOPE_read"));
+		OAuth2UserConsent userConsent = new OAuth2UserConsent("client-1:user-1", "client-1", "user-1", authorities);
+		Mockito.when(userConsentRepository.findByRegisteredClientIdAndPrincipalName("client-1", "user-1"))
+			.thenReturn(userConsent);
+
+		// When
+		OAuth2AuthorizationConsent result = service.findById("client-1", "user-1");
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getRegisteredClientId()).isEqualTo("client-1");
+		Assertions.assertThat(result.getPrincipalName()).isEqualTo("user-1");
+	}
+
+	@Test
+	void test_save_throws_exception_when_consent_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.save(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("AuthorizationConsent cannot be null");
+	}
+
+	@Test
+	void test_findById_throws_exception_when_registeredClientId_is_empty() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.findById("", "user-1"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("RegisteredClientId cannot be empty");
+	}
+
+	@Test
+	void test_findById_throws_exception_when_principalName_is_empty() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.findById("client-1", ""))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("PrincipalName cannot be empty");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationServiceTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationServiceTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.laokou.common.security.config.repository.OAuth2AuthorizationGrantAuthorizationRepository;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+
+import java.util.Optional;
+
+/**
+ * RedisOAuth2AuthorizationService测试类.
+ *
+ * @author laokou
+ */
+@ExtendWith(MockitoExtension.class)
+class RedisOAuth2AuthorizationServiceTest {
+
+	@Mock
+	private RegisteredClientRepository registeredClientRepository;
+
+	@Mock
+	private OAuth2AuthorizationGrantAuthorizationRepository authorizationGrantAuthorizationRepository;
+
+	private RedisOAuth2AuthorizationService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new RedisOAuth2AuthorizationService(registeredClientRepository,
+				authorizationGrantAuthorizationRepository);
+	}
+
+	@Test
+	void test_constructor_throws_exception_when_registeredClientRepository_is_null() {
+		// Then
+		Assertions
+			.assertThatThrownBy(
+					() -> new RedisOAuth2AuthorizationService(null, authorizationGrantAuthorizationRepository))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("RegisteredClientRepository cannot be null");
+	}
+
+	@Test
+	void test_constructor_throws_exception_when_authorizationGrantAuthorizationRepository_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> new RedisOAuth2AuthorizationService(registeredClientRepository, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("AuthorizationGrantAuthorizationRepository cannot be null");
+	}
+
+	@Test
+	void test_remove_authorization() {
+		// Given
+		RegisteredClient registeredClient = createRegisteredClient();
+		OAuth2Authorization authorization = OAuth2Authorization.withRegisteredClient(registeredClient)
+			.principalName("user")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.build();
+
+		// When
+		service.remove(authorization);
+
+		// Then
+		Mockito.verify(authorizationGrantAuthorizationRepository).deleteById(authorization.getId());
+	}
+
+	@Test
+	void test_findById_returns_null_when_not_found() {
+		// Given
+		Mockito.when(authorizationGrantAuthorizationRepository.findById("non-existent")).thenReturn(Optional.empty());
+
+		// When
+		OAuth2Authorization result = service.findById("non-existent");
+
+		// Then
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void test_findByToken_returns_null_when_not_found() {
+		// Given
+		Mockito.when(authorizationGrantAuthorizationRepository.findByAccessToken_TokenValue("non-existent-token"))
+			.thenReturn(null);
+
+		// When
+		OAuth2Authorization result = service.findByToken("non-existent-token", OAuth2TokenType.ACCESS_TOKEN);
+
+		// Then
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void test_save_throws_exception_when_authorization_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.save(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Authorization cannot be null");
+	}
+
+	@Test
+	void test_remove_throws_exception_when_authorization_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.remove(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("authorization cannot be null");
+	}
+
+	@Test
+	void test_findById_throws_exception_when_id_is_empty() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.findById(""))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("id cannot be empty");
+	}
+
+	@Test
+	void test_findByToken_throws_exception_when_token_is_empty() {
+		// Then
+		Assertions.assertThatThrownBy(() -> service.findByToken("", OAuth2TokenType.ACCESS_TOKEN))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Token cannot be empty");
+	}
+
+	private RegisteredClient createRegisteredClient() {
+		return RegisteredClient.withId("client-1")
+			.clientId("my-client")
+			.clientSecret("secret")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+			.redirectUri("https://example.com/callback")
+			.scope("openid")
+			.clientSettings(ClientSettings.builder().build())
+			.tokenSettings(TokenSettings.builder().build())
+			.build();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisRegisteredClientRepositoryTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisRegisteredClientRepositoryTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.laokou.common.security.config.entity.OAuth2RegisteredClient;
+import org.laokou.common.security.config.repository.OAuth2RegisteredClientRepository;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+
+import java.util.Optional;
+
+/**
+ * RedisRegisteredClientRepository测试类.
+ *
+ * @author laokou
+ */
+@ExtendWith(MockitoExtension.class)
+class RedisRegisteredClientRepositoryTest {
+
+	@Mock
+	private OAuth2RegisteredClientRepository registeredClientRepository;
+
+	private RedisRegisteredClientRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		repository = new RedisRegisteredClientRepository(registeredClientRepository);
+	}
+
+	@Test
+	void test_constructor_throws_exception_when_repository_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> new RedisRegisteredClientRepository(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("RegisteredClientRepository cannot be null");
+	}
+
+	@Test
+	void test_save_registeredClient() {
+		// Given
+		RegisteredClient registeredClient = RegisteredClient.withId("client-1")
+			.clientId("my-client")
+			.clientSecret("secret")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+			.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+			.redirectUri("https://example.com/callback")
+			.scope("openid")
+			.clientSettings(ClientSettings.builder().build())
+			.tokenSettings(TokenSettings.builder().build())
+			.build();
+
+		// When
+		repository.save(registeredClient);
+
+		// Then
+		Mockito.verify(registeredClientRepository).save(Mockito.any(OAuth2RegisteredClient.class));
+	}
+
+	@Test
+	void test_findById_returns_null_when_not_found() {
+		// Given
+		Mockito.when(registeredClientRepository.findById("non-existent")).thenReturn(Optional.empty());
+
+		// When
+		RegisteredClient result = repository.findById("non-existent");
+
+		// Then
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void test_findByClientId_returns_null_when_not_found() {
+		// Given
+		Mockito.when(registeredClientRepository.findByClientId("non-existent")).thenReturn(null);
+
+		// When
+		RegisteredClient result = repository.findByClientId("non-existent");
+
+		// Then
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void test_save_throws_exception_when_client_is_null() {
+		// Then
+		Assertions.assertThatThrownBy(() -> repository.save(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("RegisteredClient cannot be null");
+	}
+
+	@Test
+	void test_findById_throws_exception_when_id_is_empty() {
+		// Then
+		Assertions.assertThatThrownBy(() -> repository.findById(""))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Id cannot be empty");
+	}
+
+	@Test
+	void test_findByClientId_throws_exception_when_clientId_is_empty() {
+		// Then
+		Assertions.assertThatThrownBy(() -> repository.findByClientId(""))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("ClientId cannot be empty");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/TransmittableThreadLocalSecurityContextHolderStrategyTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/TransmittableThreadLocalSecurityContextHolderStrategyTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+import java.util.function.Supplier;
+
+/**
+ * TransmittableThreadLocalSecurityContextHolderStrategy测试类.
+ *
+ * @author laokou
+ */
+class TransmittableThreadLocalSecurityContextHolderStrategyTest {
+
+	private TransmittableThreadLocalSecurityContextHolderStrategy strategy;
+
+	@BeforeEach
+	void setUp() {
+		strategy = new TransmittableThreadLocalSecurityContextHolderStrategy();
+		strategy.clearContext();
+	}
+
+	@Test
+	void test_setContext_and_getContext() {
+		// Given
+		SecurityContext context = new SecurityContextImpl();
+
+		// When
+		strategy.setContext(context);
+		SecurityContext result = strategy.getContext();
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isSameAs(context);
+	}
+
+	@Test
+	void test_clearContext() {
+		// Given
+		SecurityContext context = new SecurityContextImpl();
+		strategy.setContext(context);
+
+		// When
+		strategy.clearContext();
+		SecurityContext result = strategy.getContext();
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isNotSameAs(context);
+	}
+
+	@Test
+	void test_createEmptyContext() {
+		// When
+		SecurityContext result = strategy.createEmptyContext();
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isInstanceOf(SecurityContextImpl.class);
+		Assertions.assertThat(result.getAuthentication()).isNull();
+	}
+
+	@Test
+	void test_getDeferredContext_returns_empty_context_when_not_set() {
+		// When
+		Supplier<SecurityContext> result = strategy.getDeferredContext();
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.get()).isNotNull().isInstanceOf(SecurityContextImpl.class);
+	}
+
+	@Test
+	void test_setDeferredContext_and_getDeferredContext() {
+		// Given
+		SecurityContext context = new SecurityContextImpl();
+		Supplier<SecurityContext> deferredContext = () -> context;
+
+		// When
+		strategy.setDeferredContext(deferredContext);
+		Supplier<SecurityContext> result = strategy.getDeferredContext();
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.get()).isSameAs(context);
+	}
+
+	@Test
+	void test_setContext_with_null_throws_exception() {
+		// When & Then
+		Assertions.assertThatThrownBy(() -> strategy.setContext(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Only non-null SecurityContext instances are permitted");
+	}
+
+	@Test
+	void test_setDeferredContext_with_null_throws_exception() {
+		// When & Then
+		Assertions.assertThatThrownBy(() -> strategy.setDeferredContext(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Only non-null Supplier instances are permitted");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToClaimsHolderConverterTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToClaimsHolderConverterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.security.config.entity.OAuth2AuthorizationGrantAuthorization;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * BytesToClaimsHolderConverter测试类.
+ *
+ * @author laokou
+ */
+class BytesToClaimsHolderConverterTest {
+
+	private BytesToClaimsHolderConverter converter;
+
+	private ClaimsHolderToBytesConverter toByteConverter;
+
+	@BeforeEach
+	void setUp() {
+		converter = new BytesToClaimsHolderConverter();
+		toByteConverter = new ClaimsHolderToBytesConverter();
+	}
+
+	@Test
+	void test_convert_bytes_to_claimsHolder() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", "user123");
+		claims.put("iss", "https://issuer.com");
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder originalClaimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+		byte[] bytes = toByteConverter.convert(originalClaimsHolder);
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder result = converter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.claims()).isNotNull();
+		Assertions.assertThat(result.claims().get("sub")).isEqualTo("user123");
+		Assertions.assertThat(result.claims().get("iss")).isEqualTo("https://issuer.com");
+	}
+
+	@Test
+	void test_convert_empty_claims_roundtrip() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder originalClaimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+		byte[] bytes = toByteConverter.convert(originalClaimsHolder);
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder result = converter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.claims()).isNotNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToOAuth2AuthorizationRequestConverterTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToOAuth2AuthorizationRequestConverterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * BytesToOAuth2AuthorizationRequestConverter测试类.
+ *
+ * @author laokou
+ */
+class BytesToOAuth2AuthorizationRequestConverterTest {
+
+	private BytesToOAuth2AuthorizationRequestConverter converter;
+
+	private OAuth2AuthorizationRequestToBytesConverter toByteConverter;
+
+	@BeforeEach
+	void setUp() {
+		converter = new BytesToOAuth2AuthorizationRequestConverter();
+		toByteConverter = new OAuth2AuthorizationRequestToBytesConverter();
+	}
+
+	@Test
+	void test_convert_bytes_to_authorizationRequest() {
+		// Given
+		OAuth2AuthorizationRequest originalRequest = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://example.com/oauth2/authorize")
+			.clientId("test-client")
+			.redirectUri("https://example.com/callback")
+			.scope("openid", "profile")
+			.state("random-state")
+			.build();
+		byte[] bytes = toByteConverter.convert(originalRequest);
+
+		// When
+		OAuth2AuthorizationRequest result = converter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getAuthorizationUri()).isEqualTo("https://example.com/oauth2/authorize");
+		Assertions.assertThat(result.getClientId()).isEqualTo("test-client");
+		Assertions.assertThat(result.getRedirectUri()).isEqualTo("https://example.com/callback");
+		Assertions.assertThat(result.getScopes()).containsExactlyInAnyOrder("openid", "profile");
+		Assertions.assertThat(result.getState()).isEqualTo("random-state");
+	}
+
+	@Test
+	void test_convert_minimal_request_roundtrip() {
+		// Given
+		OAuth2AuthorizationRequest originalRequest = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://example.com/oauth2/authorize")
+			.clientId("test-client")
+			.build();
+		byte[] bytes = toByteConverter.convert(originalRequest);
+
+		// When
+		OAuth2AuthorizationRequest result = converter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getClientId()).isEqualTo("test-client");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToUsernamePasswordAuthenticationTokenConverterTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToUsernamePasswordAuthenticationTokenConverterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+
+/**
+ * BytesToUsernamePasswordAuthenticationTokenConverter测试类.
+ *
+ * @author laokou
+ */
+class BytesToUsernamePasswordAuthenticationTokenConverterTest {
+
+	private BytesToUsernamePasswordAuthenticationTokenConverter converter;
+
+	private UsernamePasswordAuthenticationTokenToBytesConverter toByteConverter;
+
+	@BeforeEach
+	void setUp() {
+		converter = new BytesToUsernamePasswordAuthenticationTokenConverter();
+		toByteConverter = new UsernamePasswordAuthenticationTokenToBytesConverter();
+	}
+
+	@Test
+	void test_convert_bytes_to_authenticationToken() {
+		// Given
+		UsernamePasswordAuthenticationToken originalToken = UsernamePasswordAuthenticationToken.authenticated("user",
+				null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+		byte[] bytes = toByteConverter.convert(originalToken);
+
+		// When
+		UsernamePasswordAuthenticationToken result = converter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getName()).isEqualTo("user");
+		Assertions.assertThat(result.isAuthenticated()).isTrue();
+	}
+
+	@Test
+	void test_convert_unauthenticated_token_roundtrip() {
+		// Given
+		UsernamePasswordAuthenticationToken originalToken = UsernamePasswordAuthenticationToken.unauthenticated("user",
+				null);
+		byte[] bytes = toByteConverter.convert(originalToken);
+
+		// When
+		UsernamePasswordAuthenticationToken result = converter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getName()).isEqualTo("user");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/ClaimsHolderConverterIntegrationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/ClaimsHolderConverterIntegrationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import com.redis.testcontainers.RedisContainer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.security.config.entity.OAuth2AuthorizationGrantAuthorization;
+import org.laokou.common.testcontainers.util.DockerImageNames;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ClaimsHolder转换器集成测试类 - 使用Testcontainers.
+ *
+ * @author laokou
+ */
+@Testcontainers
+class ClaimsHolderConverterIntegrationTest {
+
+	@Container
+	static RedisContainer redisContainer = new RedisContainer(DockerImageNames.redis()).withExposedPorts(6379)
+		.withReuse(true);
+
+	private RedisTemplate<String, byte[]> redisTemplate;
+
+	private ClaimsHolderToBytesConverter toBytesConverter;
+
+	private BytesToClaimsHolderConverter fromBytesConverter;
+
+	@BeforeEach
+	void setUp() {
+		String redisHost = redisContainer.getHost();
+		Integer redisPort = redisContainer.getMappedPort(6379);
+
+		// 配置 Redis 连接
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisConfig);
+		connectionFactory.afterPropertiesSet();
+
+		// 配置 RedisTemplate
+		redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+
+		// 初始化转换器
+		toBytesConverter = new ClaimsHolderToBytesConverter();
+		fromBytesConverter = new BytesToClaimsHolderConverter();
+	}
+
+	@Test
+	@DisplayName("Test ClaimsHolder serialize and store to Redis then read back")
+	void test_claimsHolder_serialize_and_store_to_redis() {
+		// Given
+		String key = "test:claims:holder";
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", "user123");
+		claims.put("iss", "https://issuer.com");
+		claims.put("aud", "client-app");
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When - 序列化并存储
+		byte[] bytes = toBytesConverter.convert(claimsHolder);
+		redisTemplate.opsForValue().set(key, bytes);
+
+		// Then - 读取并反序列化
+		byte[] storedBytes = redisTemplate.opsForValue().get(key);
+		Assertions.assertThat(storedBytes).isNotNull();
+
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder result = fromBytesConverter.convert(storedBytes);
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.claims().get("sub")).isEqualTo("user123");
+		Assertions.assertThat(result.claims().get("iss")).isEqualTo("https://issuer.com");
+		Assertions.assertThat(result.claims().get("aud")).isEqualTo("client-app");
+	}
+
+	@Test
+	@DisplayName("Test ClaimsHolder full serialization roundtrip")
+	void test_claimsHolder_full_roundtrip() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("test_key", "test_value");
+		claims.put("number", 12345);
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder original = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.claims()).containsEntry("test_key", "test_value");
+		Assertions.assertThat(result.claims()).containsEntry("number", 12345);
+	}
+
+	@Test
+	@DisplayName("Test empty claims serialization roundtrip")
+	void test_empty_claimsHolder_roundtrip() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder original = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.claims()).isEmpty();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/ClaimsHolderToBytesConverterTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/ClaimsHolderToBytesConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.security.config.entity.OAuth2AuthorizationGrantAuthorization;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ClaimsHolderToBytesConverter测试类.
+ *
+ * @author laokou
+ */
+class ClaimsHolderToBytesConverterTest {
+
+	private ClaimsHolderToBytesConverter converter;
+
+	@BeforeEach
+	void setUp() {
+		converter = new ClaimsHolderToBytesConverter();
+	}
+
+	@Test
+	void test_convert_claimsHolder_to_bytes() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", "user123");
+		claims.put("iss", "https://issuer.com");
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When
+		byte[] result = converter.convert(claimsHolder);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isNotEmpty();
+	}
+
+	@Test
+	void test_convert_empty_claimsHolder_to_bytes() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When
+		byte[] result = converter.convert(claimsHolder);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestConverterIntegrationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestConverterIntegrationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import com.redis.testcontainers.RedisContainer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.testcontainers.util.DockerImageNames;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * OAuth2AuthorizationRequest转换器集成测试类 - 使用Testcontainers.
+ *
+ * @author laokou
+ */
+@Testcontainers
+class OAuth2AuthorizationRequestConverterIntegrationTest {
+
+	@Container
+	static RedisContainer redisContainer = new RedisContainer(DockerImageNames.redis()).withExposedPorts(6379)
+		.withReuse(true);
+
+	private RedisTemplate<String, byte[]> redisTemplate;
+
+	private OAuth2AuthorizationRequestToBytesConverter toBytesConverter;
+
+	private BytesToOAuth2AuthorizationRequestConverter fromBytesConverter;
+
+	@BeforeEach
+	void setUp() {
+		String redisHost = redisContainer.getHost();
+		Integer redisPort = redisContainer.getMappedPort(6379);
+
+		// 配置 Redis 连接
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisConfig);
+		connectionFactory.afterPropertiesSet();
+
+		// 配置 RedisTemplate
+		redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+
+		// 初始化转换器
+		toBytesConverter = new OAuth2AuthorizationRequestToBytesConverter();
+		fromBytesConverter = new BytesToOAuth2AuthorizationRequestConverter();
+	}
+
+	@Test
+	@DisplayName("Test OAuth2AuthorizationRequest serialize and store to Redis then read back")
+	void test_authorizationRequest_serialize_and_store_to_redis() {
+		// Given
+		String key = "test:oauth2:request";
+		OAuth2AuthorizationRequest request = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://auth.example.com/oauth2/authorize")
+			.clientId("client-123")
+			.redirectUri("https://app.example.com/callback")
+			.scope("openid", "profile", "email")
+			.state("random-state-value")
+			.build();
+
+		// When - 序列化并存储
+		byte[] bytes = toBytesConverter.convert(request);
+		redisTemplate.opsForValue().set(key, bytes);
+
+		// Then - 读取并反序列化
+		byte[] storedBytes = redisTemplate.opsForValue().get(key);
+		Assertions.assertThat(storedBytes).isNotNull();
+
+		OAuth2AuthorizationRequest result = fromBytesConverter.convert(storedBytes);
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getAuthorizationUri()).isEqualTo("https://auth.example.com/oauth2/authorize");
+		Assertions.assertThat(result.getClientId()).isEqualTo("client-123");
+		Assertions.assertThat(result.getRedirectUri()).isEqualTo("https://app.example.com/callback");
+		Assertions.assertThat(result.getScopes()).containsExactlyInAnyOrder("openid", "profile", "email");
+		Assertions.assertThat(result.getState()).isEqualTo("random-state-value");
+	}
+
+	@Test
+	@DisplayName("Test OAuth2AuthorizationRequest full serialization roundtrip")
+	void test_authorizationRequest_full_roundtrip() {
+		// Given
+		OAuth2AuthorizationRequest original = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://example.com/authorize")
+			.clientId("test-client")
+			.redirectUri("https://example.com/callback")
+			.scope("read", "write")
+			.state("xyz123")
+			.additionalParameters(params -> params.put("nonce", "nonce-value"))
+			.build();
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		OAuth2AuthorizationRequest result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getClientId()).isEqualTo("test-client");
+		Assertions.assertThat(result.getScopes()).containsExactlyInAnyOrder("read", "write");
+		Assertions.assertThat(result.getAdditionalParameters()).containsEntry("nonce", "nonce-value");
+	}
+
+	@Test
+	@DisplayName("Test minimal OAuth2AuthorizationRequest serialization roundtrip")
+	void test_minimal_authorizationRequest_roundtrip() {
+		// Given
+		OAuth2AuthorizationRequest original = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://example.com/authorize")
+			.clientId("minimal-client")
+			.build();
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		OAuth2AuthorizationRequest result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getClientId()).isEqualTo("minimal-client");
+		Assertions.assertThat(result.getAuthorizationUri()).isEqualTo("https://example.com/authorize");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestToBytesConverterTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestToBytesConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * OAuth2AuthorizationRequestToBytesConverter测试类.
+ *
+ * @author laokou
+ */
+class OAuth2AuthorizationRequestToBytesConverterTest {
+
+	private OAuth2AuthorizationRequestToBytesConverter converter;
+
+	@BeforeEach
+	void setUp() {
+		converter = new OAuth2AuthorizationRequestToBytesConverter();
+	}
+
+	@Test
+	void test_convert_authorizationRequest_to_bytes() {
+		// Given
+		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://example.com/oauth2/authorize")
+			.clientId("test-client")
+			.redirectUri("https://example.com/callback")
+			.scope("openid", "profile")
+			.state("random-state")
+			.build();
+
+		// When
+		byte[] result = converter.convert(authorizationRequest);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isNotEmpty();
+	}
+
+	@Test
+	void test_convert_minimal_authorizationRequest_to_bytes() {
+		// Given
+		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://example.com/oauth2/authorize")
+			.clientId("test-client")
+			.build();
+
+		// When
+		byte[] result = converter.convert(authorizationRequest);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isNotEmpty();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenConverterIntegrationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenConverterIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import com.redis.testcontainers.RedisContainer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.laokou.common.testcontainers.util.DockerImageNames;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * UsernamePasswordAuthenticationToken转换器集成测试类 - 使用Testcontainers.
+ *
+ * @author laokou
+ */
+@Testcontainers
+class UsernamePasswordAuthenticationTokenConverterIntegrationTest {
+
+	@Container
+	static RedisContainer redisContainer = new RedisContainer(DockerImageNames.redis()).withExposedPorts(6379)
+		.withReuse(true);
+
+	private RedisTemplate<String, byte[]> redisTemplate;
+
+	private UsernamePasswordAuthenticationTokenToBytesConverter toBytesConverter;
+
+	private BytesToUsernamePasswordAuthenticationTokenConverter fromBytesConverter;
+
+	@BeforeEach
+	void setUp() {
+		String redisHost = redisContainer.getHost();
+		Integer redisPort = redisContainer.getMappedPort(6379);
+
+		// 配置 Redis 连接
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisConfig);
+		connectionFactory.afterPropertiesSet();
+
+		// 配置 RedisTemplate
+		redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+
+		// 初始化转换器
+		toBytesConverter = new UsernamePasswordAuthenticationTokenToBytesConverter();
+		fromBytesConverter = new BytesToUsernamePasswordAuthenticationTokenConverter();
+	}
+
+	@Test
+	@DisplayName("Test authenticated token serialize and store to Redis then read back")
+	void test_authenticated_token_serialize_and_store_to_redis() {
+		// Given
+		String key = "test:auth:token";
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.authenticated("admin", null,
+				Arrays.asList(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER")));
+
+		// When - 序列化并存储
+		byte[] bytes = toBytesConverter.convert(token);
+		redisTemplate.opsForValue().set(key, bytes);
+
+		// Then - 读取并反序列化
+		byte[] storedBytes = redisTemplate.opsForValue().get(key);
+		Assertions.assertThat(storedBytes).isNotNull();
+
+		UsernamePasswordAuthenticationToken result = fromBytesConverter.convert(storedBytes);
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getName()).isEqualTo("admin");
+		Assertions.assertThat(result.isAuthenticated()).isTrue();
+		Assertions.assertThat(result.getAuthorities()).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("Test token full serialization roundtrip")
+	void test_token_full_roundtrip() {
+		// Given
+		UsernamePasswordAuthenticationToken original = UsernamePasswordAuthenticationToken.authenticated("user123",
+				null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		UsernamePasswordAuthenticationToken result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getName()).isEqualTo("user123");
+		Assertions.assertThat(result.getAuthorities().stream().map(auth -> auth.getAuthority()))
+			.containsExactly("ROLE_USER");
+	}
+
+	@Test
+	@DisplayName("Test unauthenticated token serialization roundtrip")
+	void test_unauthenticated_token_roundtrip() {
+		// Given
+		UsernamePasswordAuthenticationToken original = UsernamePasswordAuthenticationToken.unauthenticated("guest",
+				null);
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		UsernamePasswordAuthenticationToken result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getName()).isEqualTo("guest");
+	}
+
+	@Test
+	@DisplayName("Test token with multiple authorities serialization roundtrip")
+	void test_token_with_multiple_authorities_roundtrip() {
+		// Given
+		UsernamePasswordAuthenticationToken original = UsernamePasswordAuthenticationToken.authenticated("superadmin",
+				null, Arrays.asList(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"),
+						new SimpleGrantedAuthority("SCOPE_read"), new SimpleGrantedAuthority("SCOPE_write")));
+
+		// When
+		byte[] bytes = toBytesConverter.convert(original);
+		UsernamePasswordAuthenticationToken result = fromBytesConverter.convert(bytes);
+
+		// Then
+		Assertions.assertThat(result).isNotNull();
+		Assertions.assertThat(result.getAuthorities()).hasSize(4);
+		Assertions.assertThat(result.getAuthorities().stream().map(auth -> auth.getAuthority()))
+			.containsExactlyInAnyOrder("ROLE_ADMIN", "ROLE_USER", "SCOPE_read", "SCOPE_write");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenToBytesConverterTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenToBytesConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.convertor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+
+/**
+ * UsernamePasswordAuthenticationTokenToBytesConverter测试类.
+ *
+ * @author laokou
+ */
+class UsernamePasswordAuthenticationTokenToBytesConverterTest {
+
+	private UsernamePasswordAuthenticationTokenToBytesConverter converter;
+
+	@BeforeEach
+	void setUp() {
+		converter = new UsernamePasswordAuthenticationTokenToBytesConverter();
+	}
+
+	@Test
+	void test_convert_authenticationToken_to_bytes() {
+		// Given
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.authenticated("user",
+				"password", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// When
+		byte[] result = converter.convert(token);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isNotEmpty();
+	}
+
+	@Test
+	void test_convert_unauthenticated_token_to_bytes() {
+		// Given
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.unauthenticated("user",
+				"password");
+
+		// When
+		byte[] result = converter.convert(token);
+
+		// Then
+		Assertions.assertThat(result).isNotNull().isNotEmpty();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2AuthorizationCodeGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2AuthorizationCodeGrantAuthorizationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2AuthorizationCodeGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2AuthorizationCodeGrantAuthorizationTest {
+
+	@Test
+	void test_authorizationCode_creation() {
+		// Given
+		String tokenValue = "auth_code_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(300);
+
+		// When
+		OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode authorizationCode = new OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode(
+				tokenValue, issuedAt, expiresAt, false);
+
+		// Then
+		Assertions.assertThat(authorizationCode).isNotNull();
+		Assertions.assertThat(authorizationCode.getTokenValue()).isEqualTo(tokenValue);
+		Assertions.assertThat(authorizationCode.getIssuedAt()).isEqualTo(issuedAt);
+		Assertions.assertThat(authorizationCode.getExpiresAt()).isEqualTo(expiresAt);
+		Assertions.assertThat(authorizationCode.isInvalidated()).isFalse();
+	}
+
+	@Test
+	void test_authorizationCode_invalidated() {
+		// Given
+		String tokenValue = "auth_code_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(300);
+
+		// When
+		OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode authorizationCode = new OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode(
+				tokenValue, issuedAt, expiresAt, true);
+
+		// Then
+		Assertions.assertThat(authorizationCode.isInvalidated()).isTrue();
+	}
+
+	@Test
+	void test_authorizationCodeGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		String state = "random-state";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("openid");
+		authorizedScopes.add("profile");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode authorizationCode = new OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode(
+				"auth_code", now, now.plusSeconds(300), false);
+
+		// When
+		OAuth2AuthorizationCodeGrantAuthorization authorization = new OAuth2AuthorizationCodeGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken, refreshToken, null, null,
+				authorizationCode, state);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAuthorizedScopes()).containsExactlyInAnyOrder("openid", "profile");
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isEqualTo(refreshToken);
+		Assertions.assertThat(authorization.getAuthorizationCode()).isEqualTo(authorizationCode);
+		Assertions.assertThat(authorization.getState()).isEqualTo(state);
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2AuthorizationGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2AuthorizationGrantAuthorizationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * OAuth2AuthorizationGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2AuthorizationGrantAuthorizationTest {
+
+	@Test
+	void test_claimsHolder_creation() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", "user123");
+		claims.put("iss", "https://issuer.com");
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// Then
+		Assertions.assertThat(claimsHolder).isNotNull();
+		Assertions.assertThat(claimsHolder.claims()).isEqualTo(claims);
+		Assertions.assertThat(claimsHolder.claims().get("sub")).isEqualTo("user123");
+	}
+
+	@Test
+	void test_accessToken_creation() {
+		// Given
+		String tokenValue = "access_token_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(3600);
+		Set<String> scopes = new HashSet<>();
+		scopes.add("read");
+		scopes.add("write");
+		Map<String, Object> claimsMap = new HashMap<>();
+		claimsMap.put("sub", "user123");
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claims = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claimsMap);
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				tokenValue, issuedAt, expiresAt, false, OAuth2AccessToken.TokenType.BEARER, scopes,
+				OAuth2TokenFormat.SELF_CONTAINED, claims);
+
+		// Then
+		Assertions.assertThat(accessToken).isNotNull();
+		Assertions.assertThat(accessToken.getTokenValue()).isEqualTo(tokenValue);
+		Assertions.assertThat(accessToken.getIssuedAt()).isEqualTo(issuedAt);
+		Assertions.assertThat(accessToken.getExpiresAt()).isEqualTo(expiresAt);
+		Assertions.assertThat(accessToken.isInvalidated()).isFalse();
+		Assertions.assertThat(accessToken.getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.BEARER);
+		Assertions.assertThat(accessToken.getScopes()).containsExactlyInAnyOrder("read", "write");
+		Assertions.assertThat(accessToken.getTokenFormat()).isEqualTo(OAuth2TokenFormat.SELF_CONTAINED);
+		Assertions.assertThat(accessToken.getClaims()).isEqualTo(claims);
+	}
+
+	@Test
+	void test_refreshToken_creation() {
+		// Given
+		String tokenValue = "refresh_token_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(86400);
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				tokenValue, issuedAt, expiresAt, false);
+
+		// Then
+		Assertions.assertThat(refreshToken).isNotNull();
+		Assertions.assertThat(refreshToken.getTokenValue()).isEqualTo(tokenValue);
+		Assertions.assertThat(refreshToken.getIssuedAt()).isEqualTo(issuedAt);
+		Assertions.assertThat(refreshToken.getExpiresAt()).isEqualTo(expiresAt);
+		Assertions.assertThat(refreshToken.isInvalidated()).isFalse();
+	}
+
+	@Test
+	void test_refreshToken_invalidated() {
+		// Given
+		String tokenValue = "refresh_token_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(86400);
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				tokenValue, issuedAt, expiresAt, true);
+
+		// Then
+		Assertions.assertThat(refreshToken.isInvalidated()).isTrue();
+	}
+
+	@Test
+	void test_claimsHolder_with_empty_claims() {
+		// Given
+		Map<String, Object> claims = new HashMap<>();
+
+		// When
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// Then
+		Assertions.assertThat(claimsHolder.claims()).isNotNull().isEmpty();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2ClientCredentialsGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2ClientCredentialsGrantAuthorizationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2ClientCredentialsGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2ClientCredentialsGrantAuthorizationTest {
+
+	@Test
+	void test_clientCredentialsGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "service-account";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+		authorizedScopes.add("write");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		// When
+		OAuth2ClientCredentialsGrantAuthorization authorization = new OAuth2ClientCredentialsGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAuthorizedScopes()).containsExactlyInAnyOrder("read", "write");
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isNull();
+	}
+
+	@Test
+	void test_clientCredentialsGrantAuthorization_has_no_refreshToken() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "service-account";
+		Set<String> authorizedScopes = new HashSet<>();
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.REFERENCE, new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		// When
+		OAuth2ClientCredentialsGrantAuthorization authorization = new OAuth2ClientCredentialsGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken);
+
+		// Then
+		Assertions.assertThat(authorization.getRefreshToken()).isNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2DeviceCodeGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2DeviceCodeGrantAuthorizationTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2DeviceCodeGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2DeviceCodeGrantAuthorizationTest {
+
+	@Test
+	void test_deviceCode_creation() {
+		// Given
+		String tokenValue = "device_code_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(600);
+
+		// When
+		OAuth2DeviceCodeGrantAuthorization.DeviceCode deviceCode = new OAuth2DeviceCodeGrantAuthorization.DeviceCode(
+				tokenValue, issuedAt, expiresAt, false);
+
+		// Then
+		Assertions.assertThat(deviceCode).isNotNull();
+		Assertions.assertThat(deviceCode.getTokenValue()).isEqualTo(tokenValue);
+		Assertions.assertThat(deviceCode.getIssuedAt()).isEqualTo(issuedAt);
+		Assertions.assertThat(deviceCode.getExpiresAt()).isEqualTo(expiresAt);
+		Assertions.assertThat(deviceCode.isInvalidated()).isFalse();
+	}
+
+	@Test
+	void test_userCode_creation() {
+		// Given
+		String tokenValue = "user_code_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(600);
+
+		// When
+		OAuth2DeviceCodeGrantAuthorization.UserCode userCode = new OAuth2DeviceCodeGrantAuthorization.UserCode(
+				tokenValue, issuedAt, expiresAt, false);
+
+		// Then
+		Assertions.assertThat(userCode).isNotNull();
+		Assertions.assertThat(userCode.getTokenValue()).isEqualTo(tokenValue);
+		Assertions.assertThat(userCode.getIssuedAt()).isEqualTo(issuedAt);
+		Assertions.assertThat(userCode.getExpiresAt()).isEqualTo(expiresAt);
+		Assertions.assertThat(userCode.isInvalidated()).isFalse();
+	}
+
+	@Test
+	void test_deviceCodeGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		String deviceState = "device-state";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("openid");
+		Set<String> requestedScopes = new HashSet<>();
+		requestedScopes.add("openid");
+		requestedScopes.add("profile");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		OAuth2DeviceCodeGrantAuthorization.DeviceCode deviceCode = new OAuth2DeviceCodeGrantAuthorization.DeviceCode(
+				"device_code", now, now.plusSeconds(600), false);
+
+		OAuth2DeviceCodeGrantAuthorization.UserCode userCode = new OAuth2DeviceCodeGrantAuthorization.UserCode(
+				"user_code", now, now.plusSeconds(600), false);
+
+		// When
+		OAuth2DeviceCodeGrantAuthorization authorization = new OAuth2DeviceCodeGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken, refreshToken, null, deviceCode,
+				userCode, requestedScopes, deviceState);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getDeviceCode()).isEqualTo(deviceCode);
+		Assertions.assertThat(authorization.getUserCode()).isEqualTo(userCode);
+		Assertions.assertThat(authorization.getRequestedScopes()).containsExactlyInAnyOrder("openid", "profile");
+		Assertions.assertThat(authorization.getDeviceState()).isEqualTo(deviceState);
+	}
+
+	@Test
+	void test_deviceCode_invalidated() {
+		// Given
+		Instant now = Instant.now();
+
+		// When
+		OAuth2DeviceCodeGrantAuthorization.DeviceCode deviceCode = new OAuth2DeviceCodeGrantAuthorization.DeviceCode(
+				"device_code", now, now.plusSeconds(600), true);
+
+		// Then
+		Assertions.assertThat(deviceCode.isInvalidated()).isTrue();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2MailGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2MailGrantAuthorizationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2MailGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2MailGrantAuthorizationTest {
+
+	@Test
+	void test_mailGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user@example.com";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		// When
+		OAuth2MailGrantAuthorization authorization = new OAuth2MailGrantAuthorization(id, registeredClientId,
+				principalName, authorizedScopes, accessToken, refreshToken, null);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isEqualTo(refreshToken);
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2MobileGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2MobileGrantAuthorizationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2MobileGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2MobileGrantAuthorizationTest {
+
+	@Test
+	void test_mobileGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "13800138000";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		// When
+		OAuth2MobileGrantAuthorization authorization = new OAuth2MobileGrantAuthorization(id, registeredClientId,
+				principalName, authorizedScopes, accessToken, refreshToken, null);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isEqualTo(refreshToken);
+	}
+
+	@Test
+	void test_mobileGrantAuthorization_with_null_principal() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "13900139000";
+		Set<String> authorizedScopes = new HashSet<>();
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		// When
+		OAuth2MobileGrantAuthorization authorization = new OAuth2MobileGrantAuthorization(id, registeredClientId,
+				principalName, authorizedScopes, accessToken, null, null);
+
+		// Then
+		Assertions.assertThat(authorization.getPrincipal()).isNull();
+		Assertions.assertThat(authorization.getRefreshToken()).isNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2RegisteredClientTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2RegisteredClientTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2RegisteredClient测试类.
+ *
+ * @author laokou
+ */
+class OAuth2RegisteredClientTest {
+
+	@Test
+	void test_clientSettings_creation() {
+		// When
+		OAuth2RegisteredClient.ClientSettings clientSettings = new OAuth2RegisteredClient.ClientSettings(true, true,
+				"https://jwkset.com", null, null);
+
+		// Then
+		Assertions.assertThat(clientSettings).isNotNull();
+		Assertions.assertThat(clientSettings.requireProofKey()).isTrue();
+		Assertions.assertThat(clientSettings.requireAuthorizationConsent()).isTrue();
+		Assertions.assertThat(clientSettings.jwkSetUrl()).isEqualTo("https://jwkset.com");
+	}
+
+	@Test
+	void test_tokenSettings_creation() {
+		// Given
+		Duration authCodeTTL = Duration.ofMinutes(5);
+		Duration accessTokenTTL = Duration.ofHours(1);
+		Duration deviceCodeTTL = Duration.ofMinutes(10);
+		Duration refreshTokenTTL = Duration.ofDays(30);
+
+		// When
+		OAuth2RegisteredClient.TokenSettings tokenSettings = new OAuth2RegisteredClient.TokenSettings(authCodeTTL,
+				accessTokenTTL, OAuth2TokenFormat.SELF_CONTAINED, deviceCodeTTL, true, refreshTokenTTL,
+				SignatureAlgorithm.RS256, false);
+
+		// Then
+		Assertions.assertThat(tokenSettings).isNotNull();
+		Assertions.assertThat(tokenSettings.authorizationCodeTimeToLive()).isEqualTo(authCodeTTL);
+		Assertions.assertThat(tokenSettings.accessTokenTimeToLive()).isEqualTo(accessTokenTTL);
+		Assertions.assertThat(tokenSettings.accessTokenFormat()).isEqualTo(OAuth2TokenFormat.SELF_CONTAINED);
+		Assertions.assertThat(tokenSettings.deviceCodeTimeToLive()).isEqualTo(deviceCodeTTL);
+		Assertions.assertThat(tokenSettings.reuseRefreshTokens()).isTrue();
+		Assertions.assertThat(tokenSettings.refreshTokenTimeToLive()).isEqualTo(refreshTokenTTL);
+		Assertions.assertThat(tokenSettings.idTokenSignatureAlgorithm()).isEqualTo(SignatureAlgorithm.RS256);
+		Assertions.assertThat(tokenSettings.x509CertificateBoundAccessTokens()).isFalse();
+	}
+
+	@Test
+	void test_registeredClient_creation() {
+		// Given
+		String id = "client-1";
+		String clientId = "my-client";
+		Instant clientIdIssuedAt = Instant.now();
+		String clientSecret = "secret";
+		String clientName = "My Client";
+		Set<ClientAuthenticationMethod> authMethods = new HashSet<>();
+		authMethods.add(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
+		Set<AuthorizationGrantType> grantTypes = new HashSet<>();
+		grantTypes.add(AuthorizationGrantType.AUTHORIZATION_CODE);
+		grantTypes.add(AuthorizationGrantType.REFRESH_TOKEN);
+		Set<String> redirectUris = new HashSet<>();
+		redirectUris.add("https://example.com/callback");
+		Set<String> postLogoutRedirectUris = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
+		scopes.add("openid");
+		scopes.add("profile");
+		OAuth2RegisteredClient.ClientSettings clientSettings = new OAuth2RegisteredClient.ClientSettings(false, true,
+				null, null, null);
+		OAuth2RegisteredClient.TokenSettings tokenSettings = new OAuth2RegisteredClient.TokenSettings(
+				Duration.ofMinutes(5), Duration.ofHours(1), OAuth2TokenFormat.SELF_CONTAINED, Duration.ofMinutes(10),
+				true, Duration.ofDays(30), SignatureAlgorithm.RS256, false);
+
+		// When
+		OAuth2RegisteredClient client = new OAuth2RegisteredClient(id, clientId, clientIdIssuedAt, clientSecret, null,
+				clientName, authMethods, grantTypes, redirectUris, postLogoutRedirectUris, scopes, clientSettings,
+				tokenSettings);
+
+		// Then
+		Assertions.assertThat(client).isNotNull();
+		Assertions.assertThat(client.getId()).isEqualTo(id);
+		Assertions.assertThat(client.getClientId()).isEqualTo(clientId);
+		Assertions.assertThat(client.getClientIdIssuedAt()).isEqualTo(clientIdIssuedAt);
+		Assertions.assertThat(client.getClientSecret()).isEqualTo(clientSecret);
+		Assertions.assertThat(client.getClientSecretExpiresAt()).isNull();
+		Assertions.assertThat(client.getClientName()).isEqualTo(clientName);
+		Assertions.assertThat(client.getClientAuthenticationMethods())
+			.contains(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
+		Assertions.assertThat(client.getAuthorizationGrantTypes())
+			.contains(AuthorizationGrantType.AUTHORIZATION_CODE, AuthorizationGrantType.REFRESH_TOKEN);
+		Assertions.assertThat(client.getRedirectUris()).contains("https://example.com/callback");
+		Assertions.assertThat(client.getScopes()).containsExactlyInAnyOrder("openid", "profile");
+		Assertions.assertThat(client.getClientSettings()).isEqualTo(clientSettings);
+		Assertions.assertThat(client.getTokenSettings()).isEqualTo(tokenSettings);
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2TestGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2TestGrantAuthorizationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2TestGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2TestGrantAuthorizationTest {
+
+	@Test
+	void test_testGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "test-user";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		// When
+		OAuth2TestGrantAuthorization authorization = new OAuth2TestGrantAuthorization(id, registeredClientId,
+				principalName, authorizedScopes, accessToken, refreshToken, null);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isEqualTo(refreshToken);
+	}
+
+	@Test
+	void test_testGrantAuthorization_with_null_principal() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "test-user";
+		Set<String> authorizedScopes = new HashSet<>();
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		// When
+		OAuth2TestGrantAuthorization authorization = new OAuth2TestGrantAuthorization(id, registeredClientId,
+				principalName, authorizedScopes, accessToken, null, null);
+
+		// Then
+		Assertions.assertThat(authorization.getPrincipal()).isNull();
+		Assertions.assertThat(authorization.getRefreshToken()).isNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2TokenExchangeGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2TokenExchangeGrantAuthorizationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2TokenExchangeGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2TokenExchangeGrantAuthorizationTest {
+
+	@Test
+	void test_tokenExchangeGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"exchanged_access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER,
+				authorizedScopes, OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		// When
+		OAuth2TokenExchangeGrantAuthorization authorization = new OAuth2TokenExchangeGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAuthorizedScopes()).contains("read");
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2UserConsentTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2UserConsentTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2UserConsent测试类.
+ *
+ * @author laokou
+ */
+class OAuth2UserConsentTest {
+
+	@Test
+	void test_userConsent_creation() {
+		// Given
+		String id = "client-1-user-1";
+		String registeredClientId = "client-1";
+		String principalName = "user-1";
+		Set<GrantedAuthority> authorities = new HashSet<>();
+		authorities.add(new SimpleGrantedAuthority("SCOPE_read"));
+		authorities.add(new SimpleGrantedAuthority("SCOPE_write"));
+
+		// When
+		OAuth2UserConsent userConsent = new OAuth2UserConsent(id, registeredClientId, principalName, authorities);
+
+		// Then
+		Assertions.assertThat(userConsent).isNotNull();
+		Assertions.assertThat(userConsent.getId()).isEqualTo(id);
+		Assertions.assertThat(userConsent.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(userConsent.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(userConsent.getAuthorities()).hasSize(2);
+	}
+
+	@Test
+	void test_userConsent_with_empty_authorities() {
+		// Given
+		String id = "client-1-user-1";
+		String registeredClientId = "client-1";
+		String principalName = "user-1";
+		Set<GrantedAuthority> authorities = new HashSet<>();
+
+		// When
+		OAuth2UserConsent userConsent = new OAuth2UserConsent(id, registeredClientId, principalName, authorities);
+
+		// Then
+		Assertions.assertThat(userConsent.getAuthorities()).isNotNull().isEmpty();
+	}
+
+	@Test
+	void test_userConsent_authorities_contains_expected_values() {
+		// Given
+		String id = "client-1-user-1";
+		String registeredClientId = "client-1";
+		String principalName = "user-1";
+		Set<GrantedAuthority> authorities = new HashSet<>();
+		SimpleGrantedAuthority readAuthority = new SimpleGrantedAuthority("SCOPE_read");
+		authorities.add(readAuthority);
+
+		// When
+		OAuth2UserConsent userConsent = new OAuth2UserConsent(id, registeredClientId, principalName, authorities);
+
+		// Then
+		Assertions.assertThat(userConsent.getAuthorities()).contains(readAuthority);
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2UsernamePasswordGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2UsernamePasswordGrantAuthorizationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * OAuth2UsernamePasswordGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OAuth2UsernamePasswordGrantAuthorizationTest {
+
+	@Test
+	void test_usernamePasswordGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+		authorizedScopes.add("write");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		// When
+		OAuth2UsernamePasswordGrantAuthorization authorization = new OAuth2UsernamePasswordGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken, refreshToken, null);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAuthorizedScopes()).containsExactlyInAnyOrder("read", "write");
+		Assertions.assertThat(authorization.getAccessToken()).isEqualTo(accessToken);
+		Assertions.assertThat(authorization.getRefreshToken()).isEqualTo(refreshToken);
+		Assertions.assertThat(authorization.getPrincipal()).isNull();
+	}
+
+	@Test
+	void test_usernamePasswordGrantAuthorization_with_null_refreshToken() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("read");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		// When
+		OAuth2UsernamePasswordGrantAuthorization authorization = new OAuth2UsernamePasswordGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken, null, null);
+
+		// Then
+		Assertions.assertThat(authorization.getRefreshToken()).isNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OidcAuthorizationCodeGrantAuthorizationTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OidcAuthorizationCodeGrantAuthorizationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * OidcAuthorizationCodeGrantAuthorization测试类.
+ *
+ * @author laokou
+ */
+class OidcAuthorizationCodeGrantAuthorizationTest {
+
+	@Test
+	void test_idToken_creation() {
+		// Given
+		String tokenValue = "id_token_value";
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(3600);
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", "user123");
+		claims.put("iss", "https://issuer.com");
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When
+		OidcAuthorizationCodeGrantAuthorization.IdToken idToken = new OidcAuthorizationCodeGrantAuthorization.IdToken(
+				tokenValue, issuedAt, expiresAt, false, claimsHolder);
+
+		// Then
+		Assertions.assertThat(idToken).isNotNull();
+		Assertions.assertThat(idToken.getTokenValue()).isEqualTo(tokenValue);
+		Assertions.assertThat(idToken.getIssuedAt()).isEqualTo(issuedAt);
+		Assertions.assertThat(idToken.getExpiresAt()).isEqualTo(expiresAt);
+		Assertions.assertThat(idToken.isInvalidated()).isFalse();
+		Assertions.assertThat(idToken.getClaims()).isEqualTo(claimsHolder);
+	}
+
+	@Test
+	void test_oidcAuthorizationCodeGrantAuthorization_creation() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		String state = "random-state";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("openid");
+		authorizedScopes.add("profile");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationGrantAuthorization.RefreshToken refreshToken = new OAuth2AuthorizationGrantAuthorization.RefreshToken(
+				"refresh_token", now, now.plusSeconds(86400), false);
+
+		OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode authorizationCode = new OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode(
+				"auth_code", now, now.plusSeconds(300), false);
+
+		Map<String, Object> idTokenClaims = new HashMap<>();
+		idTokenClaims.put("sub", "user123");
+		OidcAuthorizationCodeGrantAuthorization.IdToken idToken = new OidcAuthorizationCodeGrantAuthorization.IdToken(
+				"id_token", now, now.plusSeconds(3600), false,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(idTokenClaims));
+
+		// When
+		OidcAuthorizationCodeGrantAuthorization authorization = new OidcAuthorizationCodeGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken, refreshToken, null, null,
+				authorizationCode, state, idToken);
+
+		// Then
+		Assertions.assertThat(authorization).isNotNull();
+		Assertions.assertThat(authorization.getId()).isEqualTo(id);
+		Assertions.assertThat(authorization.getRegisteredClientId()).isEqualTo(registeredClientId);
+		Assertions.assertThat(authorization.getPrincipalName()).isEqualTo(principalName);
+		Assertions.assertThat(authorization.getAuthorizedScopes()).containsExactlyInAnyOrder("openid", "profile");
+		Assertions.assertThat(authorization.getIdToken()).isEqualTo(idToken);
+		Assertions.assertThat(authorization.getState()).isEqualTo(state);
+	}
+
+	@Test
+	void test_idToken_invalidated() {
+		// Given
+		Instant now = Instant.now();
+		Map<String, Object> claims = new HashMap<>();
+		OAuth2AuthorizationGrantAuthorization.ClaimsHolder claimsHolder = new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(
+				claims);
+
+		// When
+		OidcAuthorizationCodeGrantAuthorization.IdToken idToken = new OidcAuthorizationCodeGrantAuthorization.IdToken(
+				"id_token", now, now.plusSeconds(3600), true, claimsHolder);
+
+		// Then
+		Assertions.assertThat(idToken.isInvalidated()).isTrue();
+	}
+
+	@Test
+	void test_oidcAuthorizationCodeGrantAuthorization_with_null_idToken() {
+		// Given
+		String id = "auth-1";
+		String registeredClientId = "client-1";
+		String principalName = "user123";
+		Set<String> authorizedScopes = new HashSet<>();
+		authorizedScopes.add("openid");
+
+		Instant now = Instant.now();
+		OAuth2AuthorizationGrantAuthorization.AccessToken accessToken = new OAuth2AuthorizationGrantAuthorization.AccessToken(
+				"access_token", now, now.plusSeconds(3600), false, OAuth2AccessToken.TokenType.BEARER, authorizedScopes,
+				OAuth2TokenFormat.SELF_CONTAINED,
+				new OAuth2AuthorizationGrantAuthorization.ClaimsHolder(new HashMap<>()));
+
+		OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode authorizationCode = new OAuth2AuthorizationCodeGrantAuthorization.AuthorizationCode(
+				"auth_code", now, now.plusSeconds(300), false);
+
+		// When
+		OidcAuthorizationCodeGrantAuthorization authorization = new OidcAuthorizationCodeGrantAuthorization(id,
+				registeredClientId, principalName, authorizedScopes, accessToken, null, null, null, authorizationCode,
+				null, null);
+
+		// Then
+		Assertions.assertThat(authorization.getIdToken()).isNull();
+		Assertions.assertThat(authorization.getState()).isNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2AuthorizationGrantAuthorizationRepositoryTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2AuthorizationGrantAuthorizationRepositoryTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.repository.CrudRepository;
+
+import java.lang.reflect.Method;
+
+/**
+ * OAuth2AuthorizationGrantAuthorizationRepository test class.
+ *
+ * @author laokou
+ */
+class OAuth2AuthorizationGrantAuthorizationRepositoryTest {
+
+	@Test
+	void test_repository_extends_CrudRepository() {
+		// Then
+		Assertions
+			.assertThat(CrudRepository.class.isAssignableFrom(OAuth2AuthorizationGrantAuthorizationRepository.class))
+			.isTrue();
+	}
+
+	@Test
+	void test_repository_has_findByState_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByState", String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByAccessToken_TokenValue_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByAccessToken_TokenValue",
+				String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByRefreshToken_TokenValue_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByRefreshToken_TokenValue",
+				String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByIdToken_TokenValue_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByIdToken_TokenValue",
+				String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByDeviceState_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByDeviceState",
+				String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByDeviceCode_TokenValue_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByDeviceCode_TokenValue",
+				String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByUserCode_TokenValue_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class.getMethod("findByUserCode_TokenValue",
+				String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+	@Test
+	void test_repository_has_findByAuthorizationCode_TokenValue_method() throws NoSuchMethodException {
+		// When
+		Method method = OAuth2AuthorizationGrantAuthorizationRepository.class
+			.getMethod("findByAuthorizationCode_TokenValue", String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2RegisteredClientRepositoryTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2RegisteredClientRepositoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * OAuth2RegisteredClientRepository test class.
+ *
+ * @author laokou
+ */
+class OAuth2RegisteredClientRepositoryTest {
+
+	@Test
+	void test_repository_extends_CrudRepository() {
+		// Then
+		Assertions.assertThat(CrudRepository.class.isAssignableFrom(OAuth2RegisteredClientRepository.class)).isTrue();
+	}
+
+	@Test
+	void test_repository_has_findByClientId_method() throws NoSuchMethodException {
+		// When
+		var method = OAuth2RegisteredClientRepository.class.getMethod("findByClientId", String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+		Assertions.assertThat(method.getReturnType().getSimpleName()).isEqualTo("OAuth2RegisteredClient");
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2UserConsentRepositoryTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2UserConsentRepositoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * OAuth2UserConsentRepository test class.
+ *
+ * @author laokou
+ */
+class OAuth2UserConsentRepositoryTest {
+
+	@Test
+	void test_repository_extends_CrudRepository() {
+		// Then
+		Assertions.assertThat(CrudRepository.class.isAssignableFrom(OAuth2UserConsentRepository.class)).isTrue();
+	}
+
+	@Test
+	void test_repository_has_findByRegisteredClientIdAndPrincipalName_method() throws NoSuchMethodException {
+		// When
+		var method = OAuth2UserConsentRepository.class.getMethod("findByRegisteredClientIdAndPrincipalName",
+				String.class, String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+		Assertions.assertThat(method.getReturnType().getSimpleName()).isEqualTo("OAuth2UserConsent");
+	}
+
+	@Test
+	void test_repository_has_deleteByRegisteredClientIdAndPrincipalName_method() throws NoSuchMethodException {
+		// When
+		var method = OAuth2UserConsentRepository.class.getMethod("deleteByRegisteredClientIdAndPrincipalName",
+				String.class, String.class);
+
+		// Then
+		Assertions.assertThat(method).isNotNull();
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/handler/OAuth2ExceptionHandlerTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/handler/OAuth2ExceptionHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.handler;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+/**
+ * OAuth2ExceptionHandler测试类.
+ *
+ * @author laokou
+ */
+class OAuth2ExceptionHandlerTest {
+
+	@Test
+	void test_error_url_constant() {
+		// Then
+		Assertions.assertThat(OAuth2ExceptionHandler.ERROR_URL)
+			.isEqualTo("https://datatracker.ietf.org/doc/html/rfc6749#section-5.2");
+	}
+
+	@Test
+	void test_getOAuth2AuthenticationException() {
+		// Given
+		String code = "invalid_token";
+		String message = "Token expired";
+		String uri = "https://example.com/error";
+
+		// When
+		OAuth2AuthenticationException exception = OAuth2ExceptionHandler.getOAuth2AuthenticationException(code, message,
+				uri);
+
+		// Then
+		Assertions.assertThat(exception).isNotNull();
+		Assertions.assertThat(exception.getError()).isNotNull();
+		Assertions.assertThat(exception.getError().getErrorCode()).isEqualTo(code);
+		Assertions.assertThat(exception.getError().getDescription()).isEqualTo(message);
+		Assertions.assertThat(exception.getError().getUri()).isEqualTo(uri);
+	}
+
+	@Test
+	void test_getOAuth2AuthenticationException_with_null_message() {
+		// Given
+		String code = "invalid_token";
+		String uri = "https://example.com/error";
+
+		// When
+		OAuth2AuthenticationException exception = OAuth2ExceptionHandler.getOAuth2AuthenticationException(code, null,
+				uri);
+
+		// Then
+		Assertions.assertThat(exception).isNotNull();
+		Assertions.assertThat(exception.getError().getErrorCode()).isEqualTo(code);
+		Assertions.assertThat(exception.getError().getDescription()).isNull();
+	}
+
+	@Test
+	void test_getOAuth2AuthenticationException_with_different_uri() {
+		// Given
+		String code = "access_denied";
+		String message = "Access denied";
+		String customUri = "https://custom.com/error";
+
+		// When
+		OAuth2AuthenticationException exception = OAuth2ExceptionHandler.getOAuth2AuthenticationException(code, message,
+				customUri);
+
+		// Then
+		Assertions.assertThat(exception.getError().getUri()).isEqualTo(customUri);
+	}
+
+}


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added comprehensive test suite for OAuth2 security module with 30+ test classes covering:
  - Entity tests for various OAuth2 authorization grant types (authorization code, device code, client credentials, token exchange, username/password, mobile, mail, test grants)
  - Repository interface tests validating `CrudRepository` extension and query method signatures
  - Service unit tests for `RedisOAuth2AuthorizationService` and `RedisOAuth2AuthorizationConsentService` with Mockito mocks
  - Integration tests using Testcontainers with Redis for converter roundtrip serialization/deserialization
  - Converter tests for claims holder, authentication tokens, and OAuth2 authorization requests
  - Configuration and utility tests for `OAuth2ResourceServerProperties`, `OAuth2ModelMapper`, `OAuth2ExceptionHandler`, and `OAuth2OpaqueTokenIntrospector`

- Added `@NonNull` annotations from `org.jspecify.annotations` to converter classes for improved null-safety:
  - `ClaimsHolderToBytesConverter`
  - `BytesToOAuth2AuthorizationRequestConverter`
  - `OAuth2AuthorizationRequestToBytesConverter`
  - `UsernamePasswordAuthenticationTokenToBytesConverter`
  - `ClaimsHolderMixin`

- Added test dependencies to `pom.xml`: `laokou-common-test`, `commons-logging`, and `laokou-common-testcontainers`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OAuth2 Security Module"] -->|"Add 30+ test classes"| B["Entity Tests"]
  A -->|"Add 30+ test classes"| C["Service Tests"]
  A -->|"Add 30+ test classes"| D["Converter Tests"]
  A -->|"Add 30+ test classes"| E["Repository Tests"]
  A -->|"Add 30+ test classes"| F["Configuration Tests"]
  G["Converter Classes"] -->|"Apply @NonNull annotations"| H["Enhanced Null-Safety"]
  I["pom.xml"] -->|"Add test dependencies"| J["Test Infrastructure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>32 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>OidcAuthorizationCodeGrantAuthorizationTest.java</strong><dd><code>OIDC Authorization Code Grant Authorization Entity Tests</code>&nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OidcAuthorizationCodeGrantAuthorizationTest.java

<ul><li>New test class for <code>OidcAuthorizationCodeGrantAuthorization</code> entity with <br>4 test methods<br> <li> Tests cover <code>IdToken</code> creation, invalidation, and full authorization <br>object instantiation<br> <li> Validates token properties including value, timestamps, and claims <br>holder<br> <li> Tests edge cases like null <code>idToken</code> and <code>state</code> parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-637d046dd1b28b417ebc8949eebd2aaa109b8cb272192361f7b7bc48f64e0ddc">+151/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsernamePasswordAuthenticationTokenConverterIntegrationTest.java</strong><dd><code>Username Password Authentication Token Converter Integration Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenConverterIntegrationTest.java

<ul><li>Integration test class using Testcontainers with Redis for token <br>serialization<br> <li> Tests authenticated and unauthenticated token roundtrip conversions<br> <li> Validates token storage and retrieval from Redis with proper <br>deserialization<br> <li> Tests multiple authorities handling and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-acdf8b5a54a062c90c3bbd10b24e1e4d09a0fe530ae4ce16a2c2984d39c2f13e">+153/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthorizationRequestConverterIntegrationTest.java</strong><dd><code>OAuth2 Authorization Request Converter Integration Tests</code>&nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestConverterIntegrationTest.java

<ul><li>Integration test class for OAuth2 authorization request serialization <br>with Redis<br> <li> Tests full roundtrip conversion with various request configurations<br> <li> Validates minimal and complete authorization request serialization<br> <li> Uses Testcontainers for Redis-based integration testing</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-8cefb7180807f3be6681d81febcd2604245cf15fdeaadb8c8d7a7cb6fdea214c">+146/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2RegisteredClientTest.java</strong><dd><code>OAuth2 Registered Client Entity Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2RegisteredClientTest.java

<ul><li>Test class for <code>OAuth2RegisteredClient</code> entity with nested settings <br>classes<br> <li> Tests <code>ClientSettings</code> and <code>TokenSettings</code> creation and properties<br> <li> Validates complete registered client instantiation with all <br>configuration options<br> <li> Covers token TTL, signature algorithms, and authentication methods</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-7371154645220895330adedd9ba76840536d37ec366e6b61035acc07ea1b7d3a">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisOAuth2AuthorizationServiceTest.java</strong><dd><code>Redis OAuth2 Authorization Service Unit Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationServiceTest.java

<ul><li>Unit test class for <code>RedisOAuth2AuthorizationService</code> with Mockito mocks<br> <li> Tests constructor validation, save, remove, and find operations<br> <li> Validates null parameter handling and exception throwing<br> <li> Tests token lookup by access token, refresh token, and ID token values</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-f351d6e56f94bc2590ef4f342738783a1de87ab4c10a70adee815fb9b2c5be03">+165/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2DeviceCodeGrantAuthorizationTest.java</strong><dd><code>OAuth2 Device Code Grant Authorization Entity Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2DeviceCodeGrantAuthorizationTest.java

<ul><li>Test class for device code grant authorization with device and user <br>codes<br> <li> Tests <code>DeviceCode</code> and <code>UserCode</code> creation and invalidation states<br> <li> Validates complete device code grant authorization instantiation<br> <li> Tests requested scopes and device state properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-93545321a1f149f8cfaec4848c548998f4d10c2dfa09cb6ed55b6717d01ef385">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClaimsHolderConverterIntegrationTest.java</strong><dd><code>Claims Holder Converter Integration Tests with Redis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/ClaimsHolderConverterIntegrationTest.java

<ul><li>Integration test for <code>ClaimsHolder</code> serialization with Redis backend<br> <li> Tests roundtrip conversion of claims with various data types<br> <li> Validates empty claims handling and Redis storage/retrieval<br> <li> Uses Testcontainers for isolated Redis testing environment</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-63248dfe85def3c71165924476c8b00b2e0ba8b00fce0322e75a668e28b5eb67">+140/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthorizationGrantAuthorizationTest.java</strong><dd><code>OAuth2 Authorization Grant Authorization Base Entity Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2AuthorizationGrantAuthorizationTest.java

<ul><li>Test class for base <code>OAuth2AuthorizationGrantAuthorization</code> entity<br> <li> Tests <code>ClaimsHolder</code>, <code>AccessToken</code>, and <code>RefreshToken</code> creation<br> <li> Validates token properties including scopes, token types, and formats<br> <li> Tests invalidation states and empty claims scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-1d7b2a66144adc682aa1211cbce295b3f44729e86fe5bb9adcef7af95e73528e">+133/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisOAuth2AuthorizationConsentServiceTest.java</strong><dd><code>Redis OAuth2 Authorization Consent Service Unit Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentServiceTest.java

<ul><li>Unit test class for <code>RedisOAuth2AuthorizationConsentService</code> with mocks<br> <li> Tests save, remove, and find operations for authorization consent<br> <li> Validates constructor null checks and parameter validation<br> <li> Tests consent retrieval and authority handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-4843ac2cb7beb29c48b8ec84d7e1e9f8b8d93f46f2fe09e7c5f4401e742513d9">+144/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthorizationCodeGrantAuthorizationTest.java</strong><dd><code>OAuth2 Authorization Code Grant Authorization Entity Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2AuthorizationCodeGrantAuthorizationTest.java

<ul><li>Test class for authorization code grant authorization entity<br> <li> Tests <code>AuthorizationCode</code> creation and invalidation states<br> <li> Validates complete authorization code grant instantiation with tokens<br> <li> Tests state parameter and authorized scopes handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-afd59d6558634ed7ef28e75074cf00b5cae9765fe294c17a49386714aa183ce5">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisRegisteredClientRepositoryTest.java</strong><dd><code>Redis Registered Client Repository Unit Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisRegisteredClientRepositoryTest.java

<ul><li>Unit test class for <code>RedisRegisteredClientRepository</code> with Mockito<br> <li> Tests save, findById, and findByClientId operations<br> <li> Validates constructor null checks and parameter validation<br> <li> Tests null return scenarios and exception handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-4c04b1858445c711ed1157b529b335d84e664cddcb6c4e5771ce3d7564234329">+133/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2UsernamePasswordGrantAuthorizationTest.java</strong><dd><code>OAuth2 Username Password Grant Authorization Entity Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2UsernamePasswordGrantAuthorizationTest.java

<ul><li>Test class for username/password grant authorization entity<br> <li> Tests complete authorization instantiation with access and refresh <br>tokens<br> <li> Validates null refresh token scenarios<br> <li> Tests authorized scopes and principal name properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-d52e979d57aa2622b4656fe25334dd95ac2855279db0a3df3450af68b66507c3">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthorizationGrantAuthorizationRepositoryTest.java</strong><dd><code>OAuth2 Authorization Grant Authorization Repository Interface Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2AuthorizationGrantAuthorizationRepositoryTest.java

<ul><li>Test class validating repository interface structure and methods<br> <li> Tests that repository extends <code>CrudRepository</code><br> <li> Validates presence of query methods for various token types and states<br> <li> Tests method signatures for device code, user code, and authorization <br>code lookups</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-6261279359972976cfdb3d99fd4a5ea8c9ba4071f4a90deb20063497ea1b537b">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TransmittableThreadLocalSecurityContextHolderStrategyTest.java</strong><dd><code>Transmittable ThreadLocal Security Context Holder Strategy Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/TransmittableThreadLocalSecurityContextHolderStrategyTest.java

<ul><li>Test class for <code>TransmittableThreadLocalSecurityContextHolderStrategy</code> <br>implementation<br> <li> Tests context setting, getting, and clearing operations<br> <li> Validates deferred context handling with suppliers<br> <li> Tests null parameter validation and exception throwing</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-d0db4be8caddac20784683fe04fcf43530a78acd9237993a7faf6d5296486fb3">+121/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2MobileGrantAuthorizationTest.java</strong><dd><code>OAuth2 Mobile Grant Authorization Entity Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2MobileGrantAuthorizationTest.java

<ul><li>Test class for mobile grant authorization entity<br> <li> Tests complete authorization instantiation with phone number principal<br> <li> Validates null principal and refresh token scenarios<br> <li> Tests access token and authorized scopes properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-0c2327b31232f05b1ff29bd422f351e4c3a170721f910cfbe5342c14e2571c42">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2TestGrantAuthorizationTest.java</strong><dd><code>OAuth2 Test Grant Authorization Entity Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2TestGrantAuthorizationTest.java

<ul><li>Test class for test grant authorization entity<br> <li> Tests complete authorization instantiation with test user principal<br> <li> Validates null principal and refresh token edge cases<br> <li> Tests access token and authorized scopes handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-a99492e33975fdc0759a73f3ee4d711a6c545f771ebb609892e8eaed7cd55482">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2OpaqueTokenIntrospectorTest.java</strong><dd><code>OAuth2 Opaque Token Introspector Unit Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java

<ul><li>Unit test class for <code>OAuth2OpaqueTokenIntrospector</code> with mocks<br> <li> Tests exception handling for invalid and missing tokens<br> <li> Validates record constructor and service injection<br> <li> Tests null authorization and access token scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-030d1af18f7319e7f98e55fc0a9e1896562d714180273d623275f730d1c3f4cd">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2ClientCredentialsGrantAuthorizationTest.java</strong><dd><code>OAuth2 Client Credentials Grant Authorization Entity Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2ClientCredentialsGrantAuthorizationTest.java

<ul><li>Test class for client credentials grant authorization entity<br> <li> Tests complete authorization instantiation without refresh token<br> <li> Validates that refresh token is always null for this grant type<br> <li> Tests access token and authorized scopes properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-5908559547245c3b3ec115c2e23e1e52cb279c87237352c87b9c0c6e56513ef8">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2UserConsentTest.java</strong><dd><code>OAuth2 User Consent Entity Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2UserConsentTest.java

<ul><li>Test class for <code>OAuth2UserConsent</code> entity<br> <li> Tests user consent creation with authorities<br> <li> Validates empty authorities handling<br> <li> Tests authority containment and properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-4103c39adc1d242a18ed80a6c78230231fbc6bb5469eaf3df5116b011b6a39ee">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2ExceptionHandlerTest.java</strong><dd><code>OAuth2 Exception Handler Utility Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/handler/OAuth2ExceptionHandlerTest.java

<ul><li>Test class for <code>OAuth2ExceptionHandler</code> utility<br> <li> Tests error URL constant value<br> <li> Validates OAuth2 authentication exception creation with various <br>parameters<br> <li> Tests null message and custom URI handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-c4dbc15f06ae611124d1f9386338dd3862ddefe7911ba1f6731768fa86049cb5">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BytesToOAuth2AuthorizationRequestConverterTest.java</strong><dd><code>Bytes to OAuth2 Authorization Request Converter Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToOAuth2AuthorizationRequestConverterTest.java

<ul><li>Test class for deserialization of OAuth2 authorization requests<br> <li> Tests roundtrip conversion from bytes to authorization request objects<br> <li> Validates minimal and complete request reconstruction<br> <li> Tests scope, state, and URI properties preservation</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-593b743d0cf27127a6e019be55ff7e8db38a9d2400db1e3ebe66014073816310">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2ResourceServerPropertiesTest.java</strong><dd><code>OAuth2 Resource Server Properties Configuration Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2ResourceServerPropertiesTest.java

<ul><li>Test class for <code>OAuth2ResourceServerProperties</code> configuration<br> <li> Tests default enabled state and request matcher initialization<br> <li> Validates ignore patterns configuration and setters<br> <li> Tests nested <code>RequestMatcher</code> class properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-7f5359677b93f7246a00c7cbc29b97efe2b9fc1cf75fda840f87d4646b527d71">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BytesToClaimsHolderConverterTest.java</strong><dd><code>Bytes to Claims Holder Converter Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToClaimsHolderConverterTest.java

<ul><li>Test class for deserialization of claims holder objects<br> <li> Tests roundtrip conversion from bytes to claims holder<br> <li> Validates claims preservation and empty claims handling<br> <li> Tests claim key-value pairs reconstruction</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-8acd868e537f250d47bf12330272cb516372eda771eb7c62eebfaffda46b4614">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2ModelMapperTest.java</strong><dd><code>OAuth2 Model Mapper Custom Grant Types Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2ModelMapperTest.java

<ul><li>Test class for <code>OAuth2ModelMapper</code> custom grant types<br> <li> Tests custom grant type constants (USERNAME_PASSWORD, TEST, MAIL, <br>MOBILE)<br> <li> Validates grant type values and uniqueness<br> <li> Tests distinction from standard OAuth2 grant types</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-fefafd7ecf33bf9a7cad4f52c169341da54a365a5e588b825d501db2fc0385bb">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2MailGrantAuthorizationTest.java</strong><dd><code>OAuth2 Mail Grant Authorization Entity Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2MailGrantAuthorizationTest.java

<ul><li>Test class for mail grant authorization entity<br> <li> Tests complete authorization instantiation with email principal<br> <li> Validates access token and refresh token properties<br> <li> Tests authorized scopes handling</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-4b02b0a62ad4a45a8d78dd70339e577a71932082c8a6e4f48ca954c23941c9b3">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2TokenExchangeGrantAuthorizationTest.java</strong><dd><code>OAuth2 Token Exchange Grant Authorization Entity Tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/entity/OAuth2TokenExchangeGrantAuthorizationTest.java

<ul><li>Test class for token exchange grant authorization entity<br> <li> Tests complete authorization instantiation without refresh token<br> <li> Validates access token and authorized scopes properties<br> <li> Tests that refresh token is null for this grant type</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-b148b4cfefd3c376e36d8f4167bdd3b9cac735bdfc31c580545d22c574cc186a">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BytesToUsernamePasswordAuthenticationTokenConverterTest.java</strong><dd><code>Bytes to Username Password Authentication Token Converter Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/BytesToUsernamePasswordAuthenticationTokenConverterTest.java

<ul><li>Test class for deserialization of authentication tokens<br> <li> Tests roundtrip conversion from bytes to authentication token objects<br> <li> Validates authenticated and unauthenticated token reconstruction<br> <li> Tests principal name and authentication state preservation</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-1987615edfb0205784fd9b428e776a65f2769be452212e37baf8a3aa5bef8a8b">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthorizationRequestToBytesConverterTest.java</strong><dd><code>OAuth2 Authorization Request to Bytes Converter Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestToBytesConverterTest.java

<ul><li>Test class for serialization of OAuth2 authorization requests to bytes<br> <li> Tests conversion of complete and minimal authorization requests<br> <li> Validates non-empty byte array output<br> <li> Tests various request configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-6114e97f0c8ead321bc0dadc4bc8cb2b25e717b6450e2a7a2c5fbbc0b82f6f10">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClaimsHolderToBytesConverterTest.java</strong><dd><code>Claims Holder to Bytes Converter Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/ClaimsHolderToBytesConverterTest.java

<ul><li>Test class for serialization of claims holder objects to bytes<br> <li> Tests conversion of claims with various data types<br> <li> Validates empty claims serialization<br> <li> Tests non-empty byte array output</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-03b62fa8a2b13903096ebe05ecb2509297e14652e0d1cee198d7276cee94a8d4">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsernamePasswordAuthenticationTokenToBytesConverterTest.java</strong><dd><code>Username Password Authentication Token to Bytes Converter Tests</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenToBytesConverterTest.java

<ul><li>Test class for serialization of authentication tokens to bytes<br> <li> Tests conversion of authenticated and unauthenticated tokens<br> <li> Validates non-empty byte array output<br> <li> Tests various token configurations with authorities</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-0f30efd8c0052cfc44316be2f169c7cbd23a0ef31ad7dc4a271d1e367334bd13">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2UserConsentRepositoryTest.java</strong><dd><code>Add OAuth2UserConsentRepository unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2UserConsentRepositoryTest.java

<ul><li>New test class for <code>OAuth2UserConsentRepository</code> with three test methods<br> <li> Tests verify that the repository extends <code>CrudRepository</code><br> <li> Tests validate the existence and return types of <br><code>findByRegisteredClientIdAndPrincipalName</code> and <br><code>deleteByRegisteredClientIdAndPrincipalName</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-64678984c36559c0ea6ef8cb5e5292950d2619d43e61581afe14003653d06bfb">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2RegisteredClientRepositoryTest.java</strong><dd><code>Add OAuth2RegisteredClientRepository unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/repository/OAuth2RegisteredClientRepositoryTest.java

<ul><li>New test class for <code>OAuth2RegisteredClientRepository</code> with two test <br>methods<br> <li> Tests verify that the repository extends <code>CrudRepository</code><br> <li> Tests validate the existence and return type of <code>findByClientId</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-4b3c4dcc2b16729cdb5a105db5bb151114a3b98428ab5f4fd56894d08ec9e8e3">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimsHolderToBytesConverter.java</strong><dd><code>Add NonNull annotations to ClaimsHolder types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/ClaimsHolderToBytesConverter.java

<ul><li>Added import for <code>org.jspecify.annotations.NonNull</code><br> <li> Applied <code>@NonNull</code> annotation to <code>ClaimsHolder</code> type parameter in <br><code>Converter</code> interface implementation<br> <li> Applied <code>@NonNull</code> annotation to <code>ClaimsHolder</code> type parameter in <br><code>JacksonJsonRedisSerializer</code> field declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-01cbfd7785c606bcff41529638e8692216630b57f1504bac1d076de7076d8599">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BytesToOAuth2AuthorizationRequestConverter.java</strong><dd><code>Add NonNull annotation to OAuth2AuthorizationRequest type</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/BytesToOAuth2AuthorizationRequestConverter.java

<ul><li>Added import for <code>org.jspecify.annotations.NonNull</code><br> <li> Applied <code>@NonNull</code> annotation to <code>OAuth2AuthorizationRequest</code> type <br>parameter in <code>JacksonJsonRedisSerializer</code> field declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-8b4dd7615eac8254c7fb1bbfebf902947749b2c42b72666ad1534fd25d92fb80">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthorizationRequestToBytesConverter.java</strong><dd><code>Add NonNull annotations to OAuth2AuthorizationRequest types</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/OAuth2AuthorizationRequestToBytesConverter.java

<ul><li>Added import for <code>org.jspecify.annotations.NonNull</code><br> <li> Applied <code>@NonNull</code> annotation to <code>OAuth2AuthorizationRequest</code> type <br>parameter in <code>Converter</code> interface implementation<br> <li> Applied <code>@NonNull</code> annotation to <code>OAuth2AuthorizationRequest</code> type <br>parameter in <code>JacksonJsonRedisSerializer</code> field declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-e51f313bad2111a092208975df39ee25d8dcc51d7d9d318916397e176e1e4657">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsernamePasswordAuthenticationTokenToBytesConverter.java</strong><dd><code>Add NonNull annotations to UsernamePasswordAuthenticationToken types</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/UsernamePasswordAuthenticationTokenToBytesConverter.java

<ul><li>Added import for <code>org.jspecify.annotations.NonNull</code><br> <li> Applied <code>@NonNull</code> annotation to <code>UsernamePasswordAuthenticationToken</code> <br>type parameter in <code>Converter</code> interface implementation<br> <li> Applied <code>@NonNull</code> annotation to <code>UsernamePasswordAuthenticationToken</code> <br>type parameter in <code>JacksonJsonRedisSerializer</code> field declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-10238ef859ae0e7e79712c423b91284dc48af8679949e6886ef254c9668e7dac">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClaimsHolderMixin.java</strong><dd><code>Add NonNull annotation to ClaimsHolderMixin constructor parameter</code></dd></summary>
<hr>

laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/convertor/ClaimsHolderMixin.java

<ul><li>Added import for <code>org.jspecify.annotations.NonNull</code><br> <li> Applied <code>@NonNull</code> annotation to the <code>claims</code> parameter in the <br><code>ClaimsHolderMixin</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-1f2573901c491c63e9f56ffd5aa4795dbb6fa7a5e0dfa43f08bb918da1d64d39">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Add test dependencies to security module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-security/pom.xml

<ul><li>Added <code>laokou-common-test</code> dependency with test scope<br> <li> Added <code>commons-logging</code> dependency version 1.3.5 with test scope<br> <li> Added <code>laokou-common-testcontainers</code> dependency with test scope</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5511/files#diff-c53e2ac9eb18e115b0a691ce279379cb06021b6cc12b34ec34ac466270db7ea2">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and integration tests for OAuth2 authorization flows, including authorization code, device code, mail, mobile, and username/password grant types.
  * Added integration tests using Testcontainers for Redis serialization/deserialization validation.
  * Added tests for converter components, repository interfaces, and exception handling.

* **Chores**
  * Enhanced code quality with null-safety annotations across converter and configuration classes.
  * Added test framework dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->