### PR TITLE
fix: maven构建失败

### DIFF
--- a/laokou-common/laokou-common-mybatis-plus/pom.xml
+++ b/laokou-common/laokou-common-mybatis-plus/pom.xml
@@ -70,6 +70,10 @@
           <groupId>com.alibaba</groupId>
           <artifactId>druid-spring-boot-4-starter</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.mybatis</groupId>
+          <artifactId>mybatis-spring</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/service/validator/AuthorizationCodeAuthParamValidator.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/service/validator/AuthorizationCodeAuthParamValidator.java
@@ -19,6 +19,7 @@ package org.laokou.auth.service.validator;
 
 import org.laokou.auth.model.AuthA;
 import org.laokou.auth.model.validator.AuthParamValidator;
+import org.laokou.auth.model.valueobject.CaptchaV;
 import org.laokou.auth.model.valueobject.UserV;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.springframework.stereotype.Component;
@@ -37,9 +38,14 @@ public class AuthorizationCodeAuthParamValidator implements AuthParamValidator {
 	@Override
 	public void validateAuth(AuthA authA) {
 		UserV userV = authA.getUserV();
+		CaptchaV captchaV = authA.getCaptchaV();
 		ParamValidator.validate(authA.getValidateName(),
 				// 校验租户编码
 				OAuth2ParamValidator.validateTenantCode(userV.tenantCode()),
+				// 校验UUID
+				OAuth2ParamValidator.validateUuid(captchaV.uuid()),
+				// 校验验证码
+				OAuth2ParamValidator.validateCaptcha(captchaV.captcha()),
 				// 校验用户名
 				OAuth2ParamValidator.validateUsername(userV.username()),
 				// 校验密码

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
@@ -219,6 +219,7 @@ public final class AuthA extends AggregateRoot implements ValidateName {
 
 	public AuthA createAuthorizationCodeAuth() throws Exception {
 		this.grantType = GrantType.AUTHORIZATION_CODE;
+		this.captchaV = getCaptchaVByAuthorizationCodeAuth();
 		this.userV = getUserVByAuthorizationCodeAuth();
 		return create();
 	}
@@ -405,6 +406,10 @@ public final class AuthA extends AggregateRoot implements ValidateName {
 
 	private String getParameterValue(String key) {
 		return parameterMap.getOrDefault(key, new String[] { StringConstants.EMPTY })[0];
+	}
+
+	private CaptchaV getCaptchaVByAuthorizationCodeAuth() {
+		return getCaptchaVByUsernamePasswordAuth();
 	}
 
 	private CaptchaV getCaptchaVByUsernamePasswordAuth() {

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/model/DomainServiceTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/test/java/org/laokou/auth/model/DomainServiceTest.java
@@ -295,7 +295,7 @@ class DomainServiceTest {
 	}
 
 	@Test
-	@DisplayName("Test authorization code password auth success")
+	@DisplayName("Test authorization code auth success")
 	void test_auth_authorizationCode_success() throws Exception {
 		createAuthorizationCodeAuthInfo(createAuthorizationCodeAuthParam());
 		AuthA authorizationCodeAuth = createAuth().createAuthorizationCodeAuth();
@@ -303,6 +303,8 @@ class DomainServiceTest {
 		Assertions.assertThatCode(() -> domainService.auth(authorizationCodeAuth)).doesNotThrowAnyException();
 		Mockito.verify(tenantGateway, Mockito.times(1)).getTenantId(this.tenantCode);
 		Mockito.verify(httpRequest, Mockito.times(1)).getParameterMap();
+		Mockito.verify(captchaValidator, Mockito.times(1))
+			.validateCaptcha(RedisKeyUtils.getAuthorizationCodeAuthCaptchaKey(this.uuid), this.captcha);
 		Mockito.verify(passwordValidator, Mockito.times(1)).validatePassword(this.password, this.password);
 		Mockito.verify(userGateway, Mockito.times(1)).getUserProfile(createUserVByAuthorizationCode());
 		Mockito.verify(menuGateway, Mockito.times(1)).getMenuPermissions(createUserE());
@@ -432,8 +434,15 @@ class DomainServiceTest {
 		Mockito.doAnswer(invocation -> {
 			AuthA authA = invocation.getArgument(0);
 			UserV userV = authA.getUserV();
+			CaptchaV captchaV = authA.getCaptchaV();
 			if (StringExtUtils.isEmpty(userV.tenantCode())) {
 				throw new IllegalArgumentException("tenant code must not be empty");
+			}
+			if (StringExtUtils.isEmpty(captchaV.uuid())) {
+				throw new IllegalArgumentException("uuid must not be empty");
+			}
+			if (StringExtUtils.isEmpty(captchaV.captcha())) {
+				throw new IllegalArgumentException("captcha must not be empty");
 			}
 			if (StringExtUtils.isEmpty(userV.username())) {
 				throw new IllegalArgumentException("username must not be empty");
@@ -444,6 +453,7 @@ class DomainServiceTest {
 			return null;
 		}).when(authorizationCodeAuthParamValidator).validateAuth(Mockito.any());
 		Mockito.when(passwordValidator.validatePassword(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
+		Mockito.when(captchaValidator.validateCaptcha(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
 		Mockito.when(tenantGateway.getTenantId(Mockito.anyString())).thenReturn(1L);
 		Mockito.when(roleGateway.getDataScopes(Mockito.any())).thenReturn(Set.of("self", "custom"));
 		Mockito.when(deptGateway.getDeptIds(Mockito.any(), Mockito.any())).thenReturn(Set.of(1L));
@@ -453,8 +463,11 @@ class DomainServiceTest {
 		Map<String, String[]> params = MapUtils.newHashMap(4);
 		params.put(Constants.USERNAME, new String[] { authorizationCodeAuthParam.username() });
 		params.put(Constants.PASSWORD, new String[] { authorizationCodeAuthParam.password() });
+		params.put(Constants.UUID, new String[] { authorizationCodeAuthParam.uuid() });
+		params.put(Constants.CAPTCHA, new String[] { authorizationCodeAuthParam.captcha() });
 		params.put(Constants.TENANT_CODE, new String[] { authorizationCodeAuthParam.tenantCode() });
 		params.put(Constants.GRANT_TYPE, new String[] { authorizationCodeAuthParam.grantType() });
+
 		Mockito.when(httpRequest.getParameterMap()).thenReturn(params);
 	}
 
@@ -535,7 +548,7 @@ class DomainServiceTest {
 	}
 
 	private AuthorizationCodAuthParam createAuthorizationCodeAuthParam() {
-		return new AuthorizationCodAuthParam(this.username, this.password, this.tenantCode,
+		return new AuthorizationCodAuthParam(this.uuid, this.captcha, this.username, this.password, this.tenantCode,
 				GrantType.AUTHORIZATION_CODE.getCode());
 	}
 
@@ -552,7 +565,7 @@ class DomainServiceTest {
 	}
 
 	private AuthorizationCodAuthParam createAuthorizationCodeEmptyAuthParam() {
-		return new AuthorizationCodAuthParam(null, null, null, GrantType.AUTHORIZATION_CODE.getCode());
+		return new AuthorizationCodAuthParam(null, null, null, null, null, GrantType.AUTHORIZATION_CODE.getCode());
 	}
 
 	private UserV createUserVByUsernamePassword() throws Exception {
@@ -624,7 +637,8 @@ class DomainServiceTest {
 	private record TestAuthParam(String username, String password, String tenantCode, String grantType) {
 	}
 
-	private record AuthorizationCodAuthParam(String username, String password, String tenantCode, String grantType) {
+	private record AuthorizationCodAuthParam(String uuid, String captcha, String username, String password,
+			String tenantCode, String grantType) {
 	}
 
 }


### PR DESCRIPTION
## Summary by Sourcery

为授权码认证流程添加验证码校验支持，并修复相关的 Maven 构建问题。

新功能：
- 在授权码认证请求和验证逻辑中加入验证码信息。

缺陷修复：
- 确保授权码认证测试覆盖验证码校验和必需参数检查，以防止构建/测试失败。
- 从 `mybatis-plus-boot-starter` 中排除有冲突的 `mybatis-spring` 依赖，以解决 Maven 构建错误。

改进：
- 优化授权码认证测试的描述，使其更加清晰。
- 在授权码认证参数处理中复用现有的验证码提取逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add captcha validation support to authorization code authentication flow and fix related Maven build issues.

New Features:
- Include captcha information in authorization code authentication requests and validation logic.

Bug Fixes:
- Ensure authorization code authentication test covers captcha validation and required parameter checks to prevent build/test failures.
- Exclude conflicting mybatis-spring dependency from the mybatis-plus-boot-starter to resolve Maven build errors.

Enhancements:
- Refine authorization code authentication test descriptions for clarity.
- Reuse existing captcha extraction logic for authorization code authentication parameters.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authorization code authentication with mandatory CAPTCHA verification to improve security by validating UUID and CAPTCHA parameters during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->