### PR TITLE
fix: 测试失败失败，无法构建项目

### DIFF
--- a/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/ValidatorUtilsTest.java
+++ b/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/ValidatorUtilsTest.java
@@ -27,8 +27,11 @@ import lombok.Data;
 import org.assertj.core.api.Assertions;
 import org.hibernate.validator.constraints.Range;
 import org.junit.jupiter.api.Test;
+import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ValidatorUtils;
+import org.springframework.context.i18n.LocaleContextHolder;
 
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -158,14 +161,26 @@ class ValidatorUtilsTest {
 	void test_getMessage_withValidCode() {
 		// Test getMessage with valid code
 		String message = ValidatorUtils.getMessage("test.message");
-		Assertions.assertThat(message).isEqualTo("测试");
+		Locale locale = LocaleContextHolder.getLocale();
+		if (ObjectUtils.equals("zh", locale.getLanguage())) {
+			Assertions.assertThat(message).isEqualTo("测试");
+		}
+		else {
+			Assertions.assertThat(message).isEqualTo("test");
+		}
 	}
 
 	@Test
 	void test_getMessage_withNullArgs() {
 		// Test getMessage with null args
 		String message = ValidatorUtils.getMessage("test.message", null);
-		Assertions.assertThat(message).isEqualTo("测试");
+		Locale locale = LocaleContextHolder.getLocale();
+		if (ObjectUtils.equals("zh", locale.getLanguage())) {
+			Assertions.assertThat(message).isEqualTo("测试");
+		}
+		else {
+			Assertions.assertThat(message).isEqualTo("test");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix locale-dependent test failures in ValidatorUtilsTest

- Add locale detection to message validation assertions

- Import ObjectUtils and LocaleContextHolder for locale handling

- Support both Chinese and English message assertions based on system locale


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Assertions"] -->|"Add Locale Detection"| B["LocaleContextHolder"]
  B -->|"Get Current Locale"| C["Locale Language Check"]
  C -->|"If Chinese"| D["Assert Chinese Message"]
  C -->|"Else"| E["Assert English Message"]
  F["ObjectUtils.equals"] -->|"Compare Language"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValidatorUtilsTest.java</strong><dd><code>Add locale-aware assertions to message tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/ValidatorUtilsTest.java

<ul><li>Added imports for <code>ObjectUtils</code>, <code>LocaleContextHolder</code>, and <code>Locale</code><br> <li> Modified <code>test_getMessage_withValidCode()</code> to check system locale and <br>assert appropriate message<br> <li> Modified <code>test_getMessage_withNullArgs()</code> to check system locale and <br>assert appropriate message<br> <li> Tests now support both Chinese ("测试") and English ("test") message <br>assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5521/files#diff-57d21485b781c474c7e637da7137424a1bff6eaa6f3ac36906a4ad2788cfedfd">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

## Summary by Sourcery

使 ValidatorUtils 的消息测试对当前系统区域设置具有容错性，避免因区域设置不同导致的失败。

Bug 修复：
- 防止当系统区域设置不是中文时，ValidatorUtilsTest 中的消息断言失败。

测试：
- 更新 ValidatorUtilsTest 中的断言，根据检测到的区域设置接受中文或英文消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make ValidatorUtils message tests tolerant to the current system locale to avoid locale-dependent failures.

Bug Fixes:
- Prevent ValidatorUtilsTest message assertions from failing when the system locale is not Chinese.

Tests:
- Update ValidatorUtilsTest assertions to accept either Chinese or English messages based on the detected locale.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation message tests with locale-specific assertions to verify correct message retrieval across different language settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->