### PR TITLE
fix: maven构建失败

### DIFF
--- a/laokou-common/laokou-common-redis/src/test/java/org/laokou/common/redis/util/RedisUtilsTest.java
+++ b/laokou-common/laokou-common-redis/src/test/java/org/laokou/common/redis/util/RedisUtilsTest.java
@@ -939,14 +939,13 @@ class RedisUtilsTest {
 		Object result = redisUtils.get(key);
 		// Note: Without type information in Jackson config, objects are deserialized as
 		// LinkedHashMap
-		Assertions.assertThat(result).isInstanceOf(Map.class);
+		Assertions.assertThat(result).isInstanceOf(TestUser.class);
 
-		@SuppressWarnings("unchecked")
-		Map<String, Object> retrievedUser = (Map<String, Object>) result;
-		Assertions.assertThat(retrievedUser.get("id")).isEqualTo(user.getId());
-		Assertions.assertThat(retrievedUser.get("name")).isEqualTo(user.getName());
-		Assertions.assertThat(retrievedUser.get("age")).isEqualTo(user.getAge());
-		Assertions.assertThat(retrievedUser.get("email")).isEqualTo(user.getEmail());
+		TestUser retrievedUser = (TestUser) result;
+		Assertions.assertThat(retrievedUser.id).isEqualTo(user.getId());
+		Assertions.assertThat(retrievedUser.name).isEqualTo(user.getName());
+		Assertions.assertThat(retrievedUser.age).isEqualTo(user.getAge());
+		Assertions.assertThat(retrievedUser.email).isEqualTo(user.getEmail());
 	}
 
 	@Test
@@ -962,12 +961,11 @@ class RedisUtilsTest {
 		Object result = redisUtils.hGet(key, field);
 		// Note: Without type information in Jackson config, objects are deserialized as
 		// LinkedHashMap
-		Assertions.assertThat(result).isInstanceOf(Map.class);
+		Assertions.assertThat(result).isInstanceOf(TestUser.class);
 
-		@SuppressWarnings("unchecked")
-		Map<String, Object> retrievedUser = (Map<String, Object>) result;
-		Assertions.assertThat(retrievedUser.get("id")).isEqualTo(user.getId());
-		Assertions.assertThat(retrievedUser.get("name")).isEqualTo(user.getName());
+		TestUser retrievedUser = (TestUser) result;
+		Assertions.assertThat(retrievedUser.id).isEqualTo(user.getId());
+		Assertions.assertThat(retrievedUser.name).isEqualTo(user.getName());
 	}
 
 	@Test
@@ -985,8 +983,8 @@ class RedisUtilsTest {
 		Assertions.assertThat(result).hasSize(2);
 		// Note: Without type information in Jackson config, objects are deserialized as
 		// LinkedHashMap
-		Assertions.assertThat(result.get(0)).isInstanceOf(Map.class);
-		Assertions.assertThat(result.get(1)).isInstanceOf(Map.class);
+		Assertions.assertThat(result.get(0)).isInstanceOf(TestUser.class);
+		Assertions.assertThat(result.get(1)).isInstanceOf(TestUser.class);
 	}
 
 	// ==================== Edge Cases and Error Scenarios ====================

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/TokenRemoveCmdExe.java
@@ -88,6 +88,7 @@ public class TokenRemoveCmdExe {
 	private void evictCache(OAuth2Authorization authorization) {
 		if (authorization.getAttribute(Principal.class.getName()) instanceof OAuth2Authentication authentication) {
 			OperateType.getCache(redisCacheManager, NameConstants.USER_MENU).evict(authentication.id());
+			return;
 		}
 		if (authorization
 			.getAttribute(Principal.class
@@ -98,7 +99,7 @@ public class TokenRemoveCmdExe {
 			redisUtils.del(RedisKeyUtils.getUserDetailKey(user.getUsername()));
 			Map<String, RedisIndexedSessionRepository.RedisSession> sessionMap = redisIndexedSessionRepository
 				.findByPrincipalName(user.getUsername());
-			sessionMap.forEach((sessionId, _) -> redisIndexedSessionRepository.deleteById(sessionId));
+			sessionMap.keySet().forEach(redisIndexedSessionRepository::deleteById);
 		}
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

针对带类型反序列化的 Redis 相关测试进行调整，并优化在移除令牌时的缓存清理逻辑。

Bug 修复：
- 确保 RedisUtils 的测试用例期望得到 `TestUser` 实例而不是通用的 `Map`，以与实际反序列化行为保持一致。
- 当基于 `OAuth2Authentication` principal 的缓存清理已成功执行时，通过提前返回来避免冗余的缓存清理逻辑。
- 通过在删除用户会话时直接遍历会话 ID 键，简化会话清理流程。

测试：
- 更新 RedisUtils 中关于复杂对象存储、哈希以及列表的测试，使其断言结果为 `TestUser` 实例而非 `Map`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Redis-related tests for typed deserialization and refine token removal cache eviction logic.

Bug Fixes:
- Ensure RedisUtils tests expect TestUser instances instead of generic Maps to align with actual deserialization behavior.
- Prevent redundant cache eviction logic by returning early when OAuth2Authentication principal-based eviction succeeds.
- Simplify session cleanup by iterating over session ID keys when deleting user sessions during token removal.

Tests:
- Update RedisUtils complex object storage, hash, and list tests to assert deserialization into TestUser instances rather than Maps.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. Internal updates include:

* **Tests**
  * Improved test assertions for object serialization validation.

* **Refactor**
  * Optimized cache eviction and session management efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->