### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/SystemSettingsProperties.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/SystemSettingsProperties.java
@@ -50,4 +50,6 @@ public class SystemSettingsProperties implements Serializable {
 
 	private String tenantCode = "laokouyun";
 
+	private Long tenantValue = 1L;
+
 }

--- a/laokou-common/laokou-common-log4j2/src/test/java/org/laokou/common/log4j2/config/TtlThreadContextMapTest.java
+++ b/laokou-common/laokou-common-log4j2/src/test/java/org/laokou/common/log4j2/config/TtlThreadContextMapTest.java
@@ -164,9 +164,7 @@ class TtlThreadContextMapTest {
 	void testThreadLocalIsolation() {
 		contextMap.put("mainKey", "mainValue");
 
-		CompletableFuture.runAsync(() -> {
-			contextMap.put("childKey", "childValue");
-		}).join();
+		CompletableFuture.runAsync(() -> contextMap.put("childKey", "childValue")).join();
 
 		// Main thread should have its value (TTL transmits to child)
 		Assertions.assertThat(contextMap.get("mainKey")).isEqualTo("mainValue");

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/util/SqlUtils.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/util/SqlUtils.java
@@ -61,11 +61,26 @@ public class SqlUtils {
 		Object parameterObject = boundSql.getParameterObject();
 		MetaObject metaObject = ObjectUtils.isNotNull(parameterObject) ? SystemMetaObject.forObject(parameterObject)
 				: null;
+		int cursor = 0;
+		int estimatedCapacity = sql.length() + (parameterMappings.size() * 16);
+		StringBuilder resultSql = new StringBuilder(estimatedCapacity);
 		for (ParameterMapping parameterMapping : parameterMappings) {
 			Object value = getParameterValue(boundSql, parameterMapping, metaObject);
-			sql = sql.replaceFirst("\\?", Matcher.quoteReplacement(formatValue(value)));
+			String formattedValue = Matcher.quoteReplacement(formatValue(value));
+			int questionMarkIndex = sql.indexOf('?', cursor);
+			if (questionMarkIndex != -1) {
+				resultSql.append(sql, cursor, questionMarkIndex);
+				resultSql.append(formattedValue);
+				cursor = questionMarkIndex + 1;
+			}
+			else {
+				break;
+			}
 		}
-		return sql;
+		if (cursor < sql.length()) {
+			resultSql.append(sql, cursor, sql.length());
+		}
+		return resultSql.toString();
 	}
 
 	/**

--- a/laokou-service/laokou-network/laokou-network-domain/src/main/java/org/laokou/network/model/enums/MqttMessageType.java
+++ b/laokou-service/laokou-network/laokou-network-domain/src/main/java/org/laokou/network/model/enums/MqttMessageType.java
@@ -17,7 +17,10 @@
 
 package org.laokou.network.model.enums;
 
+import com.google.common.collect.Maps;
 import lombok.Getter;
+
+import java.util.Map;
 
 /***
  * mqtt消息类型枚举.
@@ -242,5 +245,14 @@ public enum MqttMessageType {
 	public abstract String getTopic();
 
 	public abstract String getMqTopic();
+
+	public static Map<String, Integer> getTopics(Long tenantId, Integer qos) {
+		MqttMessageType[] values = values();
+		Map<String, Integer> topics = Maps.newHashMapWithExpectedSize(values.length);
+		for (MqttMessageType messageType : values) {
+			topics.put(messageType.getTopic().replaceFirst("\\+", tenantId.toString()), qos);
+		}
+		return topics;
+	}
 
 }

--- a/laokou-service/laokou-network/laokou-network-domain/src/main/java/org/laokou/network/model/enums/MqttMessageType.java
+++ b/laokou-service/laokou-network/laokou-network-domain/src/main/java/org/laokou/network/model/enums/MqttMessageType.java
@@ -246,11 +246,16 @@ public enum MqttMessageType {
 
 	public abstract String getMqTopic();
 
+	private static final MqttMessageType[] VALUES = values();
+
 	public static Map<String, Integer> getTopics(Long tenantId, Integer qos) {
-		MqttMessageType[] values = values();
-		Map<String, Integer> topics = Maps.newHashMapWithExpectedSize(values.length);
-		for (MqttMessageType messageType : values) {
-			topics.put(messageType.getTopic().replaceFirst("\\+", tenantId.toString()), qos);
+		Map<String, Integer> topics = Maps.newHashMapWithExpectedSize(VALUES.length);
+		for (MqttMessageType messageType : VALUES) {
+			String topic = messageType.getTopic();
+			int plusIndex = topic.indexOf('+');
+			String replacedTopic = plusIndex >= 0
+					? topic.substring(0, plusIndex) + tenantId.toString() + topic.substring(plusIndex + 1) : topic;
+			topics.put(replacedTopic, qos);
 		}
 		return topics;
 	}

--- a/laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/network/config/mqtt/MqttClientProperties.java
+++ b/laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/network/config/mqtt/MqttClientProperties.java
@@ -18,10 +18,7 @@
 package org.laokou.network.config.mqtt;
 
 import lombok.Data;
-import org.laokou.common.core.util.MapUtils;
 import org.laokou.common.core.util.UUIDGenerator;
-
-import java.util.Map;
 
 /**
  * @author laokou
@@ -65,8 +62,6 @@ public class MqttClientProperties {
 	private long reconnectInterval = 1000;
 
 	private int reconnectAttempts = Integer.MAX_VALUE;
-
-	private Map<String, Integer> topics = MapUtils.newHashMap(0);
 
 	private int willQos = 1;
 

--- a/laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/network/config/mqtt/VertxMqttClient.java
+++ b/laokou-service/laokou-network/laokou-network-infrastructure/src/main/java/org/laokou/network/config/mqtt/VertxMqttClient.java
@@ -17,13 +17,16 @@
 
 package org.laokou.network.config.mqtt;
 
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.mqtt.MqttClient;
 import io.vertx.mqtt.MqttClientOptions;
 import lombok.extern.slf4j.Slf4j;
+import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.network.config.AbstractVertxService;
+import org.laokou.network.model.enums.MqttMessageType;
 import org.laokou.network.model.valueobject.MqttMessageV;
 import org.laokou.network.config.util.VertxMqttUtils;
 
@@ -47,13 +50,17 @@ final class VertxMqttClient extends AbstractVertxService<Void> {
 
 	private final AtomicBoolean disconnect;
 
-	VertxMqttClient(Vertx vertx, MqttClientProperties mqttClientProperties, List<MessageHandler> messageHandlers) {
+	private final SystemSettingsProperties systemSettingsProperties;
+
+	VertxMqttClient(Vertx vertx, MqttClientProperties mqttClientProperties, List<MessageHandler> messageHandlers,
+			SystemSettingsProperties systemSettingsProperties) {
 		super(vertx);
 		this.mqttClientOptions = getMqttClientOptions(mqttClientProperties);
 		this.mqttClientProperties = mqttClientProperties;
 		this.messageHandlers = messageHandlers;
 		this.mqttClient = init();
 		this.disconnect = new AtomicBoolean(false);
+		this.systemSettingsProperties = systemSettingsProperties;
 	}
 
 	@Override
@@ -135,7 +142,8 @@ final class VertxMqttClient extends AbstractVertxService<Void> {
 	}
 
 	private void subscribe() {
-		Map<String, Integer> topics = mqttClientProperties.getTopics();
+		Map<String, Integer> topics = MqttMessageType.getTopics(systemSettingsProperties.getTenantValue(),
+				MqttQoS.AT_MOST_ONCE.value());
 		mqttClient.subscribe(topics).onComplete(subscribeResult -> {
 			if (subscribeResult.succeeded()) {
 				log.info("【Vertx-MQTT-Client】 => MQTT订阅成功，主题: {}", String.join("、", topics.keySet()));


### PR DESCRIPTION
## Summary by Sourcery

使 MQTT 主题订阅与租户特定设置保持一致，并优化 SQL 参数替换性能。

新功能：
- 根据系统设置和消息类型，为每个租户动态生成 MQTT 订阅主题。

改进：
- 通过使用 `StringBuilder` 替换参数占位符，而不是重复使用正则表达式替换，来优化 SQL 重构。
- 优化 Vertx MQTT 客户端配置，从消息类型和租户设置中推导订阅主题，而不是使用静态客户端属性。
- 在系统设置中扩展数值型租户标识符，以支持感知租户的 MQTT 订阅。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align MQTT topic subscription with tenant-specific settings and optimize SQL parameter substitution performance.

New Features:
- Generate MQTT subscription topics dynamically per tenant based on system settings and message types.

Enhancements:
- Optimize SQL reconstruction by replacing parameter placeholders using a StringBuilder instead of repeated regex replacement.
- Refine Vertx MQTT client configuration to derive subscription topics from message types and tenant settings rather than static client properties.
- Extend system settings with a numeric tenant identifier to support tenant-aware MQTT subscriptions.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced MQTT message handling with tenant-aware topic subscriptions.

* **Configuration**
  * Added configurable tenant value to system settings (defaults to 1).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KouShenhai/KCloud-Platform-IoT/pull/6282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->