### PR TITLE
Dev

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@
 
 image::doc/image/logo/logo.png[LOGO,500,align=center]
 
-KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的IoT云平台。基于Spring Boot 4.0.2、Spring Cloud 2025.1.0、Spring Cloud Alibaba 2025.1.0.0 最新版本开发的云服务多租户IoT平台。 遵循SpringBoot编程思想，使用阿里COLA应用框架构建，高度模块化和可配置化。具备服务注册&发现、配置中心、灰度路由、服务限流、熔断降级、监控报警、多数据源、高亮搜索、分布式任务调度、分布式链路、分布式缓存、分布式事务、分布式存储、分布式锁等功能，用于快速构建IoT微服务项目。目前支持Shell、Docker、Kubernetes等多种部署方式，并且支持GraalVM和虚拟线程。实现RBAC权限、其中包含首页、系统管理、物联管理、系统监控、数据分析等几大模块。 遵循阿里代码规范，采用RESTFul设计风格及DDD(领域驱动设计)思想，代码简洁、架构清晰，非常适合作为基础框架使用。
+KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的IoT云平台。基于Spring Boot 4.0.3、Spring Cloud 2025.1.0、Spring Cloud Alibaba 2025.1.0.0 最新版本开发的云服务多租户IoT平台。 遵循SpringBoot编程思想，使用阿里COLA应用框架构建，高度模块化和可配置化。具备服务注册&发现、配置中心、灰度路由、服务限流、熔断降级、监控报警、多数据源、高亮搜索、分布式任务调度、分布式链路、分布式缓存、分布式事务、分布式存储、分布式锁等功能，用于快速构建IoT微服务项目。目前支持Shell、Docker、Kubernetes等多种部署方式，并且支持GraalVM和虚拟线程。实现RBAC权限、其中包含首页、系统管理、物联管理、系统监控、数据分析等几大模块。 遵循阿里代码规范，采用RESTFul设计风格及DDD(领域驱动设计)思想，代码简洁、架构清晰，非常适合作为基础框架使用。
 
 image:https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/maven.yml/badge.svg?branch=master[Maven Mvnd Ci Build Stauts,link=https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/maven.yml]
 image:https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/node.js.yml/badge.svg?branch=master[Node.js CI Build Stauts,link=https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/node.js.yml]
@@ -38,7 +38,7 @@ image:https://atomgit.com/KouShenhai_/KCloud-Platform-IoT/star/2025top.svg?theme
 
 image:https://img.shields.io/static/v1?label=Spring%20Framework&message=7.0.5&color=green[Spring Framework,link=https://spring.io/projects/spring-framework]
 image:https://img.shields.io/static/v1?label=Spring%20Security&message=7.0.3&color=green[Spring Security,link=https://spring.io/projects/spring-security]
-image:https://img.shields.io/static/v1?label=Spring%20Boot&message=4.0.2&color=green[Spring Boot,link=https://spring.io/projects/spring-boot]
+image:https://img.shields.io/static/v1?label=Spring%20Boot&message=4.0.3&color=green[Spring Boot,link=https://spring.io/projects/spring-boot]
 image:https://img.shields.io/static/v1?label=Spring%20Cloud&message=2025.1.0&color=green[Spring Cloud,link=https://spring.io/projects/spring-cloud]
 image:https://img.shields.io/static/v1?label=Spring%20Cloud%20Alibaba&message=2025.1.0.0&color=orange[Spring Cloud Alibaba,link=https://github.com/alibaba/spring-cloud-alibaba]
 
@@ -147,7 +147,7 @@ image::doc/image/老寇IoT云平台业务架构图.png[架构图,align=center]
 |===
 |组件                         |版本
 
-|Spring Boot                 |4.0.2
+|Spring Boot                 |4.0.3
 |Spring Framework            |7.0.5
 |Spring Security             |7.0.3
 |Spring gRPC                 |1.0.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <div style="text-align: center"><img src="doc/image/logo/logo.png" alt="LOGO" width="500"></div>
 
-KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的IoT云平台。基于Spring Boot 4.0.2、Spring Cloud 2025.1.0、Spring Cloud Alibaba 2025.1.0.0 最新版本开发的云服务多租户IoT平台。 遵循SpringBoot编程思想，使用阿里COLA应用框架构建，高度模块化和可配置化。具备服务注册&发现、配置中心、灰度路由、服务限流、熔断降级、监控报警、多数据源、高亮搜索、分布式任务调度、分布式链路、分布式缓存、分布式事务、分布式存储、分布式锁等功能，用于快速构建IoT微服务项目。目前支持Shell、Docker、Kubernetes等多种部署方式，并且支持GraalVM和虚拟线程。实现RBAC权限、其中包含首页、系统管理、物联管理、系统监控、数据分析等几大模块。 遵循阿里代码规范，采用RESTFul设计风格及DDD(领域驱动设计)思想，代码简洁、架构清晰，非常适合作为基础框架使用。
+KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的IoT云平台。基于Spring Boot 4.0.3、Spring Cloud 2025.1.0、Spring Cloud Alibaba 2025.1.0.0 最新版本开发的云服务多租户IoT平台。 遵循SpringBoot编程思想，使用阿里COLA应用框架构建，高度模块化和可配置化。具备服务注册&发现、配置中心、灰度路由、服务限流、熔断降级、监控报警、多数据源、高亮搜索、分布式任务调度、分布式链路、分布式缓存、分布式事务、分布式存储、分布式锁等功能，用于快速构建IoT微服务项目。目前支持Shell、Docker、Kubernetes等多种部署方式，并且支持GraalVM和虚拟线程。实现RBAC权限、其中包含首页、系统管理、物联管理、系统监控、数据分析等几大模块。 遵循阿里代码规范，采用RESTFul设计风格及DDD(领域驱动设计)思想，代码简洁、架构清晰，非常适合作为基础框架使用。
 
 <a href="https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/maven.yml" target="_blank"><img src="https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/maven.yml/badge.svg?branch=master" alt="Maven Mvnd Ci Build Stauts"/></a>
 <a href="https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/node.js.yml" target="_blank"><img src="https://github.com/KouShenhai/KCloud-Platform-IoT/actions/workflows/node.js.yml/badge.svg?branch=master" alt="Node.js CI Build Stauts"/></a>
@@ -38,7 +38,7 @@ KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的I
 
 <a href="https://spring.io/projects/spring-framework" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Framework&message=7.0.5&color=green" alt="Spring Framework"/></a>
 <a href="https://spring.io/projects/spring-authorization-server" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Security&message=7.0.3&color=green" alt="Spring Security"/></a>
-<a href="https://spring.io/projects/spring-boot" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Boot&message=4.0.2&color=green" alt="Spring Boot"/></a>
+<a href="https://spring.io/projects/spring-boot" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Boot&message=4.0.3&color=green" alt="Spring Boot"/></a>
 <a href="https://spring.io/projects/spring-cloud" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Cloud&message=2025.1.0&color=green" alt="Spring Cloud"/></a>
 <a href="https://github.com/alibaba/spring-cloud-alibaba" target="_blank"><img src="https://img.shields.io/static/v1?label=Spring%20Cloud%20Alibaba&message=2025.1.0.0&color=orange" alt="Spring Cloud Alibaba"/></a>
 
@@ -136,7 +136,7 @@ KCloud-Platform-IoT（老寇IoT云平台）是一个企业级微服务架构的I
 
 |          组件          |     版本      |
 |:--------------------:|:-----------:|
-|     Spring Boot      |    4.0.2    |
+|     Spring Boot      |    4.0.3    |
 |   Spring Framework   |    7.0.5    |
 |   Spring Security    |    7.0.3    |
 |     Spring gRPC      |    1.0.0    |

--- a/archive/docs/00.二开指南/01.指南/13.项目常用注解.md
+++ b/archive/docs/00.二开指南/01.指南/13.项目常用注解.md
@@ -162,11 +162,11 @@ permalink: /pages/2e0e5f/
     <tr>
       <td style="text-align: left;">
         <font style="color: green;">
-          <strong>@EnableRouter</strong></font>
+          <strong>@EnablePrintRouter</strong></font>
       </td>
       <td style="text-align: left;">
         <font style="color: red;">开启服务路由打印</font></td>
-      <td style="text-align: left;">@EnableRouter</td>
+      <td style="text-align: left;">@EnablePrintRouter</td>
 	</tr>
     <tr>
       <td style="text-align: left;">

--- a/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserExtDetails.java
+++ b/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/UserExtDetails.java
@@ -132,9 +132,8 @@ public final class UserExtDetails implements UserDetails, OAuth2AuthenticatedPri
 	@Override
 	@NullMarked
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return AuthorityUtils.createAuthorityList(Stream.concat(this.permissions.stream(), this.scopes.stream())
-			.filter(StringExtUtils::isNotEmpty)
-			.toList());
+		return AuthorityUtils
+			.createAuthorityList(Stream.concat(this.permissions.stream(), this.scopes.stream()).toList());
 	}
 
 	/**

--- a/laokou-common/laokou-common-nacos/src/main/java/org/laokou/common/nacos/annotation/EnablePrintRouter.java
+++ b/laokou-common/laokou-common-nacos/src/main/java/org/laokou/common/nacos/annotation/EnablePrintRouter.java
@@ -30,6 +30,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Import({ RouterHandler.class })
-public @interface EnableRouter {
+public @interface EnablePrintRouter {
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/java/org/laokou/admin/AdminApp.java
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/java/org/laokou/admin/AdminApp.java
@@ -21,7 +21,7 @@ import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.annotation.EnableWarmUp;
 import org.laokou.common.i18n.util.SslUtils;
-import org.laokou.common.nacos.annotation.EnableRouter;
+import org.laokou.common.nacos.annotation.EnablePrintRouter;
 import org.laokou.common.rpc.annotation.EnableRpc;
 import org.laokou.common.security.annotation.EnableSecurity;
 import org.laokou.common.security.config.TransmittableThreadLocalSecurityContextHolderStrategy;
@@ -49,7 +49,7 @@ import java.security.NoSuchAlgorithmException;
 @Slf4j
 @EnableRpc
 @EnableWarmUp
-@EnableRouter
+@EnablePrintRouter
 @EnableSecurity
 @EnableScheduling
 @EnableDiscoveryClient

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/java/org/laokou/auth/AuthApp.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/java/org/laokou/auth/AuthApp.java
@@ -21,7 +21,7 @@ import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.annotation.EnableWarmUp;
 import org.laokou.common.i18n.util.SslUtils;
-import org.laokou.common.nacos.annotation.EnableRouter;
+import org.laokou.common.nacos.annotation.EnablePrintRouter;
 import org.laokou.common.rpc.annotation.EnableRpc;
 import org.laokou.common.security.config.TransmittableThreadLocalSecurityContextHolderStrategy;
 import org.springframework.boot.WebApplicationType;
@@ -46,7 +46,7 @@ import java.security.NoSuchAlgorithmException;
  */
 @Slf4j
 @EnableRpc
-@EnableRouter
+@EnablePrintRouter
 @EnableWarmUp
 @EnableScheduling
 @EnableDiscoveryClient

--- a/laokou-service/laokou-distributed-id/laokou-distributed-id-infrastructure/src/main/java/org/laokou/distributed/id/config/NacosSnowflakeGenerator.java
+++ b/laokou-service/laokou-distributed-id/laokou-distributed-id-infrastructure/src/main/java/org/laokou/distributed/id/config/NacosSnowflakeGenerator.java
@@ -172,17 +172,31 @@ public class NacosSnowflakeGenerator implements SnowflakeGenerator {
 		}
 		this.currentIp = InetAddress.getLocalHost().getHostAddress();
 		this.currentPort = getServerPort();
-		// 获取所有实例列表
-		List<Instance> allInstances = namingService.getAllInstances(serviceId, groupName);
+
 		// 分配 datacenterId 和 machineId
-		allocateIds(allInstances);
-		// 注册当前实例及其元数据
-		registerMetadata();
-		// 订阅实例变更事件
-		namingService.subscribe(serviceId, groupName,
-				_ -> log.debug("NacosSnowflakeGenerator received instance change event."));
-		initialized.set(true);
-		log.info("NacosSnowflakeGenerator initialized with datacenterId: {}, machineId: {}", datacenterId, machineId);
+		int maxRetry = 10;
+		for (int attempt = 1; attempt <= maxRetry; attempt++) {
+			// 获取所有实例列表
+			List<Instance> allInstances = namingService.getAllInstances(serviceId, groupName);
+			allocateIds(allInstances);
+			// 注册当前实例及其元数据
+			if (tryRegisterMetadata()) {
+				// 判断是否冲突
+				if (!hasConflict()) {
+					log.info("NacosSnowflakeGenerator successfully registered with datacenterId: {}, machineId: {}",
+							datacenterId, machineId);
+					// 订阅实例变更事件
+					namingService.subscribe(serviceId, groupName,
+							_ -> log.debug("NacosSnowflakeGenerator received instance change event."));
+					initialized.set(true);
+					log.info("NacosSnowflakeGenerator initialized with datacenterId: {}, machineId: {}", datacenterId,
+							machineId);
+					return;
+				}
+				// 冲突则注销
+				unregisterMetadata();
+			}
+		}
 	}
 
 	@Override
@@ -333,6 +347,9 @@ public class NacosSnowflakeGenerator implements SnowflakeGenerator {
 	}
 
 	private void allocateIds(List<Instance> allInstances) {
+		long maxDatacenterId = this.maxDatacenterId + 1;
+		long maxMachineId = this.maxMachineId + 1;
+		long maxCombinedId = maxDatacenterId * maxMachineId;
 		Set<Long> usedIds = allInstances.stream()
 			.filter(instance -> !isCurrentInstance(instance))
 			.map(Instance::getMetadata)
@@ -342,41 +359,69 @@ public class NacosSnowflakeGenerator implements SnowflakeGenerator {
 				String datacenterIdStr = metadata.getOrDefault(DATACENTER_ID_KEY, "0");
 				long mi = Long.parseLong(machineIdStr);
 				long di = Long.parseLong(datacenterIdStr);
-				return mi * (maxMachineId + 1) + di;
+				return di * maxMachineId + mi;
 			})
 			.collect(Collectors.toSet());
 		// 分配新的 datacenterId 和 machineId
-		// mi=0,di=0,0
-		// m1=0,di=31,31
+		// di=0,mi=0,0
+		// di=0,mi=31,31
 		// ...
 		// ...
 		// ...
-		// mi=31,di=31,1023
-		long maxCombinedId = (maxDatacenterId + 1) * (maxMachineId + 1);
+		// di=31,mi=31,1023
+		// 0 ~ 1023【不包含1024】
 		long foundCombinedId = LongStream.range(0, maxCombinedId)
 			.filter(id -> !usedIds.contains(id))
 			.findFirst()
 			.orElseThrow(() -> new RuntimeException(
 					String.format("No available ID slot. All %d slots are in use.", maxCombinedId)));
-		this.datacenterId = foundCombinedId / (maxMachineId + 1);
-		this.machineId = foundCombinedId % (maxMachineId + 1);
+		this.datacenterId = foundCombinedId / maxMachineId;
+		this.machineId = foundCombinedId % maxMachineId;
 	}
 
-	private void registerMetadata() throws NacosException {
-		Map<String, String> metadata = Map.of(DATACENTER_ID_KEY, String.valueOf(this.datacenterId), MACHINE_ID_KEY,
-				String.valueOf(this.machineId), GRPC_PORT_KEY, String.valueOf(getGrpcServerPort()));
-		Instance instance = new Instance();
-		instance.setIp(currentIp);
-		instance.setPort(currentPort);
-		instance.setMetadata(metadata);
-		instance.setWeight(1.0);
-		instance.setHealthy(true);
-		instance.setEnabled(true);
-		instance.setClusterName(getClusterName());
-		// CP强一致性【永久实例】
-		instance.setEphemeral(false);
-		namingService.registerInstance(serviceId, groupName, instance);
-		log.info("Registered instance with metadata: {}", metadata);
+	private boolean tryRegisterMetadata() {
+		try {
+			Map<String, String> metadata = Map.of(DATACENTER_ID_KEY, String.valueOf(this.datacenterId), MACHINE_ID_KEY,
+					String.valueOf(this.machineId), GRPC_PORT_KEY, String.valueOf(getGrpcServerPort()));
+			Instance instance = new Instance();
+			instance.setIp(currentIp);
+			instance.setPort(currentPort);
+			instance.setMetadata(metadata);
+			instance.setWeight(1.0);
+			instance.setHealthy(true);
+			instance.setEnabled(true);
+			instance.setClusterName(getClusterName());
+			instance.setEphemeral(true);
+			namingService.registerInstance(serviceId, groupName, instance);
+			log.info("Registered instance with metadata: {}", metadata);
+			return true;
+		}
+		catch (Exception ex) {
+			log.error("Registered instance failed", ex);
+			return false;
+		}
+	}
+
+	private boolean hasConflict() throws NacosException {
+		List<Instance> instances = namingService.getAllInstances(serviceId, groupName);
+		long count = instances.stream()
+			.map(Instance::getMetadata)
+			.filter(MapUtils::isNotEmpty)
+			.filter(meta -> ObjectUtils.equals(String.valueOf(this.datacenterId),
+					meta.getOrDefault(DATACENTER_ID_KEY, "0"))
+					&& ObjectUtils.equals(String.valueOf(this.machineId), meta.getOrDefault(MACHINE_ID_KEY, "0")))
+			.count();
+		return count > 1;
+	}
+
+	private void unregisterMetadata() {
+		try {
+			namingService.deregisterInstance(serviceId, groupName, currentIp, currentPort);
+			log.info("Deregistered instance with IP: {}, Port: {}", currentIp, currentPort);
+		}
+		catch (Exception ex) {
+			log.error("Deregistered instance failed", ex);
+		}
 	}
 
 	private boolean isCurrentInstance(Instance instance) {

--- a/laokou-service/laokou-generator/laokou-generator-start/src/main/java/org/laokou/generator/GeneratorApp.java
+++ b/laokou-service/laokou-generator/laokou-generator-start/src/main/java/org/laokou/generator/GeneratorApp.java
@@ -20,7 +20,7 @@ package org.laokou.generator;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.annotation.EnableWarmUp;
 import org.laokou.common.i18n.util.SslUtils;
-import org.laokou.common.nacos.annotation.EnableRouter;
+import org.laokou.common.nacos.annotation.EnablePrintRouter;
 import org.laokou.common.security.annotation.EnableSecurity;
 import org.laokou.common.security.config.TransmittableThreadLocalSecurityContextHolderStrategy;
 import org.mybatis.spring.annotation.MapperScan;
@@ -44,7 +44,7 @@ import java.security.NoSuchAlgorithmException;
  */
 @Slf4j
 @EnableWarmUp
-@EnableRouter
+@EnablePrintRouter
 @EnableSecurity
 @EnableScheduling
 @EnableDiscoveryClient

--- a/laokou-service/laokou-iot/laokou-iot-start/src/main/java/org/laokou/iot/IotApp.java
+++ b/laokou-service/laokou-iot/laokou-iot-start/src/main/java/org/laokou/iot/IotApp.java
@@ -20,7 +20,7 @@ package org.laokou.iot;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.annotation.EnableWarmUp;
 import org.laokou.common.i18n.util.SslUtils;
-import org.laokou.common.nacos.annotation.EnableRouter;
+import org.laokou.common.nacos.annotation.EnablePrintRouter;
 import org.laokou.common.security.annotation.EnableSecurity;
 import org.laokou.common.websocket.annotation.EnableWebSocketServer;
 import org.mybatis.spring.annotation.MapperScan;
@@ -47,7 +47,7 @@ import java.security.NoSuchAlgorithmException;
 @Slf4j
 @EnablePulsar
 @EnableWarmUp
-@EnableRouter
+@EnablePrintRouter
 @EnableSecurity
 @EnableScheduling
 @EnableWebSocketServer


### PR DESCRIPTION
## Summary by Sourcery

提高基于 Nacos 的 Snowflake ID 注册健壮性，更新 Spring Boot 版本说明，并在各服务中统一重命名启用路由的注解。

增强内容：
- 在 Nacos 中分配和注册 Snowflake 机房（datacenter）和机器（machine）ID 时，增加重试、冲突检测以及注销（deregistration）逻辑。
- 调整 Snowflake ID 分配顺序和边界，以确保 ID 分配的一致性和无冲突。
- 将启用路由的注解重命名为 `EnablePrintRouter`，并应用于 admin、auth、generator 和 IoT 等服务的入口类。

文档：
- 将 README 中的 Spring Boot 版本说明从 4.0.2 更新为 4.0.3，以反映当前技术栈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Nacos-based Snowflake ID registration robustness, update Spring Boot version references, and rename the router enabling annotation across services.

Enhancements:
- Add retry, conflict-detection, and deregistration logic when allocating and registering Snowflake datacenter and machine IDs in Nacos.
- Adjust Snowflake ID allocation ordering and bounds to ensure consistent, conflict-free ID assignments.
- Rename the router-enabling annotation to EnablePrintRouter and apply it to admin, auth, generator, and IoT service entrypoints.

Documentation:
- Update README Spring Boot version references from 4.0.2 to 4.0.3 to reflect the current stack.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ID allocation with retry mechanism and conflict detection capabilities.
  * Added GraalVM and Maven integration badges.

* **Bug Fixes**
  * Improved authority permission handling in user details.

* **Documentation**
  * Updated project documentation to reflect Spring Boot 4.0.3 upgrade (from 4.0.2).
  * Updated component naming references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->