### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/util/ParamValidator.java
+++ b/laokou-common/laokou-common-i18n/src/main/java/org/laokou/common/i18n/util/ParamValidator.java
@@ -32,10 +32,6 @@ public final class ParamValidator {
 	private ParamValidator() {
 	}
 
-	public static void validate(Validate... validates) {
-		validate("System", validates);
-	}
-
 	public static void validate(String name, Validate... validates) {
 		String validateString = StringExtUtils.collectionToDelimitedString(validates(validates), StringConstants.DROP);
 		if (StringExtUtils.isNotEmpty(validateString)) {

--- a/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/ParamValidatorTest.java
+++ b/laokou-common/laokou-common-i18n/src/test/java/org/laokou/common/i18n/ParamValidatorTest.java
@@ -34,14 +34,14 @@ class ParamValidatorTest {
 		// Test with all valid validations (should not throw exception)
 		ParamValidator.Validate valid1 = ParamValidator.validate();
 		ParamValidator.Validate valid2 = ParamValidator.validate();
-		Assertions.assertThatCode(() -> ParamValidator.validate(valid1, valid2)).doesNotThrowAnyException();
+		Assertions.assertThatCode(() -> ParamValidator.validate("System", valid1, valid2)).doesNotThrowAnyException();
 	}
 
 	@Test
 	void test_validate_withSingleError() {
 		// Test with single validation error (should throw ParamException)
 		ParamValidator.Validate invalid = ParamValidator.invalidate("用户名不能为空");
-		Assertions.assertThatThrownBy(() -> ParamValidator.validate(invalid))
+		Assertions.assertThatThrownBy(() -> ParamValidator.validate("System", invalid))
 			.isInstanceOf(ParamException.class)
 			.hasMessageContaining("用户名不能为空");
 	}
@@ -51,7 +51,7 @@ class ParamValidatorTest {
 		// Test with multiple validation errors
 		ParamValidator.Validate invalid1 = ParamValidator.invalidate("用户名不能为空");
 		ParamValidator.Validate invalid2 = ParamValidator.invalidate("密码不能为空");
-		Assertions.assertThatThrownBy(() -> ParamValidator.validate(invalid1, invalid2))
+		Assertions.assertThatThrownBy(() -> ParamValidator.validate("System", invalid1, invalid2))
 			.isInstanceOf(ParamException.class);
 	}
 
@@ -60,7 +60,7 @@ class ParamValidatorTest {
 		// Test with mixed valid and invalid validations
 		ParamValidator.Validate valid = ParamValidator.validate();
 		ParamValidator.Validate invalid = ParamValidator.invalidate("邮箱格式不正确");
-		Assertions.assertThatThrownBy(() -> ParamValidator.validate(valid, invalid))
+		Assertions.assertThatThrownBy(() -> ParamValidator.validate("System", valid, invalid))
 			.isInstanceOf(ParamException.class)
 			.hasMessageContaining("邮箱格式不正确");
 	}
@@ -148,14 +148,14 @@ class ParamValidatorTest {
 	void test_validate_withNullErrorMessage() {
 		// Test with null error message (should be treated as empty)
 		ParamValidator.Validate invalid = ParamValidator.invalidate(null);
-		Assertions.assertThatCode(() -> ParamValidator.validate(invalid)).doesNotThrowAnyException();
+		Assertions.assertThatCode(() -> ParamValidator.validate("System", invalid)).doesNotThrowAnyException();
 	}
 
 	@Test
 	void test_validate_withEmptyErrorMessage() {
 		// Test with empty error message (should be treated as valid)
 		ParamValidator.Validate invalid = ParamValidator.invalidate("");
-		Assertions.assertThatCode(() -> ParamValidator.validate(invalid)).doesNotThrowAnyException();
+		Assertions.assertThatCode(() -> ParamValidator.validate("System", invalid)).doesNotThrowAnyException();
 	}
 
 	@Test
@@ -171,7 +171,7 @@ class ParamValidatorTest {
 		// Test that ParamException has correct error code
 		ParamValidator.Validate invalid = ParamValidator.invalidate("测试错误");
 		try {
-			ParamValidator.validate(invalid);
+			ParamValidator.validate("System", invalid);
 		}
 		catch (ParamException ex) {
 			Assertions.assertThat(ex.getCode()).isEqualTo("P_System_ValidateFailed");
@@ -187,7 +187,8 @@ class ParamValidatorTest {
 		ParamValidator.Validate invalid2 = ParamValidator.invalidate("密码强度不够");
 		ParamValidator.Validate invalid3 = ParamValidator.invalidate("邮箱已被注册");
 
-		Assertions.assertThatThrownBy(() -> ParamValidator.validate(valid1, invalid1, valid2, invalid2, invalid3))
+		Assertions
+			.assertThatThrownBy(() -> ParamValidator.validate("System", valid1, invalid1, valid2, invalid2, invalid3))
 			.isInstanceOf(ParamException.class);
 
 		Set<String> errors = ParamValidator.validates(valid1, invalid1, valid2, invalid2, invalid3);
@@ -199,7 +200,7 @@ class ParamValidatorTest {
 		// Test with long error message
 		String longMessage = "这是一个非常长的错误消息，用于测试系统是否能够正确处理较长的验证错误信息，包括各种特殊字符和标点符号！@#￥%……&*（）";
 		ParamValidator.Validate invalid = ParamValidator.invalidate(longMessage);
-		Assertions.assertThatThrownBy(() -> ParamValidator.validate(invalid))
+		Assertions.assertThatThrownBy(() -> ParamValidator.validate("System", invalid))
 			.isInstanceOf(ParamException.class)
 			.hasMessageContaining(longMessage);
 	}

--- a/laokou-common/laokou-common-secret/src/main/java/org/laokou/common/secret/aspectj/ApiSecretAspectj.java
+++ b/laokou-common/laokou-common-secret/src/main/java/org/laokou/common/secret/aspectj/ApiSecretAspectj.java
@@ -85,7 +85,7 @@ public class ApiSecretAspectj {
 		String appKey = request.getHeader(APP_KEY);
 		String appSecret = request.getHeader(APP_SECRET);
 		Map<String, String> parameterMap = getParameterMap(request);
-		ParamValidator.validate(ApiSecretParamValidator.validateAppKey(appKey),
+		ParamValidator.validate("System", ApiSecretParamValidator.validateAppKey(appKey),
 				ApiSecretParamValidator.validateAppSecret(appSecret), ApiSecretParamValidator.validateNonce(nonce),
 				ApiSecretParamValidator.validateTimestamp(timestamp),
 				ApiSecretParamValidator.validateSign(appKey, appSecret, sign, nonce, timestamp, parameterMap));

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/DeptModifyCmdExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/DeptModifyCmdExe.java
@@ -18,13 +18,14 @@
 package org.laokou.admin.dept.command;
 
 import lombok.RequiredArgsConstructor;
+import org.laokou.admin.dept.ability.DeptDomainService;
+import org.laokou.admin.dept.convertor.DeptConvertor;
 import org.laokou.admin.dept.dto.DeptModifyCmd;
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.factory.DeptDomainFactory;
+import org.laokou.admin.dept.model.DeptA;
 import org.laokou.common.domain.annotation.CommandLog;
 import org.laokou.common.mybatisplus.util.TransactionalUtils;
 import org.springframework.stereotype.Component;
-import org.laokou.admin.dept.convertor.DeptConvertor;
-import org.laokou.admin.dept.ability.DeptDomainService;
 
 /**
  * 修改部门命令执行器.
@@ -41,10 +42,10 @@ public class DeptModifyCmdExe {
 
 	@CommandLog
 	public void executeVoid(DeptModifyCmd cmd) {
-		DeptE deptE = DeptConvertor.toEntity(cmd.getCo(), false);
+		DeptA deptA = DeptDomainFactory.createDeptA().create(DeptConvertor.toEntity(cmd.getCo()));
 		// 校验参数
-		deptE.checkDeptParam();
-		transactionalUtils.executeInTransaction(() -> deptDomainService.updateDept(deptE));
+		deptA.checkDeptParam();
+		transactionalUtils.executeInTransaction(() -> deptDomainService.updateDept(deptA));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/DeptSaveCmdExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/DeptSaveCmdExe.java
@@ -21,7 +21,8 @@ import lombok.RequiredArgsConstructor;
 import org.laokou.admin.dept.ability.DeptDomainService;
 import org.laokou.admin.dept.convertor.DeptConvertor;
 import org.laokou.admin.dept.dto.DeptSaveCmd;
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.factory.DeptDomainFactory;
+import org.laokou.admin.dept.model.DeptA;
 import org.laokou.common.domain.annotation.CommandLog;
 import org.laokou.common.mybatisplus.util.TransactionalUtils;
 import org.springframework.stereotype.Component;
@@ -41,10 +42,10 @@ public class DeptSaveCmdExe {
 
 	@CommandLog
 	public void executeVoid(DeptSaveCmd cmd) {
-		DeptE deptE = DeptConvertor.toEntity(cmd.getCo(), true);
+		DeptA deptA = DeptDomainFactory.createDeptA().create(DeptConvertor.toEntity(cmd.getCo()));
 		// 校验参数
-		deptE.checkDeptParam();
-		transactionalUtils.executeInTransaction(() -> deptDomainService.createDept(deptE));
+		deptA.checkDeptParam();
+		transactionalUtils.executeInTransaction(() -> deptDomainService.createDept(deptA));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/validator/DeptParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/validator/DeptParamValidator.java
@@ -17,7 +17,7 @@
 
 package org.laokou.admin.dept.service.validator;
 
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.model.DeptA;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.laokou.common.i18n.util.StringExtUtils;
@@ -30,16 +30,16 @@ final class DeptParamValidator {
 	private DeptParamValidator() {
 	}
 
-	public static ParamValidator.Validate validateParentId(DeptE deptE) {
-		Long pid = deptE.getPid();
+	public static ParamValidator.Validate validateParentId(DeptA deptA) {
+		Long pid = deptA.getDeptE().getPid();
 		if (ObjectUtils.isNull(pid)) {
 			return ParamValidator.invalidate("部门父级ID不能为空");
 		}
 		return ParamValidator.validate();
 	}
 
-	public static ParamValidator.Validate validateSort(DeptE deptE) {
-		Integer sort = deptE.getSort();
+	public static ParamValidator.Validate validateSort(DeptA deptA) {
+		Integer sort = deptA.getDeptE().getSort();
 		if (ObjectUtils.isNull(sort)) {
 			return ParamValidator.invalidate("部门排序不能为空");
 		}
@@ -49,16 +49,16 @@ final class DeptParamValidator {
 		return ParamValidator.validate();
 	}
 
-	public static ParamValidator.Validate validateId(DeptE deptE) {
-		Long id = deptE.getId();
-		if (ObjectUtils.isNull(id)) {
+	public static ParamValidator.Validate validateId(DeptA deptA) {
+		Long id = deptA.getDeptE().getId();
+		if (deptA.isModify() && ObjectUtils.isNull(id)) {
 			return ParamValidator.invalidate("部门ID不能为空");
 		}
 		return ParamValidator.validate();
 	}
 
-	public static ParamValidator.Validate validateName(DeptE deptE) {
-		String name = deptE.getName();
+	public static ParamValidator.Validate validateName(DeptA deptA) {
+		String name = deptA.getDeptE().getName();
 		if (StringExtUtils.isEmpty(name)) {
 			return ParamValidator.invalidate("部门名称不能为空");
 		}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/validator/ModifyDeptParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/validator/ModifyDeptParamValidator.java
@@ -17,8 +17,8 @@
 
 package org.laokou.admin.dept.service.validator;
 
-import org.laokou.admin.dept.model.DeptE;
-import org.laokou.admin.dept.model.DeptParamValidator;
+import org.laokou.admin.dept.model.DeptA;
+import org.laokou.admin.dept.model.validator.DeptParamValidator;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.springframework.stereotype.Component;
 
@@ -29,16 +29,16 @@ import org.springframework.stereotype.Component;
 public class ModifyDeptParamValidator implements DeptParamValidator {
 
 	@Override
-	public void validateDept(DeptE deptE) {
-		ParamValidator.validate(
+	public void validateDept(DeptA deptA) {
+		ParamValidator.validate(deptA.getValidateName(),
 				// 校验ID
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateId(deptE),
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateId(deptA),
 				// 校验父级ID
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateParentId(deptE),
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateParentId(deptA),
 				// 校验名称
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateName(deptE),
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateName(deptA),
 				// 校验排序
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateSort(deptE));
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateSort(deptA));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/validator/SaveDeptParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/service/validator/SaveDeptParamValidator.java
@@ -17,8 +17,8 @@
 
 package org.laokou.admin.dept.service.validator;
 
-import org.laokou.admin.dept.model.DeptE;
-import org.laokou.admin.dept.model.DeptParamValidator;
+import org.laokou.admin.dept.model.DeptA;
+import org.laokou.admin.dept.model.validator.DeptParamValidator;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.springframework.stereotype.Component;
 
@@ -29,14 +29,14 @@ import org.springframework.stereotype.Component;
 public class SaveDeptParamValidator implements DeptParamValidator {
 
 	@Override
-	public void validateDept(DeptE deptE) {
-		ParamValidator.validate(
+	public void validateDept(DeptA deptA) {
+		ParamValidator.validate(deptA.getValidateName(),
 				// 校验父级ID
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateParentId(deptE),
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateParentId(deptA),
 				// 校验名称
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateName(deptE),
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateName(deptA),
 				// 校验排序
-				org.laokou.admin.dept.service.validator.DeptParamValidator.validateSort(deptE));
+				org.laokou.admin.dept.service.validator.DeptParamValidator.validateSort(deptA));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/ModifyMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/ModifyMenuParamValidator.java
@@ -35,7 +35,7 @@ public class ModifyMenuParamValidator implements MenuParamValidator {
 
 	@Override
 	public void validateMenu(MenuA menuA) {
-		ParamValidator.validate(
+		ParamValidator.validate(menuA.getValidateName(),
 				// 校验ID
 				org.laokou.admin.menu.service.validator.MenuParamValidator.validateId(menuA),
 				// 校验父级ID

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/SaveMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/SaveMenuParamValidator.java
@@ -35,7 +35,7 @@ public class SaveMenuParamValidator implements MenuParamValidator {
 
 	@Override
 	public void validateMenu(MenuA menuA) {
-		ParamValidator.validate(
+		ParamValidator.validate(menuA.getValidateName(),
 				// 校验父级ID
 				org.laokou.admin.menu.service.validator.MenuParamValidator.validateParentId(menuA),
 				// 校验类型

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/ModifyRoleAuthorityParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/ModifyRoleAuthorityParamValidator.java
@@ -32,7 +32,7 @@ public class ModifyRoleAuthorityParamValidator implements RoleParamValidator {
 
 	@Override
 	public void validateRole(RoleE roleE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验ID
 				org.laokou.admin.role.service.validator.RoleParamValidator.validateId(roleE),
 				// 校验数据范围

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/ModifyRoleParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/ModifyRoleParamValidator.java
@@ -35,7 +35,7 @@ public class ModifyRoleParamValidator implements RoleParamValidator {
 
 	@Override
 	public void validateRole(RoleE roleE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验ID
 				org.laokou.admin.role.service.validator.RoleParamValidator.validateId(roleE),
 				// 校验名称

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/SaveRoleParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/SaveRoleParamValidator.java
@@ -35,7 +35,7 @@ public class SaveRoleParamValidator implements RoleParamValidator {
 
 	@Override
 	public void validateRole(RoleE roleE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验名称
 				org.laokou.admin.role.service.validator.RoleParamValidator.validateName(roleE, roleMapper, true),
 				// 校验排序

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ModifyUserAuthorityParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ModifyUserAuthorityParamValidator.java
@@ -32,7 +32,7 @@ public class ModifyUserAuthorityParamValidator implements UserParamValidator {
 
 	@Override
 	public void validateUser(UserE userE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验ID
 				org.laokou.admin.user.service.validator.UserParamValidator.validateId(userE),
 				// 校验角色IDS

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ModifyUserParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ModifyUserParamValidator.java
@@ -35,7 +35,7 @@ public class ModifyUserParamValidator implements UserParamValidator {
 
 	@Override
 	public void validateUser(UserE userE) throws Exception {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验ID
 				org.laokou.admin.user.service.validator.UserParamValidator.validateId(userE),
 				// 校验邮箱

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ResetUserPwdParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ResetUserPwdParamValidator.java
@@ -38,7 +38,7 @@ public class ResetUserPwdParamValidator implements UserParamValidator {
 
 	@Override
 	public void validateUser(UserE userE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验ID
 				org.laokou.admin.user.service.validator.UserParamValidator.validateId(userE),
 				// 校验密码

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/SaveUserParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/SaveUserParamValidator.java
@@ -35,7 +35,7 @@ public class SaveUserParamValidator implements UserParamValidator {
 
 	@Override
 	public void validateUser(UserE userE) throws Exception {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				// 校验用户名
 				org.laokou.admin.user.service.validator.UserParamValidator.validateUsername(userE, userMapper, true),
 				// 校验邮箱

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/ability/DeptDomainService.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/ability/DeptDomainService.java
@@ -19,7 +19,7 @@ package org.laokou.admin.dept.ability;
 
 import lombok.RequiredArgsConstructor;
 import org.laokou.admin.dept.gateway.DeptGateway;
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.model.DeptA;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,12 +33,12 @@ public class DeptDomainService {
 
 	private final DeptGateway deptGateway;
 
-	public void createDept(DeptE deptE) {
-		deptGateway.createDept(deptE);
+	public void createDept(DeptA deptA) {
+		deptGateway.createDept(deptA);
 	}
 
-	public void updateDept(DeptE deptE) {
-		deptGateway.updateDept(deptE);
+	public void updateDept(DeptA deptA) {
+		deptGateway.updateDept(deptA);
 	}
 
 	public void deleteDept(Long[] ids) {

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/factory/DeptDomainFactory.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/factory/DeptDomainFactory.java
@@ -17,7 +17,8 @@
 
 package org.laokou.admin.dept.factory;
 
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.model.DeptA;
+import org.laokou.admin.dept.model.entity.DeptE;
 import org.laokou.common.i18n.util.SpringContextUtils;
 
 /**
@@ -28,8 +29,12 @@ public final class DeptDomainFactory {
 	private DeptDomainFactory() {
 	}
 
-	public static DeptE getDept() {
+	public static DeptE createDeptE() {
 		return SpringContextUtils.getBeanProvider(DeptE.class);
+	}
+
+	public static DeptA createDeptA() {
+		return SpringContextUtils.getBeanProvider(DeptA.class);
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/gateway/DeptGateway.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/gateway/DeptGateway.java
@@ -17,7 +17,7 @@
 
 package org.laokou.admin.dept.gateway;
 
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.model.DeptA;
 
 /**
  * 部门网关【防腐】.
@@ -29,12 +29,12 @@ public interface DeptGateway {
 	/**
 	 * 新增部门.
 	 */
-	void createDept(DeptE deptE);
+	void createDept(DeptA deptA);
 
 	/**
 	 * 修改部门.
 	 */
-	void updateDept(DeptE deptE);
+	void updateDept(DeptA deptA);
 
 	/**
 	 * 删除部门.

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/DeptA.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/DeptA.java
@@ -18,11 +18,15 @@
 package org.laokou.admin.dept.model;
 
 import lombok.Getter;
-import lombok.Setter;
+import org.laokou.admin.dept.model.entity.DeptE;
 import org.laokou.admin.dept.model.enums.OperateType;
+import org.laokou.admin.dept.model.validator.DeptParamValidator;
 import org.laokou.common.i18n.annotation.Entity;
 import org.laokou.common.i18n.common.IdGenerator;
 import org.laokou.common.i18n.common.ValidateName;
+import org.laokou.common.i18n.dto.AggregateRoot;
+import org.laokou.common.i18n.util.InstantUtils;
+import org.laokou.common.i18n.util.ObjectUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
@@ -32,50 +36,36 @@ import org.springframework.beans.factory.annotation.Qualifier;
  */
 @Entity
 @Getter
-public class DeptE implements ValidateName {
+public class DeptA extends AggregateRoot implements ValidateName {
 
-	private Long id;
-
-	/**
-	 * 部门父节点ID.
-	 */
-	@Setter
-	@Getter
-	private Long pid;
+	private DeptE deptE;
 
 	/**
-	 * 部门名称.
+	 * 操作类型【保存/修改】.
 	 */
-	@Setter
-	@Getter
-	private String name;
-
-	/**
-	 * 部门排序.
-	 */
-	@Setter
-	@Getter
-	private Integer sort;
-
-	@Setter
-	@Getter
 	private OperateType operateType;
+
+	private final IdGenerator idGenerator;
 
 	private final DeptParamValidator saveDeptParamValidator;
 
 	private final DeptParamValidator modifyDeptParamValidator;
 
-	private final IdGenerator idGenerator;
-
-	public DeptE(@Qualifier("modifyDeptParamValidator") DeptParamValidator saveDeptParamValidator,
-			@Qualifier("saveDeptParamValidator") DeptParamValidator modifyDeptParamValidator, IdGenerator idGenerator) {
+	public DeptA(IdGenerator idGenerator,
+			@Qualifier("modifyDeptParamValidator") DeptParamValidator saveDeptParamValidator,
+			@Qualifier("saveDeptParamValidator") DeptParamValidator modifyDeptParamValidator) {
+		this.idGenerator = idGenerator;
 		this.saveDeptParamValidator = saveDeptParamValidator;
 		this.modifyDeptParamValidator = modifyDeptParamValidator;
-		this.idGenerator = idGenerator;
 	}
 
-	public Long getPrimaryKey() {
-		return idGenerator.getId();
+	public DeptA create(DeptE deptE) {
+		this.deptE = deptE;
+		Long primaryKey = this.deptE.getId();
+		super.createTime = InstantUtils.now();
+		super.id = ObjectUtils.isNotNull(primaryKey) ? primaryKey : idGenerator.getId();
+		this.operateType = ObjectUtils.isNotNull(primaryKey) ? OperateType.MODIFY : OperateType.SAVE;
+		return this;
 	}
 
 	public void checkDeptParam() {
@@ -84,6 +74,10 @@ public class DeptE implements ValidateName {
 			case MODIFY -> modifyDeptParamValidator.validateDept(this);
 			default -> throw new UnsupportedOperationException("Unsupported operation type");
 		}
+	}
+
+	public boolean isModify() {
+		return ObjectUtils.equals(OperateType.MODIFY, this.operateType);
 	}
 
 	@Override

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/entity/DeptE.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/entity/DeptE.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.admin.dept.model.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.laokou.common.i18n.annotation.Entity;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * 部门领域对象【实体】.
+ *
+ * @author laokou
+ */
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@EqualsAndHashCode(callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeptE implements Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * ID.
+	 */
+	private Long id;
+
+	/**
+	 * 部门父节点ID.
+	 */
+	private Long pid;
+
+	/**
+	 * 部门名称.
+	 */
+	private String name;
+
+	/**
+	 * 部门排序.
+	 */
+	private Integer sort;
+
+}

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/validator/DeptParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/validator/DeptParamValidator.java
@@ -15,13 +15,15 @@
  *
  */
 
-package org.laokou.admin.dept.model;
+package org.laokou.admin.dept.model.validator;
+
+import org.laokou.admin.dept.model.DeptA;
 
 /**
  * @author laokou
  */
 public interface DeptParamValidator {
 
-	void validateDept(DeptE deptE);
+	void validateDept(DeptA deptA);
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/common/config/AdminConfig.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/common/config/AdminConfig.java
@@ -29,6 +29,7 @@ public class AdminConfig {
 	static {
 		ForyFactory.INSTANCE.register(org.laokou.admin.menu.dto.clientobject.MenuTreeCO.class);
 		ForyFactory.INSTANCE.register(org.laokou.admin.menu.dto.clientobject.MenuCO.class);
+		ForyFactory.INSTANCE.register(org.laokou.admin.dept.dto.clientobject.DeptCO.class);
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/convertor/DeptConvertor.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/convertor/DeptConvertor.java
@@ -21,8 +21,8 @@ import org.laokou.admin.dept.dto.clientobject.DeptCO;
 import org.laokou.admin.dept.dto.clientobject.DeptTreeCO;
 import org.laokou.admin.dept.factory.DeptDomainFactory;
 import org.laokou.admin.dept.gatewayimpl.database.dataobject.DeptDO;
-import org.laokou.admin.dept.model.DeptE;
-import org.laokou.admin.dept.model.enums.OperateType;
+import org.laokou.admin.dept.model.DeptA;
+import org.laokou.admin.dept.model.entity.DeptE;
 
 import java.util.List;
 
@@ -33,12 +33,10 @@ import java.util.List;
  */
 public class DeptConvertor {
 
-	public static DeptDO toDataObject(DeptE deptE) {
+	public static DeptDO toDataObject(DeptA deptA) {
+		DeptE deptE = deptA.getDeptE();
 		DeptDO deptDO = new DeptDO();
-		switch (deptE.getOperateType()) {
-			case SAVE -> deptDO.setId(deptE.getPrimaryKey());
-			case MODIFY -> deptDO.setId(deptE.getId());
-		}
+		deptDO.setId(deptA.getId());
 		deptDO.setPid(deptE.getPid());
 		deptDO.setName(deptE.getName());
 		deptDO.setSort(deptE.getSort());
@@ -59,16 +57,6 @@ public class DeptConvertor {
 		return list.stream().map(DeptConvertor::toClientObject).toList();
 	}
 
-	public static DeptE toEntity(DeptCO deptCO, boolean isInsert) {
-		DeptE deptE = DeptDomainFactory.getDept();
-		// deptE.setId(deptCO.getId());
-		deptE.setPid(deptCO.getPid());
-		deptE.setName(deptCO.getName());
-		deptE.setSort(deptCO.getSort());
-		deptE.setOperateType(isInsert ? OperateType.SAVE : OperateType.MODIFY);
-		return deptE;
-	}
-
 	public static DeptTreeCO toClientObject0(DeptDO deptDO) {
 		DeptTreeCO co = new DeptTreeCO();
 		co.setId(deptDO.getId());
@@ -82,6 +70,16 @@ public class DeptConvertor {
 
 	public static List<DeptTreeCO> toClientObjectList0(List<DeptDO> list) {
 		return list.stream().map(DeptConvertor::toClientObject0).toList();
+	}
+
+	public static DeptE toEntity(DeptCO deptCO) {
+		return DeptDomainFactory.createDeptE()
+			.toBuilder()
+			.id(deptCO.getId())
+			.sort(deptCO.getSort())
+			.pid(deptCO.getPid())
+			.name(deptCO.getName())
+			.build();
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
@@ -22,7 +22,7 @@ import org.laokou.admin.dept.convertor.DeptConvertor;
 import org.laokou.admin.dept.gateway.DeptGateway;
 import org.laokou.admin.dept.gatewayimpl.database.DeptMapper;
 import org.laokou.admin.dept.gatewayimpl.database.dataobject.DeptDO;
-import org.laokou.admin.dept.model.DeptE;
+import org.laokou.admin.dept.model.DeptA;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -39,14 +39,14 @@ public class DeptGatewayImpl implements DeptGateway {
 	private final DeptMapper deptMapper;
 
 	@Override
-	public void createDept(DeptE deptE) {
-		deptMapper.insert(DeptConvertor.toDataObject(deptE));
+	public void createDept(DeptA deptA) {
+		deptMapper.insert(DeptConvertor.toDataObject(deptA));
 	}
 
 	@Override
-	public void updateDept(DeptE deptE) {
-		DeptDO deptDO = DeptConvertor.toDataObject(deptE);
-		deptDO.setVersion(deptMapper.selectVersion(deptE.getId()));
+	public void updateDept(DeptA deptA) {
+		DeptDO deptDO = DeptConvertor.toDataObject(deptA);
+		deptDO.setVersion(deptMapper.selectVersion(deptA.getId()));
 		deptMapper.updateById(deptDO);
 	}
 

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/productCategory/service/validator/ModifyProductCategoryParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/productCategory/service/validator/ModifyProductCategoryParamValidator.java
@@ -35,7 +35,7 @@ public class ModifyProductCategoryParamValidator implements ProductCategoryParam
 
 	@Override
 	public void validateProductCategory(ProductCategoryE productCategoryE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				org.laokou.iot.productCategory.service.validator.ProductCategoryParamValidator
 					.validateId(productCategoryE),
 				org.laokou.iot.productCategory.service.validator.ProductCategoryParamValidator

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/productCategory/service/validator/SaveProductCategoryParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/productCategory/service/validator/SaveProductCategoryParamValidator.java
@@ -35,7 +35,7 @@ public class SaveProductCategoryParamValidator implements ProductCategoryParamVa
 
 	@Override
 	public void validateProductCategory(ProductCategoryE productCategoryE) {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				org.laokou.iot.productCategory.service.validator.ProductCategoryParamValidator
 					.validateName(productCategoryE, true, productCategoryMapper),
 				org.laokou.iot.productCategory.service.validator.ProductCategoryParamValidator

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/ModifyThingModelParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/ModifyThingModelParamValidator.java
@@ -36,7 +36,7 @@ public class ModifyThingModelParamValidator implements ThingModelParamValidator 
 
 	@Override
 	public void validateThingModel(ThingModelE thingModelE) throws JsonProcessingException {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateId(thingModelE),
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateCodeAndName(thingModelE,
 						false, thingModelMapper),

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/SaveThingModelParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/SaveThingModelParamValidator.java
@@ -36,7 +36,7 @@ public class SaveThingModelParamValidator implements ThingModelParamValidator {
 
 	@Override
 	public void validateThingModel(ThingModelE thingModelE) throws JsonProcessingException {
-		ParamValidator.validate(
+		ParamValidator.validate("System",
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateCodeAndName(thingModelE,
 						true, thingModelMapper),
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateCategory(thingModelE),

--- a/ui/src/pages/Sys/Permission/dept.tsx
+++ b/ui/src/pages/Sys/Permission/dept.tsx
@@ -82,12 +82,6 @@ export default () => {
 			}
 		},
 		{
-			title: '部门路径',
-			dataIndex: 'path',
-			ellipsis: true,
-			hideInSearch: true,
-		},
-		{
 			title: '部门排序',
 			dataIndex: 'sort',
 			hideInSearch: true,


### PR DESCRIPTION
## Summary by Sourcery

围绕新的聚合根重构部门领域建模，规范参数校验命名，并调整转换器、网关和 UI 以与更新后的校验与实体结构保持一致。

增强内容：
- 引入 DeptA 作为聚合根，封装 DeptE 实体，集中负责 ID 生成、操作类型跟踪以及校验入口。
- 重构部门校验器和网关/服务接口，使其基于 DeptA 工作，并仅在修改类操作中有条件地要求提供 ID。
- 调整 DeptConvertor、领域工厂和管理端配置，以支持新的基于构建器的 DeptE 实体、DeptA 聚合以及 DeptCO 注册。
- 规范 ParamValidator 的使用方式，移除无参重载，在管理端和物联网校验器中统一要求显式提供校验名称。
- 简化部门 UI 表格，移除未使用的部门路径列。

测试：
- 更新 ParamValidator 测试用例，传入显式校验名称，并在新的 API 下验证错误码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor department domain modeling around a new aggregate root, standardize parameter validation naming, and adjust converters, gateways, and UI to align with the updated validation and entity structure.

Enhancements:
- Introduce DeptA as an aggregate root wrapping the DeptE entity with centralized ID generation, operation type tracking, and validation entrypoints.
- Rework department validators and gateway/service interfaces to operate on DeptA and conditionally require IDs only for modification operations.
- Adjust DeptConvertor, domain factory, and admin configuration to support the new DeptE builder-based entity, DeptA aggregate, and DeptCO registration.
- Standardize ParamValidator usage by removing the no-argument overload and requiring an explicit validation name across admin and IoT validators.
- Simplify the department UI table by removing the unused department path column.

Tests:
- Update ParamValidator tests to pass the explicit validation name and verify error codes under the new API.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Changes**
  * Removed the department path column from the department table view.

* **Refactoring**
  * Restructured internal validation framework to require explicit system context for parameter validation.
  * Refactored department and related domain models to improve architectural consistency across the admin and IoT modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->