### PR TITLE
feat: 指定分布式ID注册到Nacos为永久实例，走CP协议【强一致性】

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           verbose: true
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           files: |
             ./laokou-common/laokou-common-core/target/site/jacoco/jacoco.xml,
             ./laokou-common/laokou-common-fory/target/site/jacoco/jacoco.xml,

--- a/archive/docs/01.指南/00.开发手册/27.组件【nacos】.md
+++ b/archive/docs/01.指南/00.开发手册/27.组件【nacos】.md
@@ -978,13 +978,13 @@ class NamingUtilsTest {
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList())).hasSize(0);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", List.of("nacos-cluster"), false)).hasSize(1);
+		Assertions.assertThat(namingService.getAllInstances("test-service", List.of("iot-cluster"), false)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(0);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(0);
 
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(Duration.ofSeconds(1));
@@ -994,44 +994,44 @@ class NamingUtilsTest {
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", false)).hasSize(0);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(1);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(0);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(0);
 	}
 
 	@Test
 	void test_selectInstances() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true, false)).hasSize(1);
 
 		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", true, false)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", List.of("nacos-cluster"), true)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), true, false)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", List.of("nacos-cluster"), true, false)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", List.of("iot-cluster"), true)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), true, false)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", List.of("iot-cluster"), true, false)).hasSize(1);
 		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", true)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), true)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), true)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(0);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(0);
 	}
 
 	@Test
 	void test_selectOneHealthyInstance() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
@@ -1039,19 +1039,19 @@ class NamingUtilsTest {
 		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP")).isNotNull();
 		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", false)).isNotNull();
 		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false)).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("nacos-cluster"))).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"))).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("nacos-cluster"), false)).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("iot-cluster"))).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("iot-cluster"))).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("iot-cluster"), false)).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).isNotNull();
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 	}
 
 	@Test
 	void test_subscribeService() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
@@ -1061,11 +1061,11 @@ class NamingUtilsTest {
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", evt -> Assertions.assertThat(evt).isNotNull()));
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", evt -> Assertions.assertThat(evt).isNotNull()));
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
 
 		// 只选择订阅ip为`127.0`开头的实例。
 		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
@@ -1075,14 +1075,14 @@ class NamingUtilsTest {
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", selector, evt -> Assertions.assertThat(evt).isNotNull()));
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", selector, evt -> Assertions.assertThat(evt).isNotNull()));
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 	}
 
 	@Test
 	void test_getServicesOfServer() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
@@ -1092,7 +1092,7 @@ class NamingUtilsTest {
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", "DEFAULT_GROUP", evt -> Assertions.assertThat(evt).isNotNull()));
 		Assertions.assertThat(namingService.getSubscribeServices()).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 	}
@@ -1141,7 +1141,7 @@ spring:
         # true 临时 false 持久
         ephemeral: true
         # 集群名称
-        cluster-name: nacos-cluster
+        cluster-name: iot-cluster
 		heart-beat:
 			# 开启心跳
 			enabled: true
@@ -1161,7 +1161,7 @@ spring:
 		# 密码
         password: nacos
 		# 集群名称
-        cluster-name: nacos-cluster
+        cluster-name: iot-cluster
         # https://github.com/alibaba/spring-cloud-alibaba/blob/2021.x/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-config.adoc
         # 指定读取的文件格式
         file-extension: yaml

--- a/archive/docs/01.指南/05.后端指南/09.Spring Cloud Gateway+Redis+Nacos之动态路由和负载均衡.md
+++ b/archive/docs/01.指南/05.后端指南/09.Spring Cloud Gateway+Redis+Nacos之动态路由和负载均衡.md
@@ -110,7 +110,7 @@ spring:
         # true 临时 false 持久
         ephemeral: true
         # 服务注册&发现-集群名称
-        cluster-name: nacos-cluster
+        cluster-name: iot-cluster
         heart-beat:
           # 开启心跳检测
           enabled: true
@@ -132,7 +132,7 @@ spring:
         # 配置中心-分组
         group: DEFAULT
         # 配置中心-集群名称
-        cluster-name: nacos-cluster
+        cluster-name: iot-cluster
         # 配置中心-开启自动刷新
         refresh-enabled: true
         # 配置中心-配置文件格式

--- a/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
+++ b/laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java
@@ -93,13 +93,13 @@ class NamingUtilsTest {
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", Collections.emptyList())).hasSize(0);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", List.of("nacos-cluster"), false)).hasSize(1);
+		Assertions.assertThat(namingService.getAllInstances("test-service", List.of("iot-cluster"), false)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(0);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(0);
 
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080));
 		Thread.sleep(Duration.ofSeconds(1));
@@ -109,44 +109,44 @@ class NamingUtilsTest {
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", false)).hasSize(0);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(1);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(0);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(0);
 	}
 
 	@Test
 	void test_selectInstances() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true, false)).hasSize(1);
 
 		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", true, false)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", List.of("nacos-cluster"), true)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), true, false)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", List.of("nacos-cluster"), true, false)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", List.of("iot-cluster"), true)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), true, false)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", List.of("iot-cluster"), true, false)).hasSize(1);
 		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", true)).hasSize(1);
-		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), true)).hasSize(1);
+		Assertions.assertThat(namingService.selectInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), true)).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
-		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).hasSize(0);
+		Assertions.assertThat(namingService.getAllInstances("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).hasSize(0);
 	}
 
 	@Test
 	void test_selectOneHealthyInstance() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
@@ -154,19 +154,19 @@ class NamingUtilsTest {
 		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP")).isNotNull();
 		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", false)).isNotNull();
 		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", false)).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("nacos-cluster"))).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"))).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("nacos-cluster"), false)).isNotNull();
-		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), false)).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("iot-cluster"))).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("iot-cluster"))).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", List.of("iot-cluster"), false)).isNotNull();
+		Assertions.assertThat(namingService.selectOneHealthyInstance("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), false)).isNotNull();
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 	}
 
 	@Test
 	void test_subscribeService() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
@@ -176,11 +176,11 @@ class NamingUtilsTest {
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", evt -> Assertions.assertThat(evt).isNotNull()));
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", evt -> Assertions.assertThat(evt).isNotNull()));
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", "DEFAULT_GROUP", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", "DEFAULT_GROUP", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", List.of("nacos-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", List.of("iot-cluster"), evt -> Assertions.assertThat(evt).isNotNull()));
 
 		// 只选择订阅ip为`127.0`开头的实例。
 		NamingSelector selector = NamingSelectorFactory.newIpSelector("127.0.*");
@@ -190,14 +190,14 @@ class NamingUtilsTest {
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", selector, evt -> Assertions.assertThat(evt).isNotNull()));
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.unsubscribe("test-service", selector, evt -> Assertions.assertThat(evt).isNotNull()));
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 	}
 
 	@Test
 	void test_getServicesOfServer() throws NacosException, InterruptedException {
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.registerInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(1);
 
@@ -207,7 +207,7 @@ class NamingUtilsTest {
 		Assertions.assertThatNoException().isThrownBy(() -> namingService.subscribe("test-service", "DEFAULT_GROUP", evt -> Assertions.assertThat(evt).isNotNull()));
 		Assertions.assertThat(namingService.getSubscribeServices()).hasSize(1);
 
-		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "nacos-cluster"));
+		Assertions.assertThatNoException().isThrownBy(() -> namingService.deregisterInstance("test-service", "DEFAULT_GROUP", "127.0.0.1", 8080, "iot-cluster"));
 		Thread.sleep(Duration.ofSeconds(1));
 		Assertions.assertThat(namingService.selectInstances("test-service", true)).hasSize(0);
 	}

--- a/laokou-service/laokou-distributed-id/laokou-distributed-id-infrastructure/src/main/java/org/laokou/distributed/id/config/NacosSnowflakeGenerator.java
+++ b/laokou-service/laokou-distributed-id/laokou-distributed-id-infrastructure/src/main/java/org/laokou/distributed/id/config/NacosSnowflakeGenerator.java
@@ -369,12 +369,20 @@ public class NacosSnowflakeGenerator implements SnowflakeGenerator {
 		instance.setWeight(1.0);
 		instance.setHealthy(true);
 		instance.setEnabled(true);
+		instance.setClusterName(getClusterName());
+		// CP强一致性【永久实例】
+		instance.setEphemeral(false);
 		namingService.registerInstance(serviceId, groupName, instance);
 		log.info("Registered instance with metadata: {}", metadata);
 	}
 
 	private boolean isCurrentInstance(Instance instance) {
 		return ObjectUtils.equals(instance.getIp(), currentIp) && instance.getPort() == currentPort;
+	}
+
+	private String getClusterName() {
+		return environment.getProperty("spring.cloud.nacos.discovery.cluster-name",
+				System.getProperty("spring.cloud.nacos.discovery.cluster-name", "iot-cluster"));
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -816,17 +816,17 @@
       </snapshots>
     </repository>
     <repository>
-       <!--
+      <!--
 
-         需要在 settings.xml 配置
+        需要在 settings.xml 配置
 
-        <server>
-            <id>github</id>
-            <username>Your GitHub Username</username>
-            <password>Your GitHub Token (requires read:packages permission)</password>
-        </server>
+       <server>
+           <id>github</id>
+           <username>Your GitHub Username</username>
+           <password>Your GitHub Token (requires read:packages permission)</password>
+       </server>
 
-       -->
+      -->
       <id>spring-cloud-alibaba-github</id>
       <url>https://maven.pkg.github.com/alibaba/spring-cloud-alibaba</url>
       <releases>
@@ -855,7 +855,7 @@
         <NACOS-GROUP>IOT_GROUP</NACOS-GROUP>
         <NACOS-USERNAME>nacos</NACOS-USERNAME>
         <NACOS-PASSWORD>nacos</NACOS-PASSWORD>
-        <NACOS-CLUSTER-NAME>nacos-cluster</NACOS-CLUSTER-NAME>
+        <NACOS-CLUSTER-NAME>iot-cluster</NACOS-CLUSTER-NAME>
         <SECRET-KEY>laokou</SECRET-KEY>
       </properties>
       <activation>
@@ -878,7 +878,7 @@
         <NACOS-GROUP>IOT_GROUP</NACOS-GROUP>
         <NACOS-USERNAME>nacos</NACOS-USERNAME>
         <NACOS-PASSWORD>nacos</NACOS-PASSWORD>
-        <NACOS-CLUSTER-NAME>nacos-cluster</NACOS-CLUSTER-NAME>
+        <NACOS-CLUSTER-NAME>iot-cluster</NACOS-CLUSTER-NAME>
         <SECRET-KEY>laokou</SECRET-KEY>
       </properties>
       <activation>
@@ -912,7 +912,7 @@
         <!--suppress UnresolvedMavenProperty -->
         <NACOS-PASSWORD>${NACOS_PASSWORD:nacos}</NACOS-PASSWORD>
         <!--suppress UnresolvedMavenProperty -->
-        <NACOS-CLUSTER-NAME>${NACOS_CLUSTER_NAME:nacos-cluster}</NACOS-CLUSTER-NAME>
+        <NACOS-CLUSTER-NAME>${NACOS_CLUSTER_NAME:iot-cluster}</NACOS-CLUSTER-NAME>
         <!--suppress UnresolvedMavenProperty -->
         <SECRET-KEY>${SECRET_KEY:laokou}</SECRET-KEY>
       </properties>
@@ -1210,21 +1210,32 @@
         <version>${jacoco-maven-plugin.version}</version>
         <configuration>
           <skip>false</skip>
-          <destFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</destFile>
         </configuration>
         <executions>
           <execution>
-            <id>pre-test</id>
+            <id>prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
-            <id>post-test</id>
-            <phase>test</phase>
+            <id>report</id>
+            <phase>verify</phase>
             <goals>
               <goal>report</goal>
             </goals>
+            <configuration>
+              <!-- 指定读取的 exec 文件路径（JaCoCo 默认位置） -->
+              <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+              <!-- 指定报告输出目录 -->
+              <outputDirectory>${project.build.directory}/site/jacoco</outputDirectory>
+              <formats>
+                <!-- 生成 HTML 格式以创建 site 目录 -->
+                <format>HTML</format>
+                <!-- 同时生成 XML 格式供 CI 工具使用 -->
+                <format>XML</format>
+              </formats>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
### **User description**
fix: 修复测试用例无法上传测试覆盖报告


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Register distributed ID instances to Nacos as permanent instances using CP protocol for strong consistency

- Update cluster name from `nacos-cluster` to `iot-cluster` across test cases and documentation

- Fix test coverage upload by enabling strict CI failure on Codecov errors

- Improve JaCoCo configuration for proper test coverage report generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Nacos Instance Registration"] -->|"Set ephemeral=false"| B["Permanent Instance"]
  A -->|"Set cluster name"| C["iot-cluster"]
  B --> D["CP Protocol Strong Consistency"]
  E["Test Coverage"] -->|"Enable fail_ci_if_error"| F["Strict CI Validation"]
  G["JaCoCo Configuration"] -->|"Add XML format"| H["Codecov Integration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NacosSnowflakeGenerator.java</strong><dd><code>Configure permanent Nacos instance with CP protocol</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-service/laokou-distributed-id/laokou-distributed-id-infrastructure/src/main/java/org/laokou/distributed/id/config/NacosSnowflakeGenerator.java

<ul><li>Set instance as permanent by adding <code>instance.setEphemeral(false)</code> for <br>CP protocol strong consistency<br> <li> Add cluster name configuration via new <code>getClusterName()</code> method that <br>reads from Spring properties or system properties with fallback to <br><code>iot-cluster</code><br> <li> Configure instance metadata with datacenter ID, machine ID, and gRPC <br>port</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5531/files#diff-72803014cd11e296f0ca86d952078e1a1052b93db17f0dc95a2ed7f056505d49">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NamingUtilsTest.java</strong><dd><code>Update test cluster names to iot-cluster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-nacos/src/test/java/org/laokou/common/nacos/NamingUtilsTest.java

<ul><li>Replace all test cluster name references from <code>nacos-cluster</code> to <br><code>iot-cluster</code> across multiple test methods<br> <li> Update cluster names in registerInstance, deregisterInstance, <br>getAllInstances, selectInstances, selectOneHealthyInstance, subscribe, <br>and unsubscribe method calls<br> <li> Maintain consistent cluster naming throughout test suite for <br>distributed ID registration tests</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5531/files#diff-5b1ecb5a9d0a74e059f23d65515b76c0218bd3957b137edbfc1f2e4cf098b9d5">+31/-31</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven.yml</strong><dd><code>Enable strict Codecov error handling in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven.yml

<ul><li>Change <code>fail_ci_if_error</code> from <code>false</code> to <code>true</code> in Codecov upload step to <br>enforce strict CI validation<br> <li> Enable pipeline failure when coverage report upload encounters errors</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5531/files#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update cluster names and improve JaCoCo coverage configuration</code></dd></summary>
<hr>

pom.xml

<ul><li>Update NACOS-CLUSTER-NAME property from <code>nacos-cluster</code> to <code>iot-cluster</code> <br>in dev, test, and prod profiles<br> <li> Refactor JaCoCo plugin configuration to use standard <code>jacoco.exec</code> file <br>location and add XML format output for CI integration<br> <li> Remove custom <code>destFile</code> path and add explicit <code>dataFile</code>, <br><code>outputDirectory</code>, and format configurations for better Codecov <br>compatibility<br> <li> Fix indentation in GitHub Maven repository comment block</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5531/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+26/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>27.组件【nacos】.md</strong><dd><code>Update documentation cluster names to iot-cluster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

archive/docs/01.指南/00.开发手册/27.组件【nacos】.md

<ul><li>Update all documentation examples from <code>nacos-cluster</code> to <code>iot-cluster</code> <br>for consistency<br> <li> Update cluster-name configuration examples in Spring Cloud Nacos <br>discovery and config sections<br> <li> Maintain alignment between documentation and actual implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5531/files#diff-4c39a3f469058416281a3203ed1bf02f9568d75da6572964d3cfaea370b5421f">+33/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>09.Spring Cloud Gateway+Redis+Nacos之动态路由和负载均衡.md</strong><dd><code>Update gateway documentation cluster names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

archive/docs/01.指南/05.后端指南/09.Spring Cloud Gateway+Redis+Nacos之动态路由和负载均衡.md

<ul><li>Update cluster-name configuration from <code>nacos-cluster</code> to <code>iot-cluster</code> in <br>service registration and config center examples<br> <li> Ensure documentation reflects the new cluster naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5531/files#diff-88de3021ceca74c001529bd03abff2804453a1f7de6dd3e292de889d912a65a0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated Nacos cluster naming from "nacos-cluster" to "iot-cluster" across all environments and configurations.
  * Enabled GitHub Packages authentication for Maven repository access.
  * Enhanced JaCoCo code coverage reporting with improved output formats and configuration.

* **Bug Fixes**
  * CI pipeline now properly fails when Codecov upload encounters errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->