### PR TITLE
feat: 构建laokou-gateway native image

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -88,18 +88,6 @@ jobs:
             ./laokou-cloud/laokou-gateway/target/site/jacoco/jacoco.xml,
             ./laokou-service/laokou-auth/laokou-auth-domain/target/site/jacoco/jacoco.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Build Native Image with GraalVM
-        run: |
-          # 登录阿里云镜像仓库
-          docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }} registry.cn-shenzhen.aliyuncs.com
-          # ========== 构建laokou-gateway-native ==========
-          cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-gateway
-          # AOT处理
-          mvnd spring-boot:process-aot
-          # 构建本地镜像
-          mvnd spring-boot:build-image -DskipTests
-          # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.1-SNAPSHOT
       - name: Build Docker Image
         run: |
           # 登录阿里云镜像仓库
@@ -146,3 +134,15 @@ jobs:
           docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.1
           # 推送镜像到镜像仓库
           docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.1
+      - name: Build Native Image with GraalVM
+        run: |
+          # 登录阿里云镜像仓库
+          docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }} registry.cn-shenzhen.aliyuncs.com
+          # ========== 构建laokou-gateway-native ==========
+          cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-gateway
+          # AOT处理
+          mvnd clean install -DskipTests -Pprod spring-boot:process-aot
+          # 构建本地镜像
+          mvnd spring-boot:build-image -DskipTests
+          # 推送镜像到镜像仓库
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.1-SNAPSHOT

--- a/doc/deploy/docker-compose/docker-compose.yml
+++ b/doc/deploy/docker-compose/docker-compose.yml
@@ -361,7 +361,7 @@ services:
     ports:
       - "8848:8848"
       - "9848:9848"
-      - "9849:9849"
+      - "8048:8048"
     volumes:
       - ./nacos/logs:/opt/nacos/logs
     env_file:

--- a/laokou-cloud/laokou-gateway/run.sh
+++ b/laokou-cloud/laokou-gateway/run.sh
@@ -1,2 +1,0 @@
-docker pull registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.1-SNAPSHOT
-docker run -d -p 5555:5555 --net=host registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.1-SNAPSHOT

--- a/laokou-cloud/laokou-nacos/pom.xml
+++ b/laokou-cloud/laokou-nacos/pom.xml
@@ -137,7 +137,6 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot-old.version}</version>
         <configuration>
-          <finalName>${project.artifactId}</finalName>
           <!-- main方法的地址 只需要修改这个地址-->
           <mainClass>org.laokou.nacos.NacosApp</mainClass>
         </configuration>
@@ -174,27 +173,6 @@
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
         <version>${native-maven-plugin.version}</version>
-        <extensions>true</extensions>
-        <executions>
-          <execution>
-            <id>build-native</id>
-            <phase>package</phase>
-          </execution>
-          <execution>
-            <id>test-native</id>
-            <phase>test</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <imageName>${project.parent.artifactId}</imageName>
-          <mainClass>org.laokou.nacos.NacosApp</mainClass>
-          <fallback>false</fallback>
-          <!-- 快速构建 -->
-          <quickBuild>true</quickBuild>
-          <buildArgs>
-            <buildArg>--verbose</buildArg>
-          </buildArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary by Sourcery

将 laokou-gateway 的原生镜像构建移动到 Maven CI 工作流的末尾，并调整相关构建和部署配置。

Build:
- 更新 Maven CI 工作流，使其在构建并推送 Docker 镜像之后再构建并推送 laokou-gateway 的 GraalVM 原生镜像，并在 AOT 处理之前使用完整的 prod-profile `clean install`。
- 通过移除 `native-maven-plugin` 的执行及相关配置，简化 laokou-nacos 的 Maven 配置。

Deployment:
- 将 Docker Compose 中暴露的 Nacos 端口从 9849 更改为 8048。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move laokou-gateway native image build to the end of the Maven CI workflow and adjust related build and deployment configuration.

Build:
- Update Maven CI workflow to build and push the laokou-gateway GraalVM native image after Docker images, using a full prod-profile clean install before AOT processing.
- Simplify laokou-nacos Maven configuration by removing native-maven-plugin executions and associated settings.

Deployment:
- Change exposed Nacos port in Docker Compose from 9849 to 8048.

</details>

Build（构建）:
- 将 laokou-gateway 的 GraalVM 原生镜像构建步骤移动到 Maven CI 工作流的末尾，并在 AOT 处理前更新为使用 prod profile 进行完整的 `clean install`。
- 从 laokou-nacos 模块中移除 native-maven-plugin 的执行及相关配置，以简化其构建配置。

Deployment（部署）:
- 将 Docker Compose 配置中暴露的 Nacos 服务端口从 9849 修改为 8048。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 laokou-gateway 的原生镜像构建移动到 Maven CI 工作流的末尾，并调整相关构建和部署配置。

Build:
- 更新 Maven CI 工作流，使其在构建并推送 Docker 镜像之后再构建并推送 laokou-gateway 的 GraalVM 原生镜像，并在 AOT 处理之前使用完整的 prod-profile `clean install`。
- 通过移除 `native-maven-plugin` 的执行及相关配置，简化 laokou-nacos 的 Maven 配置。

Deployment:
- 将 Docker Compose 中暴露的 Nacos 端口从 9849 更改为 8048。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move laokou-gateway native image build to the end of the Maven CI workflow and adjust related build and deployment configuration.

Build:
- Update Maven CI workflow to build and push the laokou-gateway GraalVM native image after Docker images, using a full prod-profile clean install before AOT processing.
- Simplify laokou-nacos Maven configuration by removing native-maven-plugin executions and associated settings.

Deployment:
- Change exposed Nacos port in Docker Compose from 9849 to 8048.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Nacos service port configuration in Docker deployment (port 8048).
  * Simplified native image build workflow with updated Maven profile and command sequence.
  * Removed native image build dependencies from service configuration.
  * Updated container deployment scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->