### PR TITLE
Dev

### DIFF
--- a/archive/.gitignore
+++ b/archive/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/archive/docs/00.二开指南/02.指南/11.OAuth2.1资源服务器配置.md
+++ b/archive/docs/00.二开指南/02.指南/11.OAuth2.1资源服务器配置.md
@@ -82,8 +82,8 @@ spring:
               - /doc.html=laokou-auth
               - /webjars/**=laokou-auth
             POST:
-              - /v1/captchas/send/mail=laokou-auth
-              - /v1/captchas/send/mobile=laokou-auth
+              - /v1/captchas/send-mail=laokou-auth
+              - /v1/captchas/send-mobile=laokou-auth
             DELETE:
               - /v1/tokens=laokou-auth
 ```
@@ -108,8 +108,8 @@ spring:
 
 | 路径                         | 说明      | 用途      |
 |----------------------------|---------|---------|
-| `/v1/captchas/send/mail`   | 发送邮箱验证码 | 邮箱登录验证码 |
-| `/v1/captchas/send/mobile` | 发送手机验证码 | 手机登录验证码 |
+| `/v1/captchas/send-mail`   | 发送邮箱验证码 | 邮箱登录验证码 |
+| `/v1/captchas/send-mobile` | 发送手机验证码 | 手机登录验证码 |
 
 ### DELETE 请求
 
@@ -158,8 +158,8 @@ spring:
         request-matcher:
           ignore-patterns:
             POST:
-              - /v1/captchas/send/mail=laokou-auth
-              - /v1/captchas/send/mobile=laokou-auth
+              - /v1/captchas/send-mail=laokou-auth
+              - /v1/captchas/send-mobile=laokou-auth
               # 新增：用户注册
               - /v1/users/register=laokou-auth
 ```
@@ -250,8 +250,8 @@ spring:
               - /v1/captchas/{uuid}=laokou-auth
               - /v1/secrets=laokou-auth
             POST:
-              - /v1/captchas/send/mail=laokou-auth
-              - /v1/captchas/send/mobile=laokou-auth
+              - /v1/captchas/send-mail=laokou-auth
+              - /v1/captchas/send-mobile=laokou-auth
             DELETE:
               - /v1/tokens=laokou-auth
 ```

--- a/archive/docs/00.二开指南/02.指南/12.OAuth2.1认证API配置.md
+++ b/archive/docs/00.二开指南/02.指南/12.OAuth2.1认证API配置.md
@@ -111,7 +111,7 @@ Host: gateway:1111
 
 | 属性               | 值                          |
 |------------------|----------------------------|
-| **URL**          | `/v1/captchas/send/mobile` |
+| **URL**          | `/v1/captchas/send-mobile` |
 | **Method**       | `POST`                     |
 | **Content-Type** | `application/json`         |
 | **认证**           | 无需认证                       |
@@ -127,7 +127,7 @@ Host: gateway:1111
 **请求示例：**
 
 ```http
-POST /api/v1/captchas/send/mobile HTTP/1.1
+POST /api/v1/captchas/send-mobile HTTP/1.1
 Host: gateway:1111
 Content-Type: application/json
 
@@ -147,7 +147,7 @@ Content-Type: application/json
 
 | 属性               | 值                        |
 |------------------|--------------------------|
-| **URL**          | `/v1/captchas/send/mail` |
+| **URL**          | `/v1/captchas/send-mail` |
 | **Method**       | `POST`                   |
 | **Content-Type** | `application/json`       |
 | **认证**           | 无需认证                     |
@@ -163,7 +163,7 @@ Content-Type: application/json
 **请求示例：**
 
 ```http
-POST /api/v1/captchas/send/mail HTTP/1.1
+POST /api/v1/captchas/send-mail HTTP/1.1
 Host: gateway:1111
 Content-Type: application/json
 

--- a/doc/db/4.0.0/kcloud_platform_nacos.sql
+++ b/doc/db/4.0.0/kcloud_platform_nacos.sql
@@ -1065,7 +1065,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (11, 'gatewa
 ]', '5e013d830e3af21e5e321c0f4910fda0', '2024-05-25 18:12:47.358', '2024-11-11 20:51:44.543', 'nacos', '0:0:0:0:0:0:0:1', 'laokou-gateway', '0dac1a68-2f01-40df-bd26-bf0cb199057a', 'gateway sentinel flow rule', '', '', 'json', '', '');
 INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (38, 'auth-flow.json', 'IOT_GROUP', '[
   {
-    "resource": "/api/v1/captchas/{uuid}",
+    "resource": "/api/v1/username-password/captchas/{uuid}",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -1073,7 +1073,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (38, 'auth-f
     "controlBehavior": 0
   },
   {
-    "resource": "/api/v1/captchas/send/mobile",
+    "resource": "/api/v1/captchas/send-mobile",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -1081,7 +1081,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (38, 'auth-f
     "controlBehavior": 0
   },
     {
-    "resource": "/api/v1/captchas/send/mail",
+    "resource": "/api/v1/captchas/send-mail",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -1108,7 +1108,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (38, 'auth-f
 ', '2bb6ed92c98b4a1693426dadf1c96a30', '2024-11-11 21:17:37.578', '2024-11-11 21:18:17.553', 'nacos', '0:0:0:0:0:0:0:1', 'laokou-auth', '8140e92b-fb43-48f5-b63b-7506185206a5', 'auth sentinel flow rule', '', '', 'json', '', '');
 INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES (39, 'auth-flow.json', 'IOT_GROUP', '[
   {
-    "resource": "/api/v1/captchas/{uuid}",
+    "resource": "/api/v1/username-password/captchas/{uuid}",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -1116,7 +1116,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES (39, 'auth-fl
     "controlBehavior": 0
   },
   {
-    "resource": "/api/v1/captchas/send/mobile",
+    "resource": "/api/v1/captchas/send-mobile",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -1124,7 +1124,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES (39, 'auth-fl
     "controlBehavior": 0
   },
     {
-    "resource": "/api/v1/captchas/send/mail",
+    "resource": "/api/v1/captchas/send-mail",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -2453,7 +2453,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (41, 'admin-
 ', '546e2d9817dd516db763f5ef3ef3a756', '2024-11-11 21:20:18.495', '2024-11-12 11:14:01.899', 'nacos', '0:0:0:0:0:0:0:1', 'laokou-admin', '0dac1a68-2f01-40df-bd26-bf0cb199057a', 'admin sentinel flow rule', '', '', 'json', '', '');
 INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (43, 'auth-flow.json', 'IOT_GROUP', '[
   {
-    "resource": "/api/v1/captchas/{uuid}",
+    "resource": "/api/v1/username-password/captchas/{uuid}",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -2461,7 +2461,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (43, 'auth-f
     "controlBehavior": 0
   },
   {
-    "resource": "/api/v1/captchas/send/mobile",
+    "resource": "/api/v1/captchas/send-mobile",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -2469,7 +2469,7 @@ INSERT INTO "public"."config_info"  OVERRIDING SYSTEM VALUE VALUES  (43, 'auth-f
     "controlBehavior": 0
   },
     {
-    "resource": "/api/v1/captchas/send/mail",
+    "resource": "/api/v1/captchas/send-mail",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,

--- a/laokou-cloud/laokou-gateway/src/main/resources/application.yml
+++ b/laokou-cloud/laokou-gateway/src/main/resources/application.yml
@@ -196,14 +196,11 @@ request-matcher:
       - /actuator/**=laokou-gateway
       - /favicon.ico=laokou-gateway
       - /api/v1/username-password/captchas/{uuid}=laokou-gateway
-      - /api/v1/authorization-code/captchas/{uuid}=laokou-gateway
       - /api/v1/secrets=laokou-gateway
       - /doc.html=laokou-gateway
       - /webjars/**=laokou-gateway
       - /ws=laokou-gateway
     POST:
-      - /api/v1/captchas/send/mail=laokou-gateway
-      - /api/v1/captchas/send/mobile=laokou-gateway
+      - /api/v1/captchas/send-mail=laokou-gateway
+      - /api/v1/captchas/send-mobile=laokou-gateway
       - /api/v1/oauth2/token=laokou-gateway
-    DELETE:
-      - /api/v1/tokens=laokou-gateway

--- a/laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/aspectj/OperateType.java
+++ b/laokou-common/laokou-common-data-cache/src/main/java/org/laokou/common/data/cache/aspectj/OperateType.java
@@ -26,9 +26,6 @@ import org.laokou.common.i18n.util.ObjectUtils;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
-
 /**
  * 操作类型枚举.
  *
@@ -70,7 +67,6 @@ public enum OperateType {
 		public Object execute(String name, String key, ProceedingJoinPoint point, CacheManager cacheManager) {
 			try {
 				getCache(cacheManager, name).evict(key);
-				LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(200));
 				return point.proceed();
 			}
 			catch (GlobalException e) {

--- a/laokou-service/laokou-auth/laokou-auth-adapter/src/main/java/org/laokou/auth/web/CaptchasController.java
+++ b/laokou-service/laokou-auth/laokou-auth-adapter/src/main/java/org/laokou/auth/web/CaptchasController.java
@@ -65,7 +65,7 @@ public class CaptchasController {
 	}
 
 	@Idempotent
-	@PostMapping("/v1/captchas/send/mobile")
+	@PostMapping("/v1/captchas/send-mobile")
 	@RateLimiter(key = "SEND_MOBILE_CAPTCHA", type = Type.IP)
 	@Operation(summary = "根据UUID发送手机验证码", description = "根据UUID发送手机验证码")
 	public void sendMobileCaptchaByUuid(@RequestBody CaptchaSendCmd cmd) {
@@ -74,7 +74,7 @@ public class CaptchasController {
 	}
 
 	@Idempotent
-	@PostMapping("/v1/captchas/send/mail")
+	@PostMapping("/v1/captchas/send-mail")
 	@RateLimiter(key = "SEND_MAIL_CAPTCHA", type = Type.IP)
 	@Operation(summary = "根据UUID发送邮箱验证码", description = "根据UUID发送邮箱验证码")
 	public void sendMailCaptchaByUuid(@RequestBody CaptchaSendCmd cmd) {

--- a/laokou-service/laokou-auth/laokou-auth-adapter/src/main/java/org/laokou/auth/web/TokensController.java
+++ b/laokou-service/laokou-auth/laokou-auth-adapter/src/main/java/org/laokou/auth/web/TokensController.java
@@ -22,8 +22,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.laokou.auth.api.TokensServiceI;
 import org.laokou.auth.dto.TokenRemoveCmd;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -38,8 +39,8 @@ public class TokensController {
 
 	@DeleteMapping("/v1/tokens")
 	@Operation(summary = "删除令牌", description = "删除令牌")
-	public void removeToken(@RequestBody TokenRemoveCmd cmd) {
-		tokensServiceI.removeToken(cmd);
+	public void removeToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+		tokensServiceI.removeToken(new TokenRemoveCmd(token));
 	}
 
 }

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
@@ -19,20 +19,26 @@ package org.laokou.auth.command;
 
 import org.laokou.auth.dto.TokenRemoveCmd;
 import org.laokou.common.context.util.OAuth2Authentication;
+import org.laokou.common.context.util.UserExtDetails;
 import org.laokou.common.data.cache.aspectj.OperateType;
 import org.laokou.common.data.cache.constant.NameConstants;
 import org.laokou.common.domain.annotation.CommandLog;
 import org.laokou.common.i18n.util.ObjectUtils;
+import org.laokou.common.i18n.util.RedisKeyUtils;
 import org.laokou.common.i18n.util.StringExtUtils;
+import org.laokou.common.redis.util.RedisUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.stereotype.Component;
 
 import java.security.Principal;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
@@ -48,17 +54,23 @@ public class TokenRemoveCmdExe {
 
 	private final OAuth2AuthorizationService authorizationService;
 
+	private final RedisUtils redisUtils;
+
+	private final RedisIndexedSessionRepository redisIndexedSessionRepository;
+
 	public TokenRemoveCmdExe(@Qualifier("redisCacheManager") CacheManager redisCacheManager,
-			OAuth2AuthorizationService authorizationService) {
+			OAuth2AuthorizationService authorizationService, RedisUtils redisUtils,
+			RedisIndexedSessionRepository redisIndexedSessionRepository) {
 		this.redisCacheManager = redisCacheManager;
 		this.authorizationService = authorizationService;
+		this.redisUtils = redisUtils;
+		this.redisIndexedSessionRepository = redisIndexedSessionRepository;
 	}
 
 	/**
 	 * 执行退出登录.
 	 * @param cmd 退出登录参数
 	 */
-	@Async("virtualThreadExecutor")
 	@CommandLog
 	public void executeVoid(TokenRemoveCmd cmd) {
 		String token = cmd.getToken();
@@ -78,6 +90,18 @@ public class TokenRemoveCmdExe {
 	private void evictCache(OAuth2Authorization authorization) {
 		if (authorization.getAttribute(Principal.class.getName()) instanceof OAuth2Authentication authentication) {
 			OperateType.getCache(redisCacheManager, NameConstants.USER_MENU).evict(authentication.id());
+			LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(200));
+		}
+		if (authorization
+			.getAttribute(Principal.class
+				.getName()) instanceof UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken
+				&& usernamePasswordAuthenticationToken.getPrincipal() instanceof User user && redisUtils
+					.get(RedisKeyUtils.getUserDetailKey(user.getUsername())) instanceof UserExtDetails userExtDetails) {
+			OperateType.getCache(redisCacheManager, NameConstants.USER_MENU).evict(userExtDetails.id());
+			redisUtils.del(RedisKeyUtils.getUserDetailKey(user.getUsername()));
+			Map<String, RedisIndexedSessionRepository.RedisSession> sessionMap = redisIndexedSessionRepository
+				.findByPrincipalName(user.getUsername());
+			sessionMap.forEach((sessionId, _) -> redisIndexedSessionRepository.deleteById(sessionId));
 			LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(200));
 		}
 	}

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
@@ -65,9 +65,10 @@ public class TokenRemoveCmdExe {
 		if (StringExtUtils.isEmpty(token)) {
 			return;
 		}
-		OAuth2Authorization authorization = authorizationService.findByToken(token, OAuth2TokenType.ACCESS_TOKEN);
+		OAuth2Authorization authorization = authorizationService.findByToken(token.substring(7),
+				OAuth2TokenType.ACCESS_TOKEN);
 		if (ObjectUtils.isNotNull(authorization)) {
-			// 移除缓存
+			// 移除菜单缓存
 			evictCache(authorization);
 			// 删除token
 			authorizationService.remove(authorization);

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
@@ -39,8 +39,6 @@ import org.springframework.stereotype.Component;
 
 import java.security.Principal;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
 
 /**
  * 退出登录执行器.
@@ -90,7 +88,6 @@ public class TokenRemoveCmdExe {
 	private void evictCache(OAuth2Authorization authorization) {
 		if (authorization.getAttribute(Principal.class.getName()) instanceof OAuth2Authentication authentication) {
 			OperateType.getCache(redisCacheManager, NameConstants.USER_MENU).evict(authentication.id());
-			LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(200));
 		}
 		if (authorization
 			.getAttribute(Principal.class
@@ -102,7 +99,6 @@ public class TokenRemoveCmdExe {
 			Map<String, RedisIndexedSessionRepository.RedisSession> sessionMap = redisIndexedSessionRepository
 				.findByPrincipalName(user.getUsername());
 			sessionMap.forEach((sessionId, _) -> redisIndexedSessionRepository.deleteById(sessionId));
-			LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(200));
 		}
 	}
 

--- a/laokou-service/laokou-auth/laokou-auth-client/src/main/java/org/laokou/auth/dto/TokenRemoveCmd.java
+++ b/laokou-service/laokou-auth/laokou-auth-client/src/main/java/org/laokou/auth/dto/TokenRemoveCmd.java
@@ -17,7 +17,9 @@
 
 package org.laokou.auth.dto;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.laokou.common.i18n.dto.CommonCommand;
 
 /**
@@ -25,7 +27,9 @@ import org.laokou.common.i18n.dto.CommonCommand;
  *
  * @author laokou
  */
-@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class TokenRemoveCmd extends CommonCommand {
 
 	/**

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/pom.xml
@@ -147,6 +147,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-session-data-redis</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2ResourceServerConfig.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2ResourceServerConfig.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -61,13 +62,17 @@ class OAuth2ResourceServerConfig {
 			.csrf(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.rememberMe(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session
+				.sessionFixation().migrateSession()
+				.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+			)
 			// 自定义登录页面
 			// https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/form.html
 			// 登录页面 -> DefaultLoginPageGeneratingFilter
 			.formLogin(form -> form.loginPage("/login")
 				.permitAll())
 			// 清除 session
-			.logout(logout -> logout.clearAuthentication(true).invalidateHttpSession(true))
+			.logout(logout -> logout.logoutUrl("/logout").clearAuthentication(true).invalidateHttpSession(true))
 			.build();
 	}
 

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2ResourceServerConfig.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2ResourceServerConfig.java
@@ -27,6 +27,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.HeaderWriterLogoutHandler;
+import org.springframework.security.web.header.writers.ClearSiteDataHeaderWriter;
 
 /**
  * 资源服务器配置.
@@ -72,7 +74,10 @@ class OAuth2ResourceServerConfig {
 			.formLogin(form -> form.loginPage("/login")
 				.permitAll())
 			// 清除 session
-			.logout(logout -> logout.logoutUrl("/logout").clearAuthentication(true).invalidateHttpSession(true))
+			.logout(logout -> logout
+				.deleteCookies("JSESSIONID")
+				.addLogoutHandler(new HeaderWriterLogoutHandler(new ClearSiteDataHeaderWriter(ClearSiteDataHeaderWriter.Directive.COOKIES)))
+				.clearAuthentication(true).invalidateHttpSession(true))
 			.build();
 	}
 

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/java/org/laokou/auth/AuthApp.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/java/org/laokou/auth/AuthApp.java
@@ -31,7 +31,6 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.util.StopWatch;
 
 import java.net.InetAddress;
@@ -52,7 +51,6 @@ import java.security.NoSuchAlgorithmException;
 @EnableEncryptableProperties
 @EnableConfigurationProperties
 @EnableAspectJAutoProxy
-@EnableRedisHttpSession
 @SpringBootApplication(scanBasePackages = "org.laokou")
 class AuthApp {
 

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/java/org/laokou/auth/AuthApp.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/java/org/laokou/auth/AuthApp.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.util.StopWatch;
 
 import java.net.InetAddress;
@@ -51,6 +52,7 @@ import java.security.NoSuchAlgorithmException;
 @EnableEncryptableProperties
 @EnableConfigurationProperties
 @EnableAspectJAutoProxy
+@EnableRedisHttpSession
 @SpringBootApplication(scanBasePackages = "org.laokou")
 class AuthApp {
 

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application.yml
@@ -39,6 +39,12 @@ server:
   port: ${SERVER_PORT:1111}
   servlet:
     context-path: /api
+    session:
+      cookie:
+        same-site: none
+        secure: true
+        http-only: true
+      timeout: 30m
   tomcat:
     threads:
       # 工作线程池的最大线程数
@@ -173,8 +179,8 @@ spring:
               - /img/**=laokou-auth
               - /js/**=laokou-auth
             POST:
-              - /v1/captchas/send/mail=laokou-auth
-              - /v1/captchas/send/mobile=laokou-auth
+              - /v1/captchas/send-mail=laokou-auth
+              - /v1/captchas/send-mobile=laokou-auth
             DELETE:
               - /v1/tokens=laokou-auth
   cloud:
@@ -199,6 +205,12 @@ spring:
     configs:
       oss_resource:
         ttl: 5m
+  session:
+    timeout: 30m
+    data:
+      redis:
+        flush-mode: on-save
+        repository-type: indexed
 # actuator
 management:
   endpoints:

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/auth-flow.json
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/auth-flow.json
@@ -8,7 +8,7 @@
     "controlBehavior": 0
   },
   {
-    "resource": "/api/v1/captchas/send/mobile",
+    "resource": "/api/v1/captchas/send-mobile",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,
@@ -16,7 +16,7 @@
     "controlBehavior": 0
   },
   {
-    "resource": "/api/v1/captchas/send/mail",
+    "resource": "/api/v1/captchas/send-mail",
     "limitApp": "default",
     "count": 100000,
     "grade": 1,

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -46,7 +46,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.util.Assert;
@@ -97,8 +96,6 @@ class OAuth2ApiTest {
 	private final ServerProperties serverProperties;
 
 	private final RestClient restClient;
-
-	private final JwtDecoder jwtDecoder;
 
 	private final PasswordEncoder passwordEncoder;
 
@@ -265,8 +262,7 @@ class OAuth2ApiTest {
 	void test_logoutApi() {
 		log.info("---------- 登录已注销，开始清除令牌 ----------");
 		String apiUrl = getTokenUrlV3();
-		TokenRemoveCmd cmd = new TokenRemoveCmd();
-		cmd.setToken(TOKEN);
+		TokenRemoveCmd cmd = new TokenRemoveCmd(TOKEN);
 		restClient.method(HttpMethod.DELETE)
 			.uri(apiUrl)
 			.body(cmd)

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -487,12 +487,12 @@ class OAuth2ApiTest {
 
 	public String getSendMailCaptchaUrl() {
 		return getSchema(disabledSsl()) + "auth" + StringConstants.RISK + serverProperties.getPort()
-				+ "/api/v1/captchas/send/mail";
+				+ "/api/v1/captchas/send-mail";
 	}
 
 	public String getSendMobileCaptchaUrl() {
 		return getSchema(disabledSsl()) + "auth" + StringConstants.RISK + serverProperties.getPort()
-				+ "/api/v1/captchas/send/mobile";
+				+ "/api/v1/captchas/send-mobile";
 	}
 
 	private String getSchema(boolean disabled) {

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/测试验证码脚本.http
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/测试验证码脚本.http
@@ -1,4 +1,4 @@
-POST {{schema}}{{host}}/api/v1/captchas/send/mail
+POST {{schema}}{{host}}/api/v1/captchas/send-mail
 Content-Type: application/json
 
 {

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/src/main/resources/application.yml
@@ -171,8 +171,8 @@ spring:
               - /img/**=laokou-standalone-auth
               - /js/**=laokou-standalone-auth
             POST:
-              - /v1/captchas/send/mail=laokou-standalone-auth
-              - /v1/captchas/send/mobile=laokou-standalone-auth
+              - /v1/captchas/send-mail=laokou-standalone-auth
+              - /v1/captchas/send-mobile=laokou-standalone-auth
             DELETE:
               - /v1/tokens=laokou-standalone-auth
   cache:

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -87,59 +87,67 @@ const getRouters = (menus: any[]) => {
 	return routers;
 };
 
+const refreshTokenByAuthorizationCode = (refreshToken: string) => {
+	// 刷新令牌
+	refreshByAuthorizationCode({ refresh_token: refreshToken, grant_type: 'refresh_token' })
+		.then((res) => {
+			if (res.code === 'OK') {
+				// 清除令牌
+				clearToken();
+				// 存储令牌
+				setToken(
+					// @ts-ignore
+					"authorization_code",
+					res.data?.access_token,
+					res.data?.refresh_token,
+					res.data?.expires_in * 1000 + new Date().getTime(),
+				);
+				// 定时刷新令牌
+				// eslint-disable-next-line @typescript-eslint/no-use-before-define
+				scheduleRefreshToken().catch(console.log);
+			}
+		})
+		.finally(() => {
+			refreshTokenFlag = false;
+			// console.log('刷新令牌结束')
+		});
+}
+
+const refreshTokenByUsernamePassword = (refreshToken: string) => {
+	// 刷新令牌
+	refresh({ refresh_token: refreshToken, grant_type: 'refresh_token' })
+		.then((res) => {
+			if (res.code === 'OK') {
+				// 清除令牌
+				clearToken();
+				// 存储令牌
+				setToken(
+					// @ts-ignore
+					grantType,
+					res.data?.access_token,
+					res.data?.refresh_token,
+					res.data?.expires_in * 1000 + new Date().getTime(),
+				);
+				// 定时刷新令牌
+				// eslint-disable-next-line @typescript-eslint/no-use-before-define
+				scheduleRefreshToken().catch(console.log);
+			}
+		})
+		.finally(() => {
+			refreshTokenFlag = false;
+			// console.log('刷新令牌结束')
+		});
+}
+
 const refreshToken = async (refreshToken: string | null) => {
 	if (refreshToken && !refreshTokenFlag) {
 		// console.log('开始刷新令牌')
 		refreshTokenFlag = true;
 		const grantType = getGrantType();
 		if (grantType === "authorization_code") {
-			// 刷新令牌
-			refreshByAuthorizationCode({ refresh_token: refreshToken, grant_type: 'refresh_token' })
-				.then((res) => {
-					if (res.code === 'OK') {
-						// 清除令牌
-						clearToken();
-						// 存储令牌
-						setToken(
-							// @ts-ignore
-							"authorization_code",
-							res.data?.access_token,
-							res.data?.refresh_token,
-							res.data?.expires_in * 1000 + new Date().getTime(),
-						);
-						// 定时刷新令牌
-						// eslint-disable-next-line @typescript-eslint/no-use-before-define
-						scheduleRefreshToken().catch(console.log);
-					}
-				})
-				.finally(() => {
-					refreshTokenFlag = false;
-					// console.log('刷新令牌结束')
-				});
+			refreshTokenByAuthorizationCode(refreshToken)
 		} else {
-			// 刷新令牌
-			refresh({ refresh_token: refreshToken, grant_type: 'refresh_token' })
-				.then((res) => {
-					if (res.code === 'OK') {
-						// 清除令牌
-						clearToken();
-						// 存储令牌
-						setToken(
-							// @ts-ignore
-							grantType,
-							res.data?.access_token,
-							res.data?.refresh_token,
-							res.data?.expires_in * 1000 + new Date().getTime(),
-						);
-						// 定时刷新令牌
-						// eslint-disable-next-line @typescript-eslint/no-use-before-define
-						scheduleRefreshToken().catch(console.log);
-					}
-				})
-				.finally(() => {
-					refreshTokenFlag = false;
-					// console.log('刷新令牌结束')
-				});
+			refreshTokenByUsernamePassword(refreshToken)
 		}
 	}
 };
@@ -256,10 +264,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState }: any) => {
 										if (refreshTimeoutRef) {
 											clearTimeout(refreshTimeoutRef);
 										}
-										logout({
-											// @ts-ignore
-											token: getAccessToken(),
-										}).finally(() => {
+										logout().finally(() => {
 											clearToken();
 											history.push('/login');
 										});

--- a/ui/src/pages/Login/index.tsx
+++ b/ui/src/pages/Login/index.tsx
@@ -183,7 +183,7 @@ export default () => {
 		const code_verifier = 'kLuxodK9s4LWHEY8OklbjgdszkhYrNJ6may5BqreBhc';
 		const code_challenge = '324fId--lUav-XBoHqEsCNJl6RdCo6tUKQWtJJYXY40';
 		const code_challenge_method = 'S256';
-		window.location.href = `http://auth:1111/api/v1/oauth2/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&scope=${scope}&state=${state}&code_verifier=${code_verifier}&code_challenge=${code_challenge}&code_challenge_method=${code_challenge_method}`;
+		window.location.href = `http://127.0.0.1:1111/api/v1/oauth2/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&scope=${scope}&state=${state}&code_verifier=${code_verifier}&code_challenge=${code_challenge}&code_challenge_method=${code_challenge_method}`;
 	};
 
 	const getParamsByAuthorizationCode = (code: string) => {

--- a/ui/src/services/auth/auth.ts
+++ b/ui/src/services/auth/auth.ts
@@ -57,7 +57,6 @@ export async function refresh(
 
 /** 清除令牌 清除令牌 DELETE /api/v1/logouts */
 export async function logout(
-	body: API.LogoutParam,
 	options?: { [key: string]: any },
 ) {
 	return request<any>('/api-proxy/auth/api/v1/tokens', {
@@ -65,7 +64,6 @@ export async function logout(
 		headers: {
 			'Content-Type': 'application/json',
 		},
-		data: body,
 		...(options || {}),
 	});
 }

--- a/ui/src/services/auth/captcha.ts
+++ b/ui/src/services/auth/captcha.ts
@@ -21,7 +21,7 @@ export async function sendCaptcha(
 	requestId: string,
 	options?: { [key: string]: any },
 ) {
-	return request<any>(`/api-proxy/auth/api/v1/captchas/send/${type}`, {
+	return request<any>(`/api-proxy/auth/api/v1/captchas/send-${type}`, {
 		method: 'POST',
 		headers: {
 			'request-id': requestId,


### PR DESCRIPTION
## Summary by Sourcery

在 UI、网关和认证服务之间对齐认证、验证码和登出流程，同时收紧会话管理，并在用户登出时清理与用户相关的数据。

Bug 修复：
- 修复令牌撤销逻辑，从 `Authorization` 头中读取访问令牌，并在查询前正确去除 `bearer` 前缀。
- 确保用户菜单缓存、用户详情缓存以及基于 Redis 的会话在用户登出时被完全清除。
- 在后端、网关、UI 客户端以及 Sentinel/Nacos 配置中修正并统一验证码发送 API 路径。

功能增强：
- 重构前端令牌刷新逻辑，为不同授权模式拆分为独立函数，并简化登出调用的函数签名。
- 通过基于 Redis 的 Spring Session、严格的 Cookie 安全属性，以及显式的会话/登出处理（包括删除 Cookie 和设置 Clear-Site-Data 响应头）来强化会话管理。
- 移除缓存清理和令牌删除周边不必要的线程阻塞与异步注解，以精简登出行为。
- 更新本地 OAuth2 登录重定向目标为 `localhost`，以适配 UI 的登录流程。

文档：
- 迁移或更新归档的 OAuth2 文档文件，并新增归档目录的 `.gitignore` 以控制归档内容。

测试：
- 调整认证测试，通过构造函数来创建 `TokenRemoveCmd`，并使用更新后的验证码发送接口地址。

杂项：
- 在认证基础设施模块中添加 Spring Session Data Redis 依赖，用于集中式会话存储。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align authentication, captcha, and logout flows across UI, gateway, and auth services, while tightening session management and cleanup of user-related data on logout.

Bug Fixes:
- Fix token revocation to read the access token from the Authorization header and correctly strip the bearer prefix before lookup.
- Ensure user menu cache, user detail cache, and Redis-backed sessions are fully cleared when a user logs out.
- Correct and unify captcha send API paths in backend, gateway, UI client, and Sentinel/Nacos configuration.

Enhancements:
- Refactor frontend token refresh logic into dedicated functions for different grant types and simplify the logout call signature.
- Harden session management with Redis-backed Spring Session, secure cookie attributes, and explicit session/logout handling including cookie deletion and Clear-Site-Data headers.
- Remove unnecessary thread parking and async annotations around cache eviction and token removal to streamline logout behavior.
- Update local OAuth2 login redirect to target localhost for the UI login flow.

Documentation:
- Relocate or update archived OAuth2 documentation files and add an archive .gitignore to control archived content.

Tests:
- Adjust auth tests to construct TokenRemoveCmd via constructor and to use updated captcha send endpoint URLs.

Chores:
- Add Spring Session Data Redis dependency to the auth infrastructure module for centralized session storage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side HTTP session configuration with secure cookie attributes and 30-minute timeout
  * Enhanced logout flow with Clear-Site-Data header to clear cookies
  * Enabled Redis-backed session storage for improved session management

* **Bug Fixes**
  * Removed artificial delay in cache deletion operations for better performance

* **API Changes**
  * Updated captcha endpoints from `/v1/captchas/send/mail` and `/send/mobile` to `/v1/captchas/send-mail` and `/send-mobile`
  * Token removal now extracts credentials from Authorization header instead of request body

<!-- end of auto-generated comment: release notes by coderabbit.ai -->