### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosBalancer.java
+++ b/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosBalancer.java
@@ -38,6 +38,7 @@ import com.alibaba.cloud.nacos.NacosServiceInstance;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.client.naming.core.Balancer;
 import org.laokou.common.core.util.MapUtils;
+import org.laokou.common.i18n.util.ObjectUtils;
 import org.springframework.cloud.client.ServiceInstance;
 
 import java.util.List;
@@ -79,7 +80,7 @@ public class NacosBalancer extends Balancer {
 			Instance instance = new Instance();
 			instance.setIp(serviceInstance.getHost());
 			instance.setPort(serviceInstance.getPort());
-			instance.setWeight(Double.parseDouble(metadata.get("nacos.weight")));
+			instance.setWeight(Double.parseDouble(ObjectUtils.requireNotNull(metadata).get("nacos.weight")));
 			instance.setHealthy(Boolean.parseBoolean(metadata.get("nacos.healthy")));
 			instanceMap.put(instance, serviceInstance);
 			return instance;
@@ -100,7 +101,7 @@ public class NacosBalancer extends Balancer {
 	 */
 	private static void convertIPv4ToIPv6(NacosServiceInstance instance) {
 		if (Pattern.matches(IPV4_REGEX, instance.getHost())) {
-			String ip = instance.getMetadata().get(IPV6_KEY);
+			String ip = ObjectUtils.requireNotNull(instance.getMetadata()).get(IPV6_KEY);
 			if (StringUtils.isNotEmpty(ip)) {
 				instance.setHost(ip);
 			}

--- a/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -70,6 +70,7 @@ import org.springframework.cloud.client.loadbalancer.RequestDataContext;
 import org.springframework.cloud.client.loadbalancer.Response;
 import org.springframework.cloud.loadbalancer.core.NoopServiceInstanceListSupplier;
 import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.RoundRobinLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
 import org.springframework.http.HttpHeaders;
 import reactor.core.publisher.Mono;
@@ -79,16 +80,19 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * nacos路由负载均衡.
- * {@link com.alibaba.cloud.nacos.loadbalancer.NacosLoadBalancerClientConfiguration}
- * {@link org.springframework.cloud.loadbalancer.core.RoundRobinLoadBalancer}
+ * nacos路由负载均衡. {@link NacosLoadBalancerClientConfiguration}
+ * {@link RoundRobinLoadBalancer}
  *
  * @author XuDaojie
  * @author laokou
  * @since 2021.1
  */
 @Slf4j
-public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
+public record NacosLoadBalancer(
+		ObjectProvider<@NonNull ServiceInstanceListSupplier> serviceInstanceListSupplierProvider, String serviceId,
+		NacosDiscoveryProperties nacosDiscoveryProperties, InetIPv6Utils inetIPv6Utils,
+		List<ServiceInstanceFilter> serviceInstanceFilters,
+		Map<String, LoadBalancerAlgorithm> loadBalancerAlgorithmMap) implements ReactorServiceInstanceLoadBalancer {
 
 	/**
 	 * Storage local valid IPv6 address, it's a flag whether local machine support IPv6
@@ -96,37 +100,13 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	 */
 	static String ipv6;
 
-	private final String serviceId;
-
-	private final ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider;
-
-	private final NacosDiscoveryProperties nacosDiscoveryProperties;
-
-	private final InetIPv6Utils inetIPv6Utils;
-
-	private final List<ServiceInstanceFilter> serviceInstanceFilters;
-
-	private final Map<String, LoadBalancerAlgorithm> loadBalancerAlgorithmMap;
-
-	public NacosLoadBalancer(ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider,
-			String serviceId, NacosDiscoveryProperties nacosDiscoveryProperties, InetIPv6Utils inetIPv6Utils,
-			List<ServiceInstanceFilter> serviceInstanceFilters,
-			Map<String, LoadBalancerAlgorithm> loadBalancerAlgorithmMap) {
-		this.serviceId = serviceId;
-		this.inetIPv6Utils = inetIPv6Utils;
-		this.serviceInstanceListSupplierProvider = serviceInstanceListSupplierProvider;
-		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
-		this.serviceInstanceFilters = serviceInstanceFilters;
-		this.loadBalancerAlgorithmMap = loadBalancerAlgorithmMap;
-	}
-
 	/**
 	 * 初始化.
 	 */
 	@PostConstruct
 	public void init() {
 		String ip = nacosDiscoveryProperties.getIp();
-		if (com.alibaba.cloud.commons.lang.StringUtils.isNotEmpty(ip)) {
+		if (StringUtils.isNotEmpty(ip)) {
 			ipv6 = RegexUtils.ipv4Regex(ip) ? nacosDiscoveryProperties.getMetadata().get("IPv6") : ip;
 		}
 		else {
@@ -144,7 +124,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 			List<ServiceInstance> ipv6InstanceList = new ArrayList<>();
 			for (ServiceInstance instance : instances) {
 				if (RegexUtils.ipv4Regex(instance.getHost())) {
-					if (com.alibaba.cloud.commons.lang.StringUtils.isNotEmpty(instance.getMetadata().get("IPv6"))) {
+					if (StringUtils.isNotEmpty(instance.getMetadata().get("IPv6"))) {
 						ipv6InstanceList.add(instance);
 					}
 				}
@@ -170,7 +150,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	 */
 	@NonNull
 	@Override
-	public Mono<Response<ServiceInstance>> choose(@NonNull Request request) {
+	public Mono<@NonNull Response<@NonNull ServiceInstance>> choose(@NonNull Request request) {
 		return serviceInstanceListSupplierProvider.getIfAvailable(NoopServiceInstanceListSupplier::new)
 			.get(request)
 			.next()
@@ -183,7 +163,8 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	 * @param request 请求
 	 * @return 服务实例响应体
 	 */
-	private Response<ServiceInstance> getInstanceResponse(List<ServiceInstance> serviceInstances, Request<?> request) {
+	private Response<@NonNull ServiceInstance> getInstanceResponse(List<ServiceInstance> serviceInstances,
+			Request<?> request) {
 		if (serviceInstances.isEmpty()) {
 			log.warn("No servers available for service: {}", this.serviceId);
 			return new EmptyResponse();
@@ -209,7 +190,8 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	 * @param serviceInstances 服务实例
 	 * @return 响应结果
 	 */
-	private Response<ServiceInstance> getInstanceResponse(Request<?> request, List<ServiceInstance> serviceInstances) {
+	private Response<@NonNull ServiceInstance> getInstanceResponse(Request<?> request,
+			List<ServiceInstance> serviceInstances) {
 		if (serviceInstances.isEmpty()) {
 			log.error("No servers available for service: {}", this.serviceId);
 			return new EmptyResponse();

--- a/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
+++ b/laokou-common/laokou-common-nacos/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
@@ -35,6 +35,7 @@ package com.alibaba.cloud.nacos.loadbalancer;
 
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.util.InetIPv6Utils;
+import org.jspecify.annotations.NonNull;
 import org.laokou.common.core.util.MapUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -78,7 +79,7 @@ public class NacosLoadBalancerClientConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean({ LoadBalancerClientFactory.class, NacosDiscoveryProperties.class, InetIPv6Utils.class })
-	public ReactorLoadBalancer<ServiceInstance> nacosLoadBalancer(Environment environment,
+	public ReactorLoadBalancer<@NonNull ServiceInstance> nacosLoadBalancer(Environment environment,
 			LoadBalancerClientFactory loadBalancerClientFactory, NacosDiscoveryProperties nacosDiscoveryProperties,
 			InetIPv6Utils inetIPv6Utils, List<ServiceInstanceFilter> serviceInstanceFilters,
 			List<LoadBalancerAlgorithm> loadBalancerAlgorithms) {

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/command/query/MenuTreeListQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/command/query/MenuTreeListQryExe.java
@@ -19,7 +19,7 @@ package org.laokou.admin.menu.command.query;
 
 import org.laokou.admin.menu.dto.MenuTreeListQry;
 import org.laokou.admin.menu.dto.clientobject.MenuTreeCO;
-import org.laokou.admin.menu.service.builder.MenuTreeBuilder;
+import org.laokou.admin.menu.service.MenuTree;
 import org.laokou.admin.menu.model.enums.MenuTreeType;
 import org.laokou.common.context.util.UserUtils;
 import org.laokou.common.i18n.dto.Result;
@@ -37,22 +37,22 @@ import java.util.List;
 @Component
 public class MenuTreeListQryExe {
 
-	private final MenuTreeBuilder userMenuTreeBuilder;
+	private final MenuTree userMenuTree;
 
-	private final MenuTreeBuilder systemMenuTreeBuilder;
+	private final MenuTree systemMenuTree;
 
-	public MenuTreeListQryExe(@Qualifier("userMenuTreeBuilder") MenuTreeBuilder userMenuTreeBuilder,
-			@Qualifier("systemMenuTreeBuilder") MenuTreeBuilder systemMenuTreeBuilder) {
-		this.userMenuTreeBuilder = userMenuTreeBuilder;
-		this.systemMenuTreeBuilder = systemMenuTreeBuilder;
+	public MenuTreeListQryExe(@Qualifier("userMenuTreeBuilder") MenuTree userMenuTree,
+			@Qualifier("systemMenuTreeBuilder") MenuTree systemMenuTree) {
+		this.userMenuTree = userMenuTree;
+		this.systemMenuTree = systemMenuTree;
 	}
 
 	public Result<List<MenuTreeCO>> execute(MenuTreeListQry qry) {
 		MenuTreeType menuMenuTreeTypeEnum = MenuTreeType.getByCode(qry.getCode());
 		Assert.notNull(menuMenuTreeTypeEnum, "菜单类型不存在");
 		return switch (menuMenuTreeTypeEnum) {
-			case USER -> Result.ok(userMenuTreeBuilder.buildMenuTree(qry, UserUtils.getUserId()).getChildren());
-			case SYSTEM -> Result.ok(systemMenuTreeBuilder.buildMenuTree(qry, UserUtils.getUserId()).getChildren());
+			case USER -> Result.ok(userMenuTree.build(qry, UserUtils.getUserId()).getChildren());
+			case SYSTEM -> Result.ok(systemMenuTree.build(qry, UserUtils.getUserId()).getChildren());
 		};
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/MenuTree.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/MenuTree.java
@@ -15,32 +15,16 @@
  *
  */
 
-package org.laokou.admin.menu.service.builder;
+package org.laokou.admin.menu.service;
 
-import lombok.RequiredArgsConstructor;
-import org.laokou.admin.menu.convertor.MenuConvertor;
 import org.laokou.admin.menu.dto.MenuTreeListQry;
 import org.laokou.admin.menu.dto.clientobject.MenuTreeCO;
-import org.laokou.admin.menu.gatewayimpl.database.MenuMapper;
-import org.laokou.admin.menu.gatewayimpl.database.dataobject.MenuDO;
-import org.laokou.common.core.util.TreeUtils;
-import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 /**
  * @author laokou
  */
-@Component("systemMenuTreeBuilder")
-@RequiredArgsConstructor
-public class SystemMenuTreeBuilder implements MenuTreeBuilder {
+public interface MenuTree {
 
-	private final MenuMapper menuMapper;
-
-	@Override
-	public MenuTreeCO buildMenuTree(MenuTreeListQry qry, Long userId) {
-		List<MenuDO> list = menuMapper.selectObjectList(qry);
-		return TreeUtils.buildTreeNode(MenuConvertor.toClientObjs(list), MenuTreeCO.class);
-	}
+	MenuTreeCO build(MenuTreeListQry qry, Long userId);
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/SystemMenuTree.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/SystemMenuTree.java
@@ -15,16 +15,32 @@
  *
  */
 
-package org.laokou.admin.menu.service.builder;
+package org.laokou.admin.menu.service;
 
+import lombok.RequiredArgsConstructor;
+import org.laokou.admin.menu.convertor.MenuConvertor;
 import org.laokou.admin.menu.dto.MenuTreeListQry;
 import org.laokou.admin.menu.dto.clientobject.MenuTreeCO;
+import org.laokou.admin.menu.gatewayimpl.database.MenuMapper;
+import org.laokou.admin.menu.gatewayimpl.database.dataobject.MenuDO;
+import org.laokou.common.core.util.TreeUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 /**
  * @author laokou
  */
-public interface MenuTreeBuilder {
+@Component("systemMenuTreeBuilder")
+@RequiredArgsConstructor
+public class SystemMenuTree implements MenuTree {
 
-	MenuTreeCO buildMenuTree(MenuTreeListQry qry, Long userId);
+	private final MenuMapper menuMapper;
+
+	@Override
+	public MenuTreeCO build(MenuTreeListQry qry, Long userId) {
+		List<MenuDO> list = menuMapper.selectObjectList(qry);
+		return TreeUtils.buildTreeNode(MenuConvertor.toClientObjs(list), MenuTreeCO.class);
+	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/UserMenuTree.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/UserMenuTree.java
@@ -15,7 +15,7 @@
  *
  */
 
-package org.laokou.admin.menu.service.builder;
+package org.laokou.admin.menu.service;
 
 import lombok.RequiredArgsConstructor;
 import org.laokou.admin.menu.convertor.MenuConvertor;
@@ -26,9 +26,8 @@ import org.laokou.admin.menu.gatewayimpl.database.dataobject.MenuDO;
 import org.laokou.common.context.util.UserUtils;
 import org.laokou.common.core.util.TreeUtils;
 import org.laokou.common.data.cache.annotation.DistributedCache;
-import org.laokou.common.data.cache.constant.NameConstants;
 import org.laokou.common.data.cache.aspectj.OperateType;
-import org.laokou.common.fory.config.ForyFactory;
+import org.laokou.common.data.cache.constant.NameConstants;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -38,17 +37,13 @@ import java.util.List;
  */
 @Component("userMenuTreeBuilder")
 @RequiredArgsConstructor
-public class UserMenuTreeBuilder implements MenuTreeBuilder {
+public class UserMenuTree implements MenuTree {
 
 	private final MenuMapper menuMapper;
 
-	static {
-		ForyFactory.INSTANCE.register(org.laokou.admin.menu.dto.clientobject.MenuTreeCO.class);
-	}
-
 	@Override
 	@DistributedCache(name = NameConstants.USER_MENU, key = "#userId", operateType = OperateType.GET)
-	public MenuTreeCO buildMenuTree(MenuTreeListQry qry, Long userId) {
+	public MenuTreeCO build(MenuTreeListQry qry, Long userId) {
 		List<MenuDO> list;
 		if (UserUtils.isSuperAdmin()) {
 			list = menuMapper.selectAllMenuList();

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/MenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/MenuParamValidator.java
@@ -36,14 +36,14 @@ final class MenuParamValidator {
 
 	static ParamValidator.Validate validatePermission(MenuA menuA, MenuMapper menuMapper) {
 		String permission = menuA.getMenuE().getPermission();
-		if (menuA.isMenu() && StringExtUtils.isEmpty(permission)) {
+		if (menuA.isButton() && StringExtUtils.isEmpty(permission)) {
 			return org.laokou.common.i18n.util.ParamValidator.invalidate("菜单权限标识不能为空");
 		}
-		if (menuA.isMenu() && menuA.isSave() && menuMapper
+		if (menuA.isButton() && menuA.isSave() && menuMapper
 			.selectCount(Wrappers.lambdaQuery(MenuDO.class).eq(MenuDO::getPermission, permission)) > 0) {
 			return org.laokou.common.i18n.util.ParamValidator.invalidate("菜单权限标识已存在");
 		}
-		if (menuA.isMenu() && menuA.isModify()
+		if (menuA.isButton() && menuA.isModify()
 				&& menuMapper.selectCount(Wrappers.lambdaQuery(MenuDO.class)
 					.eq(MenuDO::getPermission, permission)
 					.ne(MenuDO::getId, menuA.getId())) > 0) {
@@ -99,7 +99,7 @@ final class MenuParamValidator {
 		if (menuA.isMenu() && ObjectUtils.isNull(status)) {
 			return ParamValidator.invalidate("菜单状态不能为空");
 		}
-		if (menuA.statusNotExist()) {
+		if (menuA.isMenu() && menuA.statusNotExist()) {
 			return ParamValidator.invalidate("菜单状态不存在");
 		}
 		return ParamValidator.validate();

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/menu/model/MenuA.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/menu/model/MenuA.java
@@ -106,6 +106,10 @@ public class MenuA extends AggregateRoot implements ValidateName {
 		return ObjectUtils.isNotNull(menuE.getType()) && menuE.getType() == MenuType.MENU.getCode();
 	}
 
+	public boolean isButton() {
+		return ObjectUtils.isNotNull(menuE.getType()) && menuE.getType() == MenuType.BUTTON.getCode();
+	}
+
 	public boolean statusNotExist() {
 		return !List.of(MenuStatus.DISABLE.getCode(), MenuStatus.ENABLE.getCode()).contains(this.menuE.getStatus());
 	}

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/common/config/AdminConfig.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/common/config/AdminConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.admin.common.config;
+
+import org.laokou.common.fory.config.ForyFactory;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author laokou
+ */
+@Configuration
+public class AdminConfig {
+
+	static {
+		ForyFactory.INSTANCE.register(org.laokou.admin.menu.dto.clientobject.MenuTreeCO.class);
+		ForyFactory.INSTANCE.register(org.laokou.admin.menu.dto.clientobject.MenuCO.class);
+	}
+
+}


### PR DESCRIPTION
## Summary by Sourcery

在收紧校验逻辑和空值安全性的同时，重构 Nacos 负载均衡器和后台菜单树组件。

**Bug 修复：**
- 修正菜单权限校验逻辑，使其仅应用于“按钮类型”菜单，并将状态存在性检查与“菜单类型”条目明确绑定。

**增强改进：**
- 将 `NacosLoadBalancer` 重构为 Java record，引入更完善的空值安全注解，并简化 `String` 工具方法的使用。
- 统一菜单树抽象，将 `MenuTreeBuilder` 重命名为 `MenuTree`，并更新用户/系统菜单树的实现及其调用方式。
- 引入集中式的 `AdminConfig`，用于在 `ForyFactory` 中注册与菜单相关的 DTO，而不再在各个构建器中单独注册。
- 加强 `NacosBalancer` 对 IP 和权重的处理，强制使用非空的元数据访问，并引入更安全的 IPv6 主机转换逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Nacos load balancer and admin menu tree components while tightening validation and null-safety.

Bug Fixes:
- Correct menu permission validation to apply only to button-type menus and tie status existence checks explicitly to menu-type entries.

Enhancements:
- Refactor NacosLoadBalancer into a Java record with improved null-safety annotations and simplified String utility usage.
- Unify the menu tree abstraction by renaming MenuTreeBuilder to MenuTree and updating user/system menu tree implementations and their usage.
- Introduce a central AdminConfig to register menu-related DTOs with ForyFactory instead of registering them in individual builders.
- Strengthen NacosBalancer IP and weight handling by enforcing non-null metadata access and safer IPv6 host conversion logic.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Simplified menu service API with streamlined method names and improved type structures.
  * Enhanced load balancer with immutable design patterns and strengthened null-safety checks.
  * Updated menu validation logic to support button-type differentiation.

* **Bug Fixes**
  * Improved null-safety in metadata access and IPv6 address handling within load balancing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->