### PR TITLE
fix: maven报错

### DIFF
--- a/laokou-cloud/laokou-gateway/src/main/resources/router.json
+++ b/laokou-cloud/laokou-gateway/src/main/resources/router.json
@@ -114,8 +114,8 @@
     "order": 1
   },
   {
-    "id": "laokou-mqtt",
-    "uri": "lb://laokou-mqtt",
+    "id": "laokou-network",
+    "uri": "lb://laokou-network",
     "predicates": [
       {
         "name": "Path",

--- a/laokou-cloud/laokou-gateway/src/test/resources/router.json
+++ b/laokou-cloud/laokou-gateway/src/test/resources/router.json
@@ -114,44 +114,6 @@
     "order": 1
   },
   {
-    "id": "laokou-mqtt",
-    "uri": "lb://laokou-mqtt",
-    "predicates": [
-      {
-        "name": "Path",
-        "args": {
-          "pattern": "/api-gateway/network/**"
-        }
-      },
-      {
-        "name": "Weight",
-        "args": {
-          "_genkey_0": "network",
-          "_genkey_1": "100"
-        }
-      }
-    ],
-    "filters": [
-      {
-        "name": "StripPrefix",
-        "args": {
-          "parts": "2"
-        }
-      },
-      {
-        "name": "RewritePath",
-        "args": {
-          "_genkey_0": "/api-gateway/network/(?<path>.*)",
-          "_genkey_1": "/$\\{path}"
-        }
-      }
-    ],
-    "metadata": {
-      "version": "v1"
-    },
-    "order": 1
-  },
-  {
     "id": "laokou-generator",
     "uri": "lb://laokou-generator",
     "predicates": [

--- a/laokou-service/laokou-network/laokou-network-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-network/laokou-network-start/src/main/resources/application.yml
@@ -55,7 +55,7 @@ management:
         otlp:
           endpoint: http://otel-collector:4317/v1/traces
           compression: gzip
-          timeout: 5s
+          timeout: 10s
           transport: grpc
   metrics:
     tags:
@@ -66,7 +66,7 @@ logging:
 
 spring:
   application:
-    name: ${SERVICE_ID:laokou-mqtt}
+    name: ${SERVICE_ID:laokou-network}
   profiles:
     active: @PROFILE-ACTIVE@
   config:
@@ -77,70 +77,6 @@ spring:
       enabled: true
   lifecycle:
     timeout-per-shutdown-phase: "2m"
-  datasource:
-    dynamic:
-      p6spy: false
-      strict: true
-      datasource:
-        master:
-          type: com.zaxxer.hikari.HikariDataSource
-          driver-class-name: ${DS_DRIVER:org.postgresql.Driver}
-          url: jdbc:${DS_PLATFORM:postgresql}://${DS_HOST:postgresql}:${DS_PORT:5432}/kcloud_platform_iot?tcpKeepAlive=true&reWriteBatchedInserts=true&stringtype=unspecified&ApplicationName=laokou-mqtt&useSSL=false
-          username: ENC(l126CTjtLG8OkXRNs5aofcN96EQpbQmQorTqpnWFMvcysQLjNBEuX+9f6hLwdoEk)
-          password: ENC(BhsqlMbKjWVxPseo9OX8osLuL2Y4rWfGTyBRXaZTsAdzZ1Z4rBewBmoXjf2Hnu4o)
-          hikari:
-            connection-timeout: 180000
-            validation-timeout: 3000
-            idle-timeout: 180000
-            max-lifetime: 1800000
-            maximum-pool-size: 60
-            minimum-idle: 10
-            is-read-only: false
-        domain:
-          type: com.zaxxer.hikari.HikariDataSource
-          driver-class-name: ${DS_DRIVER:org.postgresql.Driver}
-          url: jdbc:${DS_PLATFORM:postgresql}://${DS_HOST:postgresql}:${DS_PORT:5432}/kcloud_platform_domain?tcpKeepAlive=true&reWriteBatchedInserts=true&stringtype=unspecified&ApplicationName=laokou-mqtt&useSSL=false
-          username: ENC(l126CTjtLG8OkXRNs5aofcN96EQpbQmQorTqpnWFMvcysQLjNBEuX+9f6hLwdoEk)
-          password: ENC(BhsqlMbKjWVxPseo9OX8osLuL2Y4rWfGTyBRXaZTsAdzZ1Z4rBewBmoXjf2Hnu4o)
-          hikari:
-            connection-timeout: 180000
-            validation-timeout: 3000
-            idle-timeout: 180000
-            max-lifetime: 1800000
-            maximum-pool-size: 60
-            minimum-idle: 10
-            is-read-only: false
-  data:
-    redis:
-      client-type: lettuce
-      host: redis
-      port: 6379
-      password: ENC(BhsqlMbKjWVxPseo9OX8osLuL2Y4rWfGTyBRXaZTsAdzZ1Z4rBewBmoXjf2Hnu4o)
-      connect-timeout: 60000ms
-      timeout: 60000ms
-      lettuce:
-        pool:
-          max-active: 1000
-          max-wait: 2m
-          max-idle: 500
-          min-idle: 200
-  redisson:
-    password: ${spring.data.redis.password}
-    node:
-      type: single
-      single:
-        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
-  security:
-    oauth2:
-      resource-server:
-        enabled: true
-        request-matcher:
-          ignore-patterns:
-            GET:
-              - /v3/api-docs/**=laokou-mqtt
-              - /actuator/**=laokou-mqtt
-              - /scalar/**=laokou-mqtt
-              - /favicon.svg=laokou-mqtt
   cloud:
     loadbalancer:
       nacos:


### PR DESCRIPTION
## Summary by Sourcery

使 laokou-network 服务配置与其实际角色保持一致，并通过移除未使用的基础设施配置来简化配置。

Bug 修复：
- 将 Spring 应用名从 laokou-mqtt 更正为 laokou-network，以避免服务配置不匹配。

增强项：
- 增大 OpenTelemetry trace exporter 的超时时间，以提升在收集器响应缓慢情况下的鲁棒性。
- 从 laokou-network 服务中移除数据库、Redis、Redisson 和 OAuth2 resource-server 配置，以避免不必要的依赖和配置复杂度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the laokou-network service configuration with its actual role and simplify it by removing unused infrastructure settings.

Bug Fixes:
- Correct the Spring application name to use laokou-network instead of laokou-mqtt to avoid mismatched service configuration.

Enhancements:
- Increase the OpenTelemetry trace exporter timeout to improve resilience to slow collector responses.
- Remove database, Redis, Redisson, and OAuth2 resource-server configuration from the laokou-network service to avoid unnecessary dependencies and configuration complexity.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Updated gateway routing to direct network API requests to the network service instead of the previous service target.
  * Streamlined network service configuration by consolidating settings and adjusting timeout parameters for improved stability.
  * Removed deprecated service references from test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->