### PR TITLE
fix: 测试失败失败，无法构建项目

### DIFF
--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/AggregateRoot.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/AggregateRoot.java
@@ -18,6 +18,7 @@
 package org.laokou.common.i18n.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.Instant;
 
@@ -27,6 +28,7 @@ import java.time.Instant;
  * @author laokou
  */
 @Getter
+@Setter
 public abstract class AggregateRoot extends Identifier {
 
 	/**

--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/Identifier.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/dto/Identifier.java
@@ -18,6 +18,7 @@
 package org.laokou.common.i18n.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -27,6 +28,7 @@ import java.io.Serializable;
  * @author laokou
  */
 @Getter
+@Setter
 public abstract class Identifier implements Serializable {
 
 	/**

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
@@ -115,7 +115,7 @@ public class AuthA extends AggregateRoot implements ValidateName {
 	/**
 	 * ID生成器.
 	 */
-	private final IdGenerator idGenerator;
+	private final transient IdGenerator idGenerator;
 
 	/**
 	 * 请求值Map映射.


### PR DESCRIPTION
## Summary by Sourcery

将领域 ID 生成器依赖标记为不可序列化，并通过 Lombok setter 使聚合根基类可变，以解决与序列化相关的测试失败问题。

Enhancements:
- 将 `AuthA.idGenerator` 标记为 `transient`，以避免序列化 ID 生成器依赖。
- 在 `AggregateRoot` 和 `Identifier` 基类上启用 Lombok 生成的 setter，以便在需要时允许修改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mark domain ID generator dependency as non-serializable and make aggregate root base classes mutable via Lombok setters to resolve serialization-related test failures.

Enhancements:
- Mark AuthA.idGenerator as transient to avoid serializing the ID generator dependency.
- Enable Lombok-generated setters on AggregateRoot and Identifier base classes to allow mutation where required.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal data model configuration and structure handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->