### PR TITLE
fix: maven构建失败

### DIFF
--- a/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/util/RedisUtils.java
+++ b/laokou-common/laokou-common-redis/src/main/java/org/laokou/common/redis/util/RedisUtils.java
@@ -347,7 +347,7 @@ public record RedisUtils(RedisTemplate<String, Object> redisTemplate, RedissonCl
 		return dataMap;
 	}
 
-	public <T> T execute(@NonNull RedisScript<T> script, List<String> keys, Object... args) {
+	public Long execute(RedisScript<@NonNull Long> script, List<String> keys, Object... args) {
 		return redisTemplate.execute(script, keys, args);
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 解决由 `RedisUtils` 中不兼容或过于通用的 Redis 脚本执行方法签名导致的 Maven 构建失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve Maven build failure caused by an incompatible or overly generic Redis script execution method signature in RedisUtils.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced internal Redis utility to enforce stricter type validation, improving reliability and preventing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->