### PR TITLE
feat: 构建laokou-gateway native image

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -90,9 +90,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build Native Image with GraalVM
         run: |
+          docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }} registry.cn-shenzhen.aliyuncs.com
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-gateway
           mvnd spring-boot:process-aot
           mvnd spring-boot:build-image -DskipTests
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.1-SNAPSHOT
       - name: Build Docker Image
         run: |
           # 登录阿里云镜像仓库

--- a/laokou-cloud/laokou-gateway/pom.xml
+++ b/laokou-cloud/laokou-gateway/pom.xml
@@ -173,7 +173,7 @@
           <!-- main方法的地址 只需要修改这个地址-->
           <mainClass>org.laokou.gateway.GatewayApp</mainClass>
           <!-- Docker镜像名称 -->
-          <imageName>${project.artifactId}-native:${project.version}</imageName>
+          <imageName>${docker.registry}/${docker.namespace}/${project.artifactId}-native:${project.version}</imageName>
         </configuration>
         <executions>
           <execution>

--- a/laokou-service/laokou-auth/laokou-auth-start/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-start/pom.xml
@@ -26,6 +26,7 @@
     </dependency>
   </dependencies>
   <build>
+    <finalName>${project.artifactId}</finalName>
     <plugins>
       <!-- 打包插件，将 Java 源代码编译为字节码（.class 文件） -->
       <plugin>
@@ -39,9 +40,10 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot-maven-plugin.version}</version>
         <configuration>
-          <finalName>${project.artifactId}</finalName>
           <!-- main方法的地址 只需要修改这个地址-->
           <mainClass>org.laokou.auth.AuthApp</mainClass>
+          <!-- Docker镜像名称 -->
+          <imageName>${docker.registry}/${docker.namespace}/${project.artifactId}-native:${project.version}</imageName>
         </configuration>
         <executions>
           <execution>
@@ -55,27 +57,6 @@
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
         <version>${native-maven-plugin.version}</version>
-        <extensions>true</extensions>
-        <executions>
-          <execution>
-            <id>build-native</id>
-            <phase>package</phase>
-          </execution>
-          <execution>
-            <id>test-native</id>
-            <phase>test</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <imageName>${project.parent.artifactId}</imageName>
-          <mainClass>org.laokou.auth.AuthApp</mainClass>
-          <fallback>false</fallback>
-          <!-- 快速构建 -->
-          <quickBuild>true</quickBuild>
-          <buildArgs>
-            <buildArg>--verbose</buildArg>
-          </buildArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>io.fabric8</groupId>


### PR DESCRIPTION
## Summary by Sourcery

为 `laokou-gateway` 配置原生镜像的 Docker 构建，并使认证服务的构建设置与对外发布镜像的方式保持一致。

Build:
- 在项目构建层面为 `laokou-auth` starter 设置最终制品名称，并移除 `native-maven-plugin` 的原生镜像构建配置，改用 Spring Boot 的镜像构建机制。
- 更新 `auth` 和 `gateway` 模块的 Spring Boot `imageName` 设置，采用基于参数化 Docker 仓库/命名空间的命名约定。

CI:
- 扩展 Maven 的 GitHub Actions 工作流，在构建完成后登录 Docker 仓库并推送 `laokou-gateway` 原生镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure native image Docker builds for laokou-gateway and align auth service build settings with external image publishing.

Build:
- Set the laokou-auth starter final artifact name at the project build level and remove native-maven-plugin native image build configuration in favor of Spring Boot image building.
- Update Spring Boot imageName settings for auth and gateway modules to use a parameterized Docker registry/namespace-based naming convention.

CI:
- Extend the Maven GitHub Actions workflow to log in to the Docker registry and push the laokou-gateway native image after building it.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Docker image publishing to a container registry for native application builds.
  * Updated Maven plugin configuration for native image build handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->