### PR TITLE
fix: 测试失败失败，无法构建项目

### DIFF
--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/AbstractWebSocketServerChannelInitializer.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/AbstractWebSocketServerChannelInitializer.java
@@ -18,7 +18,7 @@
 package org.laokou.common.websocket.config;
 
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
@@ -33,13 +33,13 @@ import java.util.concurrent.TimeUnit;
  * @author laokou
  */
 @RequiredArgsConstructor
-public abstract class AbstractWebSocketServerChannelInitializer extends AbstractChannelInitializer<NioSocketChannel> {
+public abstract class AbstractWebSocketServerChannelInitializer extends AbstractChannelInitializer<SocketChannel> {
 
 	protected final SpringWebSocketServerProperties springWebSocketServerProperties;
 
 	// @formatter:off
 	@Override
-	protected void initChannel(NioSocketChannel channel) throws Exception {
+	protected void initChannel(SocketChannel channel) throws Exception {
 		ChannelPipeline pipeline = channel.pipeline();
 		// 前置处理
 		preHandler(channel, pipeline);


### PR DESCRIPTION
## 由 Sourcery 提供的总结

增强内容：
- 更新抽象的 WebSocket 服务器通道初始化器，在类定义和 `initChannel` 方法签名中使用泛型的 `SocketChannel` 类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update the abstract WebSocket server channel initializer to use the generic SocketChannel type in its class definition and initChannel method signature.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated WebSocket server channel handling to use a more flexible base channel type, improving code maintainability. No changes to existing functionality or user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->