### PR TITLE
fix: 测试失败失败，无法构建项目

### DIFF
--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/AbstractServer.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/AbstractServer.java
@@ -114,6 +114,15 @@ public abstract class AbstractServer implements Server {
 	}
 
 	/**
+	 * 是否正在运行.
+	 * @return true表示正在运行，false表示已停止
+	 */
+	@Override
+	public final boolean isRunning() {
+		return running.get();
+	}
+
+	/**
 	 * 绑定端口.
 	 * @param bootstrap 启动类
 	 * @param port 端口

--- a/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/Server.java
+++ b/laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/Server.java
@@ -39,4 +39,10 @@ public interface Server {
 	 */
 	void stop();
 
+	/**
+	 * 是否正在运行.
+	 * @return true表示正在运行，false表示已停止
+	 */
+	boolean isRunning();
+
 }

--- a/laokou-common/laokou-common-websocket/src/test/java/org/laokou/common/websocket/config/WebSocketMessageSendIntegrationTest.java
+++ b/laokou-common/laokou-common-websocket/src/test/java/org/laokou/common/websocket/config/WebSocketMessageSendIntegrationTest.java
@@ -261,6 +261,8 @@ class WebSocketMessageSendIntegrationTest {
 		properties.setReaderIdleTime(60);
 		properties.setBossCorePoolSize(1);
 		properties.setWorkerCorePoolSize(2);
+		// Disable io_uring for consistent test behavior across environments
+		properties.setUseIoUring(false);
 
 		// Create handler
 		WebSocketServerHandler handler = new WebSocketServerHandler(properties, introspector);
@@ -273,8 +275,16 @@ class WebSocketMessageSendIntegrationTest {
 		server = new WebSocketServer(initializer, properties, Executors.newVirtualThreadPerTaskExecutor());
 		Thread.ofVirtual().start(() -> server.start());
 
-		// Wait for server to start
-		Thread.sleep(1000);
+		// Wait for server to be ready with polling (max 10 seconds)
+		int maxWaitMs = 10000;
+		int waitedMs = 0;
+		while (!server.isRunning() && waitedMs < maxWaitMs) {
+			Thread.sleep(100);
+			waitedMs += 100;
+		}
+		if (!server.isRunning()) {
+			throw new RuntimeException("Server failed to start within " + maxWaitMs + "ms");
+		}
 
 		// Initialize client event loop
 		clientGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
@@ -437,7 +447,7 @@ class WebSocketMessageSendIntegrationTest {
 		void close() throws Exception {
 			if (channel != null && channel.isActive()) {
 				channel.writeAndFlush(new CloseWebSocketFrame());
-				channel.closeFuture().await(5, TimeUnit.SECONDS);
+				channel.close().await(5, TimeUnit.SECONDS);
 			}
 		}
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `isRunning()` method to Server interface and implementation

- Replace fixed sleep with polling for server startup verification

- Disable io_uring in tests for consistent cross-environment behavior

- Fix channel closure method call in test cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Server Interface"] -->|"add isRunning()"| B["AbstractServer Implementation"]
  C["Test Setup"] -->|"use isRunning()"| D["Polling Verification"]
  D -->|"replace sleep"| E["Reliable Startup Detection"]
  C -->|"disable io_uring"| F["Consistent Test Behavior"]
  C -->|"fix channel.close()"| G["Proper Resource Cleanup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Server.java</strong><dd><code>Add isRunning method to Server interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/Server.java

<ul><li>Added <code>isRunning()</code> method declaration to the Server interface<br> <li> Method returns boolean indicating server running state</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5526/files#diff-885008a175d7d7f7828d5186f77ebb244b79e5576c43bff5017426b58d27667f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AbstractServer.java</strong><dd><code>Implement isRunning method in AbstractServer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-websocket/src/main/java/org/laokou/common/websocket/config/AbstractServer.java

<ul><li>Implemented <code>isRunning()</code> method in AbstractServer class<br> <li> Returns current state of <code>running</code> atomic variable<br> <li> Marked as final override method</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5526/files#diff-5ac01e82809560dc0ba178de274d26ddaea64f301705996fd5dd1e6eb80e3002">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebSocketMessageSendIntegrationTest.java</strong><dd><code>Fix test startup verification and channel closure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-websocket/src/test/java/org/laokou/common/websocket/config/WebSocketMessageSendIntegrationTest.java

<ul><li>Disabled io_uring in test properties for consistent behavior<br> <li> Replaced fixed 1-second sleep with polling mechanism<br> <li> Added 10-second timeout with 100ms polling intervals<br> <li> Throws RuntimeException if server fails to start within timeout<br> <li> Fixed channel closure from <code>closeFuture().await()</code> to <code>close().await()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5526/files#diff-d3d03837d7c3880ff87fd1f3105f7eb10e0c31b7a8ba73b6f9f3fa0d7f34adfc">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebSocketServerIntegrationTest.java</strong><dd><code>Fix test startup verification and channel closure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-websocket/src/test/java/org/laokou/common/websocket/config/WebSocketServerIntegrationTest.java

<ul><li>Disabled io_uring in test properties for consistent behavior<br> <li> Replaced fixed 1-second sleep with polling mechanism<br> <li> Added 10-second timeout with 100ms polling intervals<br> <li> Throws RuntimeException if server fails to start within timeout<br> <li> Fixed channel closure from <code>closeFuture().await()</code> to <code>close().await()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5526/files#diff-9a6b61fec0f8b765bdbe7e0a823cc6a5a1dbf68f4d4212f90a2b67a0bdaecc6d">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `isRunning()` method to check whether the websocket server is currently operational.

* **Tests**
  * Enhanced server startup validation with polling mechanism and timeout handling.
  * Improved client shutdown sequence for more reliable resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->