### PR TITLE
feat: 升级go版本为1.26.2

### DIFF
--- a/KEdge-Gateway/go.mod
+++ b/KEdge-Gateway/go.mod
@@ -1,6 +1,6 @@
 module KEdge-Gateway
 
-go 1.24.2
+go 1.26.2
 
 require (
 	github.com/DeRuina/timberjack v1.4.1


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 将 `go.mod` 中的 Go 语言版本从 1.24.2 提升到 1.26.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump the Go language version in go.mod from 1.24.2 to 1.26.2.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement to 1.26.2 to align with current toolchain standards and ensure compatibility with the latest build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->