### PR TITLE
Dev

### DIFF
--- a/laokou-cloud/laokou-gateway/src/test/java/org/laokou/gateway/repository/NacosRouteDefinitionRepositoryTest.java
+++ b/laokou-cloud/laokou-gateway/src/test/java/org/laokou/gateway/repository/NacosRouteDefinitionRepositoryTest.java
@@ -55,7 +55,7 @@ import java.util.concurrent.Executors;
  */
 @Testcontainers
 @DisplayName("Nacos Route Definition Repository Tests")
-public class NacosRouteDefinitionRepositoryTest {
+class NacosRouteDefinitionRepositoryTest {
 
 	@Container
 	static NacosContainer nacosContainer = new NacosContainer(DockerImageNames.nacos(), 18848, 19848);

--- a/laokou-common/laokou-common-data-cache/pom.xml
+++ b/laokou-common/laokou-common-data-cache/pom.xml
@@ -75,6 +75,12 @@
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
## Summary by Sourcery

为数据缓存模块添加 Redis 测试依赖，并调整网关测试类的可见性以适配 JUnit 5。

Build:
- 在数据缓存模块中添加 `spring-boot-starter-data-redis`，作为可选的 test 范围依赖。

Tests:
- 更新 `NacosRouteDefinitionRepositoryTest`，将其可见性调整为包级私有，以符合 JUnit 5 的约定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Redis test dependency for the data cache module and adjust a gateway test class visibility for JUnit 5.

Build:
- Add spring-boot-starter-data-redis as an optional test-scoped dependency in the data cache module.

Tests:
- Update NacosRouteDefinitionRepositoryTest to use package-private visibility in line with JUnit 5 conventions.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Spring Boot Redis test dependency to improve test coverage for caching functionality
  * Refined test class visibility for better code organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->