### PR TITLE
fix: nodejs构建报错

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,10 +24,7 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install UI
-        run: |
-          HUSKY=0 pnpm install
-          pnpm config set ignore-scripts false
-          pnpm run max setup
+        run: pnpm install --dangerously-allow-all-builds
         working-directory: ./ui
       - name: Build UI
         run: pnpm build
@@ -41,10 +38,7 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install BigScreen
-        run: |
-          HUSKY=0 pnpm install
-          pnpm config set ignore-scripts false
-          pnpm run max setup
+        run: pnpm install --dangerously-allow-all-builds
         working-directory: ./bigScreen
       - name: Build BigScreen
         run: pnpm build


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 更改 Node.js GitHub Actions 工作流中 UI 和 BigScreen 的 pnpm 安装步骤，使用带有构建许可的单一安装命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Change UI and BigScreen pnpm installation steps in the Node.js GitHub Actions workflow to use a single install command with build allowances.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow dependency installation process for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->