### PR TITLE
fix: maven构建失败

### DIFF
--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/DataFilterInterceptor.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/DataFilterInterceptor.java
@@ -45,7 +45,8 @@ public class DataFilterInterceptor implements InnerInterceptor {
 	@Override
 	public void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
 			ResultHandler resultHandler, BoundSql boundSql) {
-		if (parameter instanceof Map<?, ?> map && map.get(PageQuery.PAGE_QUERY) instanceof PageQuery pageQuery) {
+		if (parameter instanceof Map<?, ?> map && map.containsKey(PageQuery.PAGE_QUERY)
+				&& map.get(PageQuery.PAGE_QUERY) instanceof PageQuery pageQuery) {
 			// 获取aop拼接的sql
 			String sqlFilter = pageQuery.getSqlFilter();
 			if (StringExtUtils.isEmpty(sqlFilter)) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add null safety check before accessing map value

- Prevent potential NullPointerException in data filter logic

- Ensure map contains key before instanceof check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Map parameter check"] --> B["containsKey validation"]
  B --> C["instanceof PageQuery check"]
  C --> D["Safe value retrieval"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataFilterInterceptor.java</strong><dd><code>Add containsKey validation before map access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/config/DataFilterInterceptor.java

<ul><li>Added <code>map.containsKey(PageQuery.PAGE_QUERY)</code> check before accessing map <br>value<br> <li> Prevents NullPointerException when key doesn't exist in parameter map<br> <li> Improves null safety in beforeQuery method condition</ul>


</details>


  </td>
  <td><a href="https://github.com/KouShenhai/KCloud-Platform-IoT/pull/5585/files#diff-b03205c76f7b9cb599cc619713450fae65a38f78262e18087ae83a9edc2fadef">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability by adding defensive parameter validation to prevent null-pointer and missing-key exceptions during data processing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->