### PR TITLE
Dev

### DIFF
--- a/doc/db/kcloud_platform.sql
+++ b/doc/db/kcloud_platform.sql
@@ -216,6 +216,7 @@ COMMENT ON INDEX "public"."sys_i18n_menu_code_name_idx" IS '编码_名称_唯一
 
 ALTER TABLE "public"."sys_i18n_menu" ADD CONSTRAINT "sys_i18n_menu_pkey" PRIMARY KEY ("id");
 
+INSERT INTO "public"."sys_i18n_menu" VALUES (8, 1, 1, '2026-03-07 12:06:37', '2026-03-07 12:06:37', 0, 0, 1, 1,  'menu.iot.device.thingModel', '物模型');
 INSERT INTO "public"."sys_i18n_menu" VALUES (10, 1, 1, '2026-03-07 12:06:37', '2026-03-07 12:06:37', 0, 0, 1, 1, 'menu.iot.device.productCategory', '产品类别');
 INSERT INTO "public"."sys_i18n_menu" VALUES (1, 1, 1, '2026-03-07 12:06:37', '2026-03-07 12:06:37', 0, 0, 1, 1,  'menu.sys', '系统管理');
 INSERT INTO "public"."sys_i18n_menu" VALUES (4, 1, 1, '2026-03-07 12:06:37', '2026-03-07 12:06:37', 0, 0, 1, 1,  'menu.sys.log.notice', '通知日志');
@@ -387,6 +388,12 @@ INSERT INTO "public"."sys_menu" VALUES (16, 1, 1, '2025-01-18 09:39:31', '2026-0
 INSERT INTO "public"."sys_menu" VALUES (15, 1, 1, '2025-01-18 09:38:58', '2026-05-29 01:22:57.821007', 0, 1, 1, 1, 12, NULL, 0, '产品', '/iot/device/product', NULL, 3, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (82, 1, 1, '2025-03-15 12:15:37.277552', '2025-03-15 12:15:37.278549', 0, 0, 1, 1, 31, 'sys:oss:upload', 1, '上传文件', NULL, NULL, 5, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (90, 1, 1, '2026-05-20 07:08:34', '2026-05-29 01:19:03.585621', 0, 2, 1, 1, 88, NULL, 0, 'API文档', '/sys/config/apiDoc', NULL, 2, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (14, 1, 1, '2025-01-18 09:37:53', '2026-05-29 01:22:42.9652', 0, 1, 1, 1, 12, NULL, 0, '物模型', '/iot/device/thingModel', NULL, 1, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (72, 1, 1, '2025-03-16 11:02:48.298633', '2025-03-16 11:02:48.298633', 0, 0, 1, 1, 14, 'iot:thing-model:detail', 1, '查看物模型', NULL, NULL, 1, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (73, 1, 1, '2025-03-16 11:02:24.689321', '2025-03-16 11:02:24.689321', 0, 0, 1, 1, 14, 'iot:thing-model:remove', 1, '删除物模型', NULL, NULL, 2, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (74, 1, 1, '2025-03-16 11:01:52.176027', '2025-03-16 11:18:56.079399', 0, 2, 1, 1, 14, 'iot:thing-model:modify', 1, '修改物模型', NULL, NULL, 3, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (75, 1, 1, '2025-03-16 11:01:31.000074', '2025-03-16 11:01:31.000074', 0, 0, 1, 1, 14, 'iot:thing-model:save', 1, '新增物模型', NULL, NULL, 4, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (76, 1, 1, '2025-03-16 11:00:58.755018', '2025-03-16 11:00:58.755018', 0, 0, 1, 1, 14, 'iot:thing-model:page', 1, '分页查询物模型列表', NULL, NULL, 5, 0, 0, NULL);
 
 -- ----------------------------
 -- -------------菜单套餐------------

--- a/doc/db/kcloud_platform.sql
+++ b/doc/db/kcloud_platform.sql
@@ -246,8 +246,7 @@ INSERT INTO "public"."sys_i18n_menu" VALUES (28, 1, 1, '2026-03-07 12:06:37', '2
 INSERT INTO "public"."sys_i18n_menu" VALUES (29, 1, 1, '2026-03-07 12:06:37', '2026-03-07 12:06:37', 0, 0, 1, 1, 'menu.sys.config.generator', '代码生成器');
 INSERT INTO "public"."sys_i18n_menu" VALUES (27, 1, 1, '2026-03-07 12:06:37', '2026-03-07 12:06:37', 0, 0, 1, 1, 'menu.sys.cluster', '集群管理');
 INSERT INTO "public"."sys_i18n_menu" VALUES (30, 1, 1, '2026-05-07 12:06:37', '2026-05-07 12:06:37', 0, 0, 1, 1, 'menu.sys.config.apiDoc', 'API文档');
-INSERT INTO "public"."sys_i18n_menu" VALUES (31, 1, 1, '2026-06-05 00:00:00', '2026-06-05 00:00:00', 0, 0, 1, 1, 'menu.network', '网络管理');
-INSERT INTO "public"."sys_i18n_menu" VALUES (32, 1, 1, '2026-06-05 00:00:00', '2026-06-05 00:00:00', 0, 0, 1, 1, 'menu.network.connection', '连接管理');
+INSERT INTO "public"."sys_i18n_menu" VALUES (32, 1, 1, '2026-06-05 00:00:00', '2026-06-05 00:00:00', 0, 0, 1, 1, 'menu.iot.network.connection', '网络连接');
 
 -- ----------------------------
 -- -------------菜单------------
@@ -302,7 +301,7 @@ COMMENT ON INDEX "public"."sys_menu_type_idx" IS '菜单类型_索引';
 INSERT INTO "public"."sys_menu" VALUES (33, 1, 1, '2025-01-21 05:19:17', '2025-01-21 05:19:20', 0, 0, 1, 1, 1, NULL, 0, '集群管理', '/sys/cluster', NULL, 3, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (19, 1, 1, '2025-01-21 05:19:17', '2026-05-29 01:19:54.280534', 0, 1, 1, 1, 17, NULL, 0, '部门', '/sys/permission/dept', NULL, 2, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (6, 1, 1, '2024-09-17 18:36:56', '2026-06-13 16:09:10.335754', 0, 1, 1, 1, 2, NULL, 0, '通知日志', '/sys/log/notice', '', 1, 0, 0, NULL);
-INSERT INTO "public"."sys_menu" VALUES (108, 1, 1, '2026-06-05 00:00:00', '2026-06-07 19:29:30.266887', 0, 1, 1, 1, 11, NULL, 0, '连接管理', '/iot/network/connection', NULL, 1, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (108, 1, 1, '2026-06-05 00:00:00', '2026-06-07 19:29:30.266887', 0, 1, 1, 1, 11, NULL, 0, '网络连接', '/iot/network/connection', NULL, 1, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (12, 1, 1, '2025-01-18 09:28:42', '2026-05-29 01:21:36.257117', 0, 1, 1, 1, 11, NULL, 0, '设备管理', '/iot/device', NULL, 1, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (13, 1, 1, '2025-01-18 09:30:03', '2026-05-29 01:23:03.948971', 0, 1, 1, 1, 12, NULL, 0, '设备', '/iot/device/index', NULL, 4, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (20, 1, 1, '2025-01-21 05:19:17', '2026-05-29 01:19:59.024113', 0, 1, 1, 1, 17, NULL, 0, '角色', '/sys/permission/role', NULL, 3, 0, 0, NULL);
@@ -394,6 +393,11 @@ INSERT INTO "public"."sys_menu" VALUES (73, 1, 1, '2025-03-16 11:02:24.689321', 
 INSERT INTO "public"."sys_menu" VALUES (74, 1, 1, '2025-03-16 11:01:52.176027', '2025-03-16 11:18:56.079399', 0, 2, 1, 1, 14, 'iot:thing-model:modify', 1, '修改物模型', NULL, NULL, 3, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (75, 1, 1, '2025-03-16 11:01:31.000074', '2025-03-16 11:01:31.000074', 0, 0, 1, 1, 14, 'iot:thing-model:save', 1, '新增物模型', NULL, NULL, 4, 0, 0, NULL);
 INSERT INTO "public"."sys_menu" VALUES (76, 1, 1, '2025-03-16 11:00:58.755018', '2025-03-16 11:00:58.755018', 0, 0, 1, 1, 14, 'iot:thing-model:page', 1, '分页查询物模型列表', NULL, NULL, 5, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (120, 1, 1, '2026-06-19 15:42:26.14658', '2026-06-19 15:42:26.31174', 0, 0, 1, 1, 29, 'sys:i18n-menu:detail', 1, '查看国际化菜单', NULL, NULL, 1, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (121, 1, 1, '2026-06-19 15:43:07.457194', '2026-06-19 15:43:07.4775', 0, 0, 1, 1, 29, 'sys:i18n-menu:remove', 1, '删除国际化菜单', NULL, NULL, 2, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (122, 1, 1, '2026-06-19 15:43:36.840718', '2026-06-19 15:43:58.433843', 0, 1, 1, 1, 29, 'sys:i18n-menu:modify', 1, '修改国际化菜单', NULL, NULL, 3, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (123, 1, 1, '2026-06-19 15:44:27.722691', '2026-06-19 15:44:27.741956', 0, 0, 1, 1, 29, 'sys:i18n-menu:save', 1, '新增国际化菜单', NULL, NULL, 4, 0, 0, NULL);
+INSERT INTO "public"."sys_menu" VALUES (124, 1, 1, '2026-06-19 15:45:03.403504', '2026-06-19 15:45:25.009303', 0, 1, 1, 1, 29, 'sys:i18n-menu:page', 1, '分页查询国际化菜单列表', NULL, NULL, 5, 0, 0, NULL);
 
 -- ----------------------------
 -- -------------菜单套餐------------

--- a/laokou-service/laokou-admin/laokou-admin-adapter/src/main/java/org/laokou/admin/web/RolesController.java
+++ b/laokou-service/laokou-admin/laokou-admin-adapter/src/main/java/org/laokou/admin/web/RolesController.java
@@ -25,6 +25,7 @@ import org.laokou.admin.role.api.RolesServiceI;
 import org.laokou.admin.role.dto.RoleExportCmd;
 import org.laokou.admin.role.dto.RoleGetQry;
 import org.laokou.admin.role.dto.RoleImportCmd;
+import org.laokou.admin.role.dto.RoleListQry;
 import org.laokou.admin.role.dto.RoleModifyAuthorityCmd;
 import org.laokou.admin.role.dto.RoleModifyCmd;
 import org.laokou.admin.role.dto.RolePageQry;
@@ -52,6 +53,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 /**
  * 角色管理控制器.
@@ -123,6 +126,13 @@ public class RolesController {
 	@Operation(summary = "分页查询角色列表", description = "分页查询角色列表")
 	public Result<Page<RoleCO>> pageRole(@Validated @RequestBody RolePageQry qry) {
 		return rolesServiceI.pageRole(qry);
+	}
+
+	@TraceLog
+	@PostMapping("/v1/roles/list")
+	@Operation(summary = "查询角色列表", description = "查询角色列表")
+	public Result<List<RoleCO>> listRole(@Validated @RequestBody RoleListQry qry) {
+		return rolesServiceI.listRole(qry);
 	}
 
 	@TraceLog

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptGetQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptGetQryExe.java
@@ -34,10 +34,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeptGetQryExe {
 
-	private final DeptMapper adminDeptMapper;
+	private final DeptMapper deptMapper;
 
 	public Result<DeptCO> execute(DeptGetQry qry) {
-		return Result.ok(DeptConvertor.toClientObject(adminDeptMapper.selectById(qry.getId())));
+		return Result.ok(DeptConvertor.toClientObject(deptMapper.selectById(qry.getId())));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptPageQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptPageQryExe.java
@@ -38,11 +38,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DeptPageQryExe {
 
-	private final DeptMapper adminDeptMapper;
+	private final DeptMapper deptMapper;
 
 	public Result<Page<DeptCO>> execute(DeptPageQry qry) {
-		List<DeptDO> list = adminDeptMapper.selectObjectPage(qry);
-		long total = adminDeptMapper.selectObjectCount(qry);
+		List<DeptDO> list = deptMapper.selectObjectPage(qry);
+		long total = deptMapper.selectObjectCount(qry);
 		return Result.ok(Page.create(DeptConvertor.toClientObjectList(list), total));
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptTreeListQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptTreeListQryExe.java
@@ -37,11 +37,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DeptTreeListQryExe {
 
-	private final DeptMapper adminDeptMapper;
+	private final DeptMapper deptMapper;
 
 	public Result<List<DeptTreeCO>> execute(DeptTreeListQry qry) {
-		DeptTreeCO co = TreeUtils
-			.buildTreeNode(DeptConvertor.toClientObjectList0(adminDeptMapper.selectObjectList(qry)), DeptTreeCO.class);
+		DeptTreeCO co = TreeUtils.buildTreeNode(DeptConvertor.toClientObjectList0(deptMapper.selectObjectList(qry)),
+				DeptTreeCO.class);
 		return Result.ok(co.getChildren());
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/command/query/MenuPageQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/command/query/MenuPageQryExe.java
@@ -38,11 +38,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MenuPageQryExe {
 
-	private final MenuMapper adminMenuMapper;
+	private final MenuMapper menuMapper;
 
 	public Result<Page<MenuCO>> execute(MenuPageQry qry) {
-		List<MenuDO> list = adminMenuMapper.selectObjectPage(qry);
-		long total = adminMenuMapper.selectObjectCount(qry);
+		List<MenuDO> list = menuMapper.selectObjectPage(qry);
+		long total = menuMapper.selectObjectCount(qry);
 		return Result.ok(Page.create(MenuConvertor.toClientObjects(list), total));
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/SystemMenuTree.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/SystemMenuTree.java
@@ -35,11 +35,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SystemMenuTree implements MenuTree {
 
-	private final MenuMapper adminMenuMapper;
+	private final MenuMapper menuMapper;
 
 	@Override
 	public MenuTreeCO build(MenuTreeListQry qry, Long userId) {
-		List<MenuDO> list = adminMenuMapper.selectObjectList(qry);
+		List<MenuDO> list = menuMapper.selectObjectList(qry);
 		return TreeUtils.buildTreeNode(MenuConvertor.toClientObjs(list), MenuTreeCO.class);
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/UserMenuTree.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/UserMenuTree.java
@@ -39,17 +39,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserMenuTree implements MenuTree {
 
-	private final MenuMapper adminMenuMapper;
+	private final MenuMapper menuMapper;
 
 	@Override
 	@DataCache(name = NameConstants.USER_MENU, key = "#userId", operateType = OperateType.GET)
 	public MenuTreeCO build(MenuTreeListQry qry, Long userId) {
 		List<MenuDO> list;
 		if (UserUtils.isSuperAdmin()) {
-			list = adminMenuMapper.selectAllMenuList();
+			list = menuMapper.selectAllMenuList();
 		}
 		else {
-			list = adminMenuMapper.selectMenuListByUserId(userId);
+			list = menuMapper.selectMenuListByUserId(userId);
 		}
 		return TreeUtils.buildTreeNode(MenuConvertor.toClientObjs(list), MenuTreeCO.class);
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/ModifyMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/ModifyMenuParamValidator.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ModifyMenuParamValidator implements MenuParamValidator {
 
-	private final MenuMapper adminMenuMapper;
+	private final MenuMapper menuMapper;
 
 	@Override
 	public void validateMenu(MenuA menuA) {
@@ -43,11 +43,11 @@ public class ModifyMenuParamValidator implements MenuParamValidator {
 				// 校验类型
 				org.laokou.admin.menu.service.validator.MenuParamValidator.validateType(menuA),
 				// 校验名称
-				org.laokou.admin.menu.service.validator.MenuParamValidator.validateName(menuA, adminMenuMapper),
+				org.laokou.admin.menu.service.validator.MenuParamValidator.validateName(menuA, menuMapper),
 				// 校验路径
-				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePath(menuA, adminMenuMapper),
+				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePath(menuA, menuMapper),
 				// 校验权限标识
-				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePermission(menuA, adminMenuMapper),
+				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePermission(menuA, menuMapper),
 				// 校验状态
 				org.laokou.admin.menu.service.validator.MenuParamValidator.validateStatus(menuA),
 				// 校验排序

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/SaveMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/menu/service/validator/SaveMenuParamValidator.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SaveMenuParamValidator implements MenuParamValidator {
 
-	private final MenuMapper adminMenuMapper;
+	private final MenuMapper menuMapper;
 
 	@Override
 	public void validateMenu(MenuA menuA) {
@@ -41,11 +41,11 @@ public class SaveMenuParamValidator implements MenuParamValidator {
 				// 校验类型
 				org.laokou.admin.menu.service.validator.MenuParamValidator.validateType(menuA),
 				// 校验名称
-				org.laokou.admin.menu.service.validator.MenuParamValidator.validateName(menuA, adminMenuMapper),
+				org.laokou.admin.menu.service.validator.MenuParamValidator.validateName(menuA, menuMapper),
 				// 校验路径
-				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePath(menuA, adminMenuMapper),
+				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePath(menuA, menuMapper),
 				// 校验权限标识
-				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePermission(menuA, adminMenuMapper),
+				org.laokou.admin.menu.service.validator.MenuParamValidator.validatePermission(menuA, menuMapper),
 				// 校验状态
 				org.laokou.admin.menu.service.validator.MenuParamValidator.validateStatus(menuA),
 				// 校验排序

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/command/query/RoleGetQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/command/query/RoleGetQryExe.java
@@ -36,14 +36,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RoleGetQryExe {
 
-	private final RoleMapper adminRoleMapper;
+	private final RoleMapper roleMapper;
 
 	private final RoleMenuMapper roleMenuMapper;
 
 	private final RoleDeptMapper roleDeptMapper;
 
 	public Result<RoleCO> execute(RoleGetQry qry) {
-		RoleCO roleCO = RoleConvertor.toClientObject(adminRoleMapper.selectById(qry.getId()));
+		RoleCO roleCO = RoleConvertor.toClientObject(roleMapper.selectById(qry.getId()));
 		roleCO.setMenuIds(roleMenuMapper.selectMenuIdsByRoleId(qry.getId()));
 		roleCO.setDeptIds(roleDeptMapper.selectDeptIdsByRoleId(qry.getId()));
 		return Result.ok(roleCO);

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/command/query/RoleListQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/command/query/RoleListQryExe.java
@@ -15,29 +15,34 @@
  *
  */
 
-package org.laokou.admin.menu.command.query;
+package org.laokou.admin.role.command.query;
 
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.RequiredArgsConstructor;
-import org.laokou.admin.menu.convertor.MenuConvertor;
-import org.laokou.admin.menu.dto.MenuGetQry;
-import org.laokou.admin.menu.dto.clientobject.MenuCO;
-import org.laokou.admin.menu.gatewayimpl.database.MenuMapper;
+import org.laokou.admin.role.convertor.RoleConvertor;
+import org.laokou.admin.role.dto.RoleListQry;
+import org.laokou.admin.role.dto.clientobject.RoleCO;
+import org.laokou.admin.role.gatewayimpl.database.RoleMapper;
+import org.laokou.admin.role.gatewayimpl.database.dataobject.RoleDO;
 import org.laokou.common.i18n.dto.Result;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
- * 查看菜单请求执行器.
+ * 查询角色请求执行器.
  *
  * @author laokou
  */
 @Component
 @RequiredArgsConstructor
-public class MenuGetQryExe {
+public class RoleListQryExe {
 
-	private final MenuMapper menuMapper;
+	private final RoleMapper roleMapper;
 
-	public Result<MenuCO> execute(MenuGetQry qry) {
-		return Result.ok(MenuConvertor.toClientObject(menuMapper.selectById(qry.getId())));
+	public Result<List<RoleCO>> execute(RoleListQry qry) {
+		List<RoleDO> list = roleMapper.selectList(Wrappers.lambdaQuery(RoleDO.class).orderByAsc(RoleDO::getSort));
+		return Result.ok(RoleConvertor.toClientObjects(list));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/command/query/RolePageQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/command/query/RolePageQryExe.java
@@ -38,11 +38,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RolePageQryExe {
 
-	private final RoleMapper adminRoleMapper;
+	private final RoleMapper roleMapper;
 
 	public Result<Page<RoleCO>> execute(RolePageQry qry) {
-		List<RoleDO> list = adminRoleMapper.selectObjectPage(qry);
-		long total = adminRoleMapper.selectObjectCount(qry);
+		List<RoleDO> list = roleMapper.selectObjectPage(qry);
+		long total = roleMapper.selectObjectCount(qry);
 		return Result.ok(Page.create(RoleConvertor.toClientObjects(list), total));
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/RolesServiceImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/RolesServiceImpl.java
@@ -26,10 +26,12 @@ import org.laokou.admin.role.command.RoleModifyCmdExe;
 import org.laokou.admin.role.command.RoleRemoveCmdExe;
 import org.laokou.admin.role.command.RoleSaveCmdExe;
 import org.laokou.admin.role.command.query.RoleGetQryExe;
+import org.laokou.admin.role.command.query.RoleListQryExe;
 import org.laokou.admin.role.command.query.RolePageQryExe;
 import org.laokou.admin.role.dto.RoleExportCmd;
 import org.laokou.admin.role.dto.RoleGetQry;
 import org.laokou.admin.role.dto.RoleImportCmd;
+import org.laokou.admin.role.dto.RoleListQry;
 import org.laokou.admin.role.dto.RoleModifyAuthorityCmd;
 import org.laokou.admin.role.dto.RoleModifyCmd;
 import org.laokou.admin.role.dto.RolePageQry;
@@ -39,6 +41,8 @@ import org.laokou.admin.role.dto.clientobject.RoleCO;
 import org.laokou.common.i18n.dto.Page;
 import org.laokou.common.i18n.dto.Result;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * 角色接口实现类.
@@ -64,6 +68,8 @@ public class RolesServiceImpl implements RolesServiceI {
 	private final RolePageQryExe rolePageQryExe;
 
 	private final RoleGetQryExe roleGetQryExe;
+
+	private final RoleListQryExe roleListQryExe;
 
 	@Override
 	public void saveRole(RoleSaveCmd cmd) {
@@ -98,6 +104,11 @@ public class RolesServiceImpl implements RolesServiceI {
 	@Override
 	public Result<Page<RoleCO>> pageRole(RolePageQry qry) {
 		return rolePageQryExe.execute(qry);
+	}
+
+	@Override
+	public Result<List<RoleCO>> listRole(RoleListQry qry) {
+		return roleListQryExe.execute(qry);
 	}
 
 	@Override

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/ModifyRoleParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/ModifyRoleParamValidator.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ModifyRoleParamValidator implements RoleParamValidator {
 
-	private final RoleMapper adminRoleMapper;
+	private final RoleMapper roleMapper;
 
 	@Override
 	public void validateRole(RoleA roleA) {
@@ -39,7 +39,7 @@ public class ModifyRoleParamValidator implements RoleParamValidator {
 				// 校验ID
 				org.laokou.admin.role.service.validator.RoleParamValidator.validateId(roleA),
 				// 校验名称
-				org.laokou.admin.role.service.validator.RoleParamValidator.validateName(roleA, adminRoleMapper),
+				org.laokou.admin.role.service.validator.RoleParamValidator.validateName(roleA, roleMapper),
 				// 校验排序
 				org.laokou.admin.role.service.validator.RoleParamValidator.validateSort(roleA));
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/SaveRoleParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/role/service/validator/SaveRoleParamValidator.java
@@ -31,13 +31,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SaveRoleParamValidator implements RoleParamValidator {
 
-	private final RoleMapper adminRoleMapper;
+	private final RoleMapper roleMapper;
 
 	@Override
 	public void validateRole(RoleA roleA) {
 		ParamValidator.validate(roleA.getValidateName(),
 				// 校验名称
-				org.laokou.admin.role.service.validator.RoleParamValidator.validateName(roleA, adminRoleMapper),
+				org.laokou.admin.role.service.validator.RoleParamValidator.validateName(roleA, roleMapper),
 				// 校验排序
 				org.laokou.admin.role.service.validator.RoleParamValidator.validateSort(roleA));
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/command/query/UserGetQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/command/query/UserGetQryExe.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserGetQryExe {
 
-	private final UserMapper adminUserMapper;
+	private final UserMapper userMapper;
 
 	private final UserRoleMapper userRoleMapper;
 
@@ -48,7 +48,7 @@ public class UserGetQryExe {
 
 	public Result<UserCO> execute(UserGetQry qry) throws Exception {
 		try {
-			UserCO userCO = UserConvertor.toClientObject(adminUserMapper.selectById(qry.getId()));
+			UserCO userCO = UserConvertor.toClientObject(userMapper.selectById(qry.getId()));
 			userCO.setRoleIds(userRoleMapper.selectRoleIdsByUserId(qry.getId()));
 			DynamicDataSourceContextHolder.push(DSConstants.DOMAIN);
 			OssLogDO ossLogDO = adminOssLogMapper.selectById(userCO.getAvatar());

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/command/query/UserPageQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/command/query/UserPageQryExe.java
@@ -40,11 +40,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserPageQryExe {
 
-	private final UserMapper adminUserMapper;
+	private final UserMapper userMapper;
 
 	public Result<Page<UserCO>> execute(UserPageQry qry) {
-		List<UserDO> list = adminUserMapper.selectObjectPage(qry);
-		long total = adminUserMapper.selectObjectCount(qry);
+		List<UserDO> list = userMapper.selectObjectPage(qry);
+		long total = userMapper.selectObjectCount(qry);
 		return Result.ok(Page.create(UserConvertor.toClientObjects(list), total));
 	}
 

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ModifyUserParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ModifyUserParamValidator.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ModifyUserParamValidator implements UserParamValidator {
 
-	private final UserMapper adminUserMapper;
+	private final UserMapper userMapper;
 
 	@Override
 	public void validateUser(UserA userA) throws Exception {
@@ -39,9 +39,9 @@ public class ModifyUserParamValidator implements UserParamValidator {
 				// 校验ID
 				org.laokou.admin.user.service.validator.UserParamValidator.validateId(userA),
 				// 校验邮箱
-				org.laokou.admin.user.service.validator.UserParamValidator.validateMail(userA, adminUserMapper, false),
+				org.laokou.admin.user.service.validator.UserParamValidator.validateMail(userA, userMapper, false),
 				// 校验手机号
-				org.laokou.admin.user.service.validator.UserParamValidator.validateMobile(userA, adminUserMapper),
+				org.laokou.admin.user.service.validator.UserParamValidator.validateMobile(userA, userMapper),
 				// 校验部门ID
 				org.laokou.admin.user.service.validator.UserParamValidator.validateDeptId(userA));
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ResetUserPwdParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/ResetUserPwdParamValidator.java
@@ -34,7 +34,7 @@ public class ResetUserPwdParamValidator implements UserParamValidator {
 
 	private final PasswordEncoder passwordEncoder;
 
-	private final UserMapper adminUserMapper;
+	private final UserMapper userMapper;
 
 	@Override
 	public void validateUser(UserA userA) {
@@ -43,7 +43,7 @@ public class ResetUserPwdParamValidator implements UserParamValidator {
 				org.laokou.admin.user.service.validator.UserParamValidator.validateId(userA),
 				// 校验密码
 				org.laokou.admin.user.service.validator.UserParamValidator.validatePassword(userA, passwordEncoder,
-						adminUserMapper, true));
+						userMapper, true));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/SaveUserParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/SaveUserParamValidator.java
@@ -31,20 +31,19 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SaveUserParamValidator implements UserParamValidator {
 
-	private final UserMapper adminUserMapper;
+	private final UserMapper userMapper;
 
 	@Override
 	public void validateUser(UserA userA) throws Exception {
 		ParamValidator.validate(userA.getValidateName(),
 				// 校验用户名
-				org.laokou.admin.user.service.validator.UserParamValidator.validateUsername(userA, adminUserMapper,
-						true),
+				org.laokou.admin.user.service.validator.UserParamValidator.validateUsername(userA, userMapper, true),
 				// 校验密码
 				org.laokou.admin.user.service.validator.UserParamValidator.validatePassword(userA, null, null, false),
 				// 校验邮箱
-				org.laokou.admin.user.service.validator.UserParamValidator.validateMail(userA, adminUserMapper, true),
+				org.laokou.admin.user.service.validator.UserParamValidator.validateMail(userA, userMapper, true),
 				// 校验手机号
-				org.laokou.admin.user.service.validator.UserParamValidator.validateMobile(userA, adminUserMapper),
+				org.laokou.admin.user.service.validator.UserParamValidator.validateMobile(userA, userMapper),
 				// 校验部门ID
 				org.laokou.admin.user.service.validator.UserParamValidator.validateDeptId(userA));
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/UserParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/user/service/validator/UserParamValidator.java
@@ -49,7 +49,7 @@ final class UserParamValidator {
 	}
 
 	public static ParamValidator.Validate validatePassword(UserA userA, PasswordEncoder passwordEncoder,
-			UserMapper adminUserMapper, boolean isResetPwd) {
+			UserMapper userMapper, boolean isResetPwd) {
 		String password = userA.getUserE().getPassword();
 		if (StringExtUtils.isEmpty(password)) {
 			return ParamValidator.invalidate("用户密码不能为空");
@@ -58,7 +58,7 @@ final class UserParamValidator {
 			return ParamValidator.invalidate("用户密码长度为6-30个字符");
 		}
 		if (isResetPwd) {
-			UserDO userDO = adminUserMapper.selectById(userA.getId());
+			UserDO userDO = userMapper.selectById(userA.getId());
 			if (ObjectUtils.isNull(userDO)) {
 				return ParamValidator.invalidate("用户不存在");
 			}
@@ -69,7 +69,7 @@ final class UserParamValidator {
 		return ParamValidator.validate();
 	}
 
-	public static ParamValidator.Validate validateUsername(UserA userA, UserMapper adminUserMapper, boolean isSave)
+	public static ParamValidator.Validate validateUsername(UserA userA, UserMapper userMapper, boolean isSave)
 			throws Exception {
 		String username = userA.getUserE().getUsername();
 		Long id = userA.getId();
@@ -83,11 +83,11 @@ final class UserParamValidator {
 		if (!RegexUtils.matches("^[A-Za-z]+$|^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]+$", username)) {
 			return ParamValidator.invalidate("用户名只能为大小写字母或大小写字母与数字的组合");
 		}
-		if (isSave && adminUserMapper
+		if (isSave && userMapper
 			.selectCount(Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getUsername, encryptUsername)) > 0) {
 			return ParamValidator.invalidate("用户名已存在");
 		}
-		if (!isSave && adminUserMapper.selectCount(Wrappers.lambdaQuery(UserDO.class)
+		if (!isSave && userMapper.selectCount(Wrappers.lambdaQuery(UserDO.class)
 			.eq(UserDO::getUsername, encryptUsername)
 			.ne(UserDO::getId, id)) > 0) {
 			return ParamValidator.invalidate("用户名已存在");
@@ -95,7 +95,7 @@ final class UserParamValidator {
 		return ParamValidator.validate();
 	}
 
-	public static ParamValidator.Validate validateMail(UserA userA, UserMapper adminUserMapper, boolean isSave)
+	public static ParamValidator.Validate validateMail(UserA userA, UserMapper userMapper, boolean isSave)
 			throws Exception {
 		String mail = userA.getUserE().getMail();
 		if (StringExtUtils.isNotEmpty(mail)) {
@@ -107,11 +107,11 @@ final class UserParamValidator {
 			}
 			Long id = userA.getId();
 			String encryptMail = AESUtils.encrypt(mail);
-			if (isSave && adminUserMapper
+			if (isSave && userMapper
 				.selectCount(Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getMail, encryptMail)) > 0) {
 				return ParamValidator.invalidate("用户邮箱已存在");
 			}
-			if (!isSave && adminUserMapper.selectCount(
+			if (!isSave && userMapper.selectCount(
 					Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getMail, encryptMail).ne(UserDO::getId, id)) > 0) {
 				return ParamValidator.invalidate("用户邮箱已存在");
 			}
@@ -119,7 +119,7 @@ final class UserParamValidator {
 		return ParamValidator.validate();
 	}
 
-	public static ParamValidator.Validate validateMobile(UserA userA, UserMapper adminUserMapper) throws Exception {
+	public static ParamValidator.Validate validateMobile(UserA userA, UserMapper userMapper) throws Exception {
 		String mobile = userA.getUserE().getMobile();
 		if (StringExtUtils.isNotEmpty(mobile)) {
 			if (!RegexUtils.mobileRegex(mobile)) {
@@ -127,11 +127,11 @@ final class UserParamValidator {
 			}
 			Long id = userA.getId();
 			String encryptMobile = AESUtils.encrypt(mobile);
-			if (userA.isSave() && adminUserMapper
+			if (userA.isSave() && userMapper
 				.selectCount(Wrappers.lambdaQuery(UserDO.class).eq(UserDO::getMobile, encryptMobile)) > 0) {
 				return ParamValidator.invalidate("用户手机号已存在");
 			}
-			if (userA.isModify() && adminUserMapper.selectCount(Wrappers.lambdaQuery(UserDO.class)
+			if (userA.isModify() && userMapper.selectCount(Wrappers.lambdaQuery(UserDO.class)
 				.eq(UserDO::getMobile, encryptMobile)
 				.ne(UserDO::getId, id)) > 0) {
 				return ParamValidator.invalidate("用户手机号已存在");

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/role/api/RolesServiceI.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/role/api/RolesServiceI.java
@@ -20,6 +20,7 @@ package org.laokou.admin.role.api;
 import org.laokou.admin.role.dto.RoleExportCmd;
 import org.laokou.admin.role.dto.RoleGetQry;
 import org.laokou.admin.role.dto.RoleImportCmd;
+import org.laokou.admin.role.dto.RoleListQry;
 import org.laokou.admin.role.dto.RoleModifyAuthorityCmd;
 import org.laokou.admin.role.dto.RoleModifyCmd;
 import org.laokou.admin.role.dto.RolePageQry;
@@ -28,6 +29,8 @@ import org.laokou.admin.role.dto.RoleSaveCmd;
 import org.laokou.admin.role.dto.clientobject.RoleCO;
 import org.laokou.common.i18n.dto.Page;
 import org.laokou.common.i18n.dto.Result;
+
+import java.util.List;
 
 /**
  * 角色接口.
@@ -77,6 +80,12 @@ public interface RolesServiceI {
 	 * @param qry 分页查询请求
 	 */
 	Result<Page<RoleCO>> pageRole(RolePageQry qry);
+
+	/**
+	 * 查询角色.
+	 * @param qry 查询请求
+	 */
+	Result<List<RoleCO>> listRole(RoleListQry qry);
 
 	/**
 	 * 查看角色.

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/role/dto/RoleListQry.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/role/dto/RoleListQry.java
@@ -15,29 +15,17 @@
  *
  */
 
-package org.laokou.admin.menu.command.query;
+package org.laokou.admin.role.dto;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.laokou.admin.menu.convertor.MenuConvertor;
-import org.laokou.admin.menu.dto.MenuGetQry;
-import org.laokou.admin.menu.dto.clientobject.MenuCO;
-import org.laokou.admin.menu.gatewayimpl.database.MenuMapper;
-import org.laokou.common.i18n.dto.Result;
-import org.springframework.stereotype.Component;
+import org.laokou.common.i18n.dto.CommonCommand;
 
 /**
- * 查看菜单请求执行器.
- *
  * @author laokou
  */
-@Component
+@Getter
 @RequiredArgsConstructor
-public class MenuGetQryExe {
-
-	private final MenuMapper menuMapper;
-
-	public Result<MenuCO> execute(MenuGetQry qry) {
-		return Result.ok(MenuConvertor.toClientObject(menuMapper.selectById(qry.getId())));
-	}
+public class RoleListQry extends CommonCommand {
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/ability/DeptDomainService.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/ability/DeptDomainService.java
@@ -31,18 +31,18 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeptDomainService {
 
-	private final DeptGateway adminDeptGateway;
+	private final DeptGateway deptGateway;
 
 	public void createDept(DeptA deptA) {
-		adminDeptGateway.createDept(deptA);
+		deptGateway.createDept(deptA);
 	}
 
 	public void updateDept(DeptA deptA) {
-		adminDeptGateway.updateDept(deptA);
+		deptGateway.updateDept(deptA);
 	}
 
 	public void deleteDept(Long[] ids) {
-		adminDeptGateway.deleteDept(ids);
+		deptGateway.deleteDept(ids);
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/menu/ability/MenuDomainService.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/menu/ability/MenuDomainService.java
@@ -31,18 +31,18 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MenuDomainService {
 
-	private final MenuGateway adminMenuGateway;
+	private final MenuGateway menuGateway;
 
 	public void createMenu(MenuA menuA) {
-		adminMenuGateway.createMenu(menuA);
+		menuGateway.createMenu(menuA);
 	}
 
 	public void updateMenu(MenuA menuA) {
-		adminMenuGateway.updateMenu(menuA);
+		menuGateway.updateMenu(menuA);
 	}
 
 	public void deleteMenu(Long[] ids) {
-		adminMenuGateway.deleteMenu(ids);
+		menuGateway.deleteMenu(ids);
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/role/ability/RoleDomainService.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/role/ability/RoleDomainService.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutorService;
 @RequiredArgsConstructor
 public class RoleDomainService {
 
-	private final RoleGateway adminRoleGateway;
+	private final RoleGateway roleGateway;
 
 	private final RoleMenuGateway roleMenuGateway;
 
@@ -47,18 +47,18 @@ public class RoleDomainService {
 	private final ExecutorService virtualTaskExecutor;
 
 	public void createRole(RoleA roleA) {
-		adminRoleGateway.createRole(roleA);
+		roleGateway.createRole(roleA);
 	}
 
 	public void updateRole(RoleA roleA) {
-		adminRoleGateway.updateRole(roleA);
+		roleGateway.updateRole(roleA);
 	}
 
 	public void updateAuthorityRole(RoleA roleA) throws InterruptedException {
 		roleA.checkRoleParam();
 		List<Callable<Boolean>> futures = new ArrayList<>(3);
 		futures.add(() -> {
-			adminRoleGateway.updateRole(roleA);
+			roleGateway.updateRole(roleA);
 			return true;
 		});
 		futures.add(() -> {
@@ -75,7 +75,7 @@ public class RoleDomainService {
 	public void deleteRole(Long[] ids) throws InterruptedException {
 		List<Callable<Boolean>> futures = new ArrayList<>(3);
 		futures.add(() -> {
-			adminRoleGateway.deleteRole(ids);
+			roleGateway.deleteRole(ids);
 			return true;
 		});
 		futures.add(() -> {

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/user/ability/UserDomainService.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/user/ability/UserDomainService.java
@@ -37,18 +37,18 @@ import java.util.concurrent.ExecutorService;
 @RequiredArgsConstructor
 public class UserDomainService {
 
-	private final UserGateway adminUserGateway;
+	private final UserGateway userGateway;
 
 	private final UserRoleGateway userRoleGateway;
 
 	private final ExecutorService virtualTaskExecutor;
 
 	public void createUser(UserA userA) {
-		adminUserGateway.createUser(userA);
+		userGateway.createUser(userA);
 	}
 
 	public void updateUser(UserA userA) {
-		adminUserGateway.updateUser(userA);
+		userGateway.updateUser(userA);
 	}
 
 	public void updateAuthorityUser(UserA userA) throws Exception {
@@ -63,7 +63,7 @@ public class UserDomainService {
 	public void deleteUser(Long[] ids) throws InterruptedException {
 		List<Callable<Boolean>> futures = new ArrayList<>(2);
 		futures.add(() -> {
-			adminUserGateway.deleteUser(ids);
+			userGateway.deleteUser(ids);
 			return true;
 		});
 		futures.add(() -> {

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/user/model/entity/UserE.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/user/model/entity/UserE.java
@@ -33,7 +33,7 @@ import java.util.List;
  *
  * @author laokou
  */
-@Entity("adminUserE")
+@Entity
 @Getter
 @Builder(toBuilder = true)
 @EqualsAndHashCode(callSuper = false)

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
@@ -32,27 +32,27 @@ import java.util.Arrays;
  *
  * @author laokou
  */
-@Component("adminDeptGateway")
+@Component
 @RequiredArgsConstructor
 public class DeptGatewayImpl implements DeptGateway {
 
-	private final DeptMapper adminDeptMapper;
+	private final DeptMapper deptMapper;
 
 	@Override
 	public void createDept(DeptA deptA) {
-		adminDeptMapper.insert(DeptConvertor.toDataObject(deptA));
+		deptMapper.insert(DeptConvertor.toDataObject(deptA));
 	}
 
 	@Override
 	public void updateDept(DeptA deptA) {
 		DeptDO deptDO = DeptConvertor.toDataObject(deptA);
-		deptDO.setVersion(adminDeptMapper.selectVersion(deptA.getId()));
-		adminDeptMapper.updateById(deptDO);
+		deptDO.setVersion(deptMapper.selectVersion(deptA.getId()));
+		deptMapper.updateById(deptDO);
 	}
 
 	@Override
 	public void deleteDept(Long[] ids) {
-		adminDeptMapper.deleteByIds(Arrays.asList(ids));
+		deptMapper.deleteByIds(Arrays.asList(ids));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/database/DeptMapper.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/database/DeptMapper.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Repository;
  * @author laokou
  */
 @Mapper
-@Repository("adminDeptMapper")
+@Repository
 public interface DeptMapper extends CrudMapper<Long, Integer, DeptDO> {
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/menu/gatewayimpl/MenuGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/menu/gatewayimpl/MenuGatewayImpl.java
@@ -32,27 +32,27 @@ import java.util.Arrays;
  *
  * @author laokou
  */
-@Component("adminMenuGateway")
+@Component
 @RequiredArgsConstructor
 public class MenuGatewayImpl implements MenuGateway {
 
-	private final MenuMapper adminMenuMapper;
+	private final MenuMapper menuMapper;
 
 	@Override
 	public void createMenu(MenuA menuA) {
-		adminMenuMapper.insert(MenuConvertor.toDataObject(menuA));
+		menuMapper.insert(MenuConvertor.toDataObject(menuA));
 	}
 
 	@Override
 	public void updateMenu(MenuA menuA) {
 		MenuDO menuDO = MenuConvertor.toDataObject(menuA);
-		menuDO.setVersion(adminMenuMapper.selectVersion(menuA.getId()));
-		adminMenuMapper.updateById(menuDO);
+		menuDO.setVersion(menuMapper.selectVersion(menuA.getId()));
+		menuMapper.updateById(menuDO);
 	}
 
 	@Override
 	public void deleteMenu(Long[] ids) {
-		adminMenuMapper.deleteByIds(Arrays.asList(ids));
+		menuMapper.deleteByIds(Arrays.asList(ids));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/menu/gatewayimpl/database/MenuMapper.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/menu/gatewayimpl/database/MenuMapper.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @author laokou
  */
 @Mapper
-@Repository("adminMenuMapper")
+@Repository
 public interface MenuMapper extends CrudMapper<Long, Integer, MenuDO> {
 
 	List<MenuDO> selectAllMenuList();

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/role/gatewayimpl/RoleGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/role/gatewayimpl/RoleGatewayImpl.java
@@ -33,32 +33,32 @@ import java.util.Arrays;
  * @author laokou
  */
 @Slf4j
-@Component("adminRoleGateway")
+@Component
 @RequiredArgsConstructor
 public class RoleGatewayImpl implements RoleGateway {
 
-	private final RoleMapper adminRoleMapper;
+	private final RoleMapper roleMapper;
 
 	@Override
 	public void createRole(RoleA roleA) {
 		RoleDO roleDO = RoleConvertor.toDataObject(roleA);
-		adminRoleMapper.insert(roleDO);
+		roleMapper.insert(roleDO);
 	}
 
 	@Override
 	public void updateRole(RoleA roleA) {
 		RoleDO roleDO = RoleConvertor.toDataObject(roleA);
 		roleDO.setVersion(getVersion(roleA.getId()));
-		adminRoleMapper.updateById(roleDO);
+		roleMapper.updateById(roleDO);
 	}
 
 	@Override
 	public void deleteRole(Long[] ids) {
-		adminRoleMapper.deleteByIds(Arrays.asList(ids));
+		roleMapper.deleteByIds(Arrays.asList(ids));
 	}
 
 	private Integer getVersion(Long id) {
-		return adminRoleMapper.selectVersion(id);
+		return roleMapper.selectVersion(id);
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/role/gatewayimpl/database/RoleMapper.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/role/gatewayimpl/database/RoleMapper.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Repository;
  * @author laokou
  */
 @Mapper
-@Repository("adminRoleMapper")
+@Repository
 public interface RoleMapper extends CrudMapper<Long, Integer, RoleDO> {
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/user/gatewayimpl/UserGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/user/gatewayimpl/UserGatewayImpl.java
@@ -33,28 +33,28 @@ import java.util.Arrays;
  * @author laokou
  */
 @Slf4j
-@Component("adminUserGateway")
+@Component
 @RequiredArgsConstructor
 public class UserGatewayImpl implements UserGateway {
 
-	private final UserMapper adminUserMapper;
+	private final UserMapper userMapper;
 
 	@Override
 	public void createUser(UserA userA) {
 		UserDO userDO = UserConvertor.toDataObject(userA);
-		adminUserMapper.insert(userDO);
+		userMapper.insert(userDO);
 	}
 
 	@Override
 	public void updateUser(UserA userA) {
 		UserDO userDO = UserConvertor.toDataObject(userA);
-		userDO.setVersion(adminUserMapper.selectVersion(userA.getId()));
-		adminUserMapper.updateById(userDO);
+		userDO.setVersion(userMapper.selectVersion(userA.getId()));
+		userMapper.updateById(userDO);
 	}
 
 	@Override
 	public void deleteUser(Long[] ids) {
-		adminUserMapper.deleteByIds(Arrays.asList(ids));
+		userMapper.deleteByIds(Arrays.asList(ids));
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/user/gatewayimpl/database/UserMapper.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/user/gatewayimpl/database/UserMapper.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Repository;
  * @author laokou
  */
 @Mapper
-@Repository("adminUserMapper")
+@Repository
 public interface UserMapper extends CrudMapper<Long, Integer, UserDO> {
 
 }

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/pom.xml
@@ -25,6 +25,12 @@
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-adapter</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.laokou</groupId>
+          <artifactId>laokou-common-grpc-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/design.md
+++ b/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The `/sys/base/dict` page is an Ant Design Pro workspace that already uses `ProTable`, `DrawerForm`, `useAccess`, and `useIntl` to manage dictionary types and dictionary items. It calls the existing admin services in `ui/src/services/admin/dict.ts` and `ui/src/services/admin/dictItem.ts`.
+
+The requested optimization is a frontend usability change: administrators should be able to manage dictionary types and the selected dictionary type's items in one page without changing REST APIs, backend behavior, database schema, menu permissions, or import/export contracts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Present dictionary types and dictionary items as a coordinated single-page master-detail workflow.
+- Keep the selected dictionary type visible and use it as the required context for item query, create, import, export, and delete operations.
+- Improve empty, disabled, loading, and selection states so item operations are clearly unavailable until a dictionary type is selected.
+- Preserve current permission checks and internationalized labels.
+- Keep the page responsive for desktop and smaller viewports.
+
+**Non-Goals:**
+
+- No backend API path, DTO, permission, or response contract changes.
+- No database migration, seed data migration, or menu/permission data change.
+- No new frontend dependency or global layout pattern.
+- No Kafka, WebSocket, SSE, or cross-service interaction changes.
+
+## Decisions
+
+### Decision: Keep the Existing Route, Services, and Drawers
+
+The implementation will keep `/sys/base/dict`, `DictDrawer`, `DictItemDrawer`, `pageDict`, `pageDictItem`, `importDict`, `importDictItem`, `exportDict`, and `exportDictItem`.
+
+Rationale: the change is an experience optimization, and the existing service layer already exposes all required dictionary and item operations. Keeping the contracts stable reduces rollout risk and preserves backward compatibility.
+
+Alternative considered: introduce a combined backend endpoint returning dictionary types and items together. This was rejected because the existing selection-driven item query is sufficient and avoids unnecessary backend coupling.
+
+### Decision: Use a Master-Detail Page Model
+
+Dictionary types will remain the master list. Selecting one dictionary type will update the selected state and reload the dictionary item table using `typeId`. The dictionary item area will show a clear selected-dictionary context and a guided empty state when nothing is selected.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant DictPage as /sys/base/dict
+    participant DictAPI as Dict API
+    participant ItemAPI as Dict Item API
+
+    User->>DictPage: Open page
+    DictPage->>DictAPI: POST /api/v1/dicts/page
+    DictAPI-->>DictPage: Dictionary type page
+    User->>DictPage: Select dictionary type
+    DictPage->>ItemAPI: POST /api/v1/dict-items/page with typeId
+    ItemAPI-->>DictPage: Dictionary item page
+    User->>DictPage: Create/edit/import/export item
+    DictPage->>ItemAPI: Existing item operation with selected typeId
+```
+
+Rationale: this matches the domain relationship between dictionary types and dictionary items and minimizes context switching.
+
+Alternative considered: use tabs or separate pages for type and item management. This was rejected because it hides the relationship and makes item maintenance slower.
+
+### Decision: Keep Permission Gates at Existing Operation Points
+
+The page will continue to use the existing `access.canDict*` and `access.canDictItem*` checks for table requests, toolbar actions, and row actions.
+
+Rationale: RBAC behavior is already centralized in `ui/src/access.ts`; changing it is out of scope and would increase security risk.
+
+### Decision: Treat Item Actions as Selection-Dependent
+
+Dictionary item create, delete, import, export, and query will be disabled or return an empty state until a dictionary type is selected. When creating a dictionary item, the selected dictionary type's `id` will be assigned as `typeId`.
+
+Rationale: dictionary items are invalid without a parent dictionary type. Making this dependency visible prevents accidental item operations and keeps export/import scoped.
+
+## Risks / Trade-offs
+
+- [Risk] Narrow two-column layouts can become cramped on smaller screens. → Mitigation: use responsive Ant Design grid behavior so the page stacks on small viewports and uses a wider item area on desktop.
+- [Risk] Selection can become stale after deleting or importing dictionary types. → Mitigation: clear selected dictionary state and item selections when dictionary type data changes, then reload both tables.
+- [Risk] Hidden permission actions may make the page appear empty for low-privilege users. → Mitigation: retain table empty states and permission-gated requests so users see read-only data when read permission exists and no unauthorized actions when it does not.
+- [Risk] Exporting items without a selected dictionary type could export unintended data. → Mitigation: keep item export disabled without selection and always include the selected `typeId`.
+
+## Migration Plan
+
+Deploy as a frontend-only change. No database migration, backend deployment, Kafka topic, or message format change is required.
+
+Rollback by reverting the modified frontend page and any related locale or style changes. Existing data, APIs, and permissions remain compatible.
+
+## Open Questions
+
+- None. The implementation can proceed using the existing API and permission model.

--- a/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/proposal.md
+++ b/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The current data dictionary page already contains dictionary type and dictionary item tables, but the management flow is still visually heavy and easy to lose context when switching between type-level and item-level operations. Optimizing it into a clearer single-page master-detail workspace will let administrators maintain dictionary types and their items together with fewer jumps and fewer accidental operations.
+
+## What Changes
+
+- Refine `ui/src/pages/Sys/Base/dict.tsx` into a single-page dictionary workspace where the left area manages dictionary types and the right area manages items for the selected dictionary type.
+- Keep the existing drawer-based create, view, and edit flows for dictionary types and dictionary items, while improving selection state, empty state, disabled states, and toolbar context.
+- Preserve existing import, export, delete, pagination, search, and permission-gated operations for both dictionary types and dictionary items.
+- Make dictionary item operations explicitly depend on the currently selected dictionary type, including item create/import/export/query behavior.
+- Improve responsive layout so the page remains usable on wide desktop screens and stacks predictably on smaller screens.
+- No API, database, or permission model changes are intended.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `data-dictionary`: Clarify the front-end requirement for managing dictionary types and dictionary items in one coordinated page with selection-driven item management.
+
+## Impact
+
+- Affected frontend code:
+  - `ui/src/pages/Sys/Base/dict.tsx`
+  - Existing drawer components may be reused as-is unless minor prop or context improvements are needed:
+    - `ui/src/pages/Sys/Base/DictDrawer.tsx`
+    - `ui/src/pages/Sys/Base/DictItemDrawer.tsx`
+- Affected services:
+  - Reuses existing `ui/src/services/admin/dict.ts`
+  - Reuses existing `ui/src/services/admin/dictItem.ts`
+- Affected specs:
+  - `openspec/specs/data-dictionary/spec.md`
+- Backward compatibility:
+  - Existing REST API paths, request payloads, response handling, permissions, and routes remain unchanged.
+- Database migration:
+  - No database schema or seed data migration is required.
+- Rollback plan:
+  - Revert the frontend page changes for `dict.tsx` and any related locale-only adjustments. Since APIs and database state are unchanged, rollback does not require data repair.

--- a/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/specs/data-dictionary/spec.md
+++ b/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/specs/data-dictionary/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: 数据字典前端工作台
+系统 SHALL 在 Umi Max 前端提供 `/sys/base/dict` 数据字典页面，并挂载到 `系统管理 / 基础数据 / 数据字典`。页面 MUST 使用 React 函数组件、TypeScript、Ant Design Pro 组件，复用 `ui/src/services/admin/dict.ts` 与 `ui/src/services/admin/dictItem.ts`，并遵循项目现有 `ProTable`、`DrawerForm`、`useAccess`、`useIntl` 模式。页面 SHALL 在同一个页面内提供字典类型和字典项的主从管理体验：字典类型作为主列表，字典项作为当前选中字典类型的明细列表；字典项查询、新增、删除、导入和导出 MUST 以当前选中字典类型为上下文。
+
+#### Scenario: 打开数据字典页面
+- **GIVEN** 当前用户可访问系统管理基础数据菜单
+- **WHEN** 用户进入 `/sys/base/dict`
+- **THEN** 前端 SHALL 展示字典类型列表和字典项管理区域
+- **AND** 前端 SHALL 在未选择字典类型时提示用户先选择字典类型
+
+#### Scenario: 选择字典类型后展示字典项
+- **GIVEN** 当前用户拥有 `read` scope、`sys:dict:page` 权限和 `sys:dict-item:page` 权限
+- **WHEN** 用户在字典类型列表中选择一个字典类型
+- **THEN** 前端 SHALL 记录当前选中字典类型
+- **AND** 前端 SHALL 使用该字典类型的 `id` 作为 `typeId` 查询字典项列表
+- **AND** 前端 SHALL 在字典项区域展示当前字典类型名称或标识
+
+#### Scenario: 页面按权限展示操作
+- **GIVEN** 当前用户仅拥有部分 `sys:dict:*` 或 `sys:dict-item:*` 权限
+- **WHEN** 前端渲染字典类型和字典项的工具栏及行操作
+- **THEN** 前端 MUST 只展示用户有权执行的新增、查看、修改、删除、导入、导出操作
+
+#### Scenario: 字典类型表单提交
+- **GIVEN** 用户打开新增或修改字典类型抽屉
+- **WHEN** 用户提交表单
+- **THEN** 前端 MUST 校验必填字段，新增时携带幂等请求标识，成功后关闭抽屉并刷新字典类型列表
+- **AND** 前端 SHALL 清理可能失效的选中字典类型和字典项选择状态
+
+#### Scenario: 字典项操作依赖选中字典类型
+- **GIVEN** 用户尚未选择字典类型
+- **WHEN** 前端渲染字典项新增、批量删除、导入或导出操作
+- **THEN** 前端 MUST 禁用这些操作或提示用户先选择字典类型
+- **AND** 前端 MUST NOT 发起缺少 `typeId` 的字典项查询、导入或导出请求
+
+#### Scenario: 字典项表单提交
+- **GIVEN** 用户已选择一个字典类型并打开新增或修改字典项抽屉
+- **WHEN** 用户提交字典项表单
+- **THEN** 前端 MUST 自动携带当前字典类型 `typeId`，成功后关闭抽屉并刷新当前字典项列表
+
+#### Scenario: 字典项导入导出限定当前字典类型
+- **GIVEN** 用户已选择一个字典类型并拥有对应导入或导出权限
+- **WHEN** 用户导入或导出字典项
+- **THEN** 前端 MUST 在请求中携带当前字典类型 `typeId`
+- **AND** 操作完成后前端 SHALL 刷新当前字典类型的字典项列表或保持当前查询上下文
+
+#### Scenario: 响应式管理布局
+- **GIVEN** 用户在不同宽度的浏览器中访问 `/sys/base/dict`
+- **WHEN** 前端渲染数据字典页面
+- **THEN** 页面 SHALL 在桌面宽度下同时展示字典类型和字典项管理区域
+- **AND** 页面 SHALL 在较窄宽度下保持表格、工具栏和抽屉操作可用且不遮挡关键内容

--- a/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/tasks.md
+++ b/openspec/changes/archive/2026-06-15-optimize-dict-single-page-management/tasks.md
@@ -1,0 +1,23 @@
+## 1. Frontend Review
+
+- [x] 1.1 Review `ui/src/pages/Sys/Base/dict.tsx` state, table columns, toolbar actions, and selection flow.
+- [x] 1.2 Review `DictDrawer` and `DictItemDrawer` props to confirm existing create, view, edit, and callback behavior can be reused.
+- [x] 1.3 Confirm existing locale keys and access flags cover the optimized single-page workflow.
+
+## 2. Frontend Implementation
+
+- [x] 2.1 Refactor `dict.tsx` state helpers so dictionary type selection, dictionary item selection, and reload behavior are explicit and easy to follow.
+- [x] 2.2 Optimize the page layout into a clear master-detail workspace with dictionary types on the left and current dictionary items on the right for desktop widths.
+- [x] 2.3 Improve the dictionary item empty state and toolbar context so users can see when no dictionary type is selected and which dictionary type is active.
+- [x] 2.4 Ensure dictionary item query, create, import, export, and delete actions are disabled or guarded when no dictionary type is selected.
+- [x] 2.5 Ensure dictionary type changes that can invalidate the selected type clear item selection and reload the affected tables.
+- [x] 2.6 Preserve existing permission checks for dictionary type and dictionary item table requests, toolbar buttons, and row actions.
+- [x] 2.7 Keep existing drawer forms, request IDs, import/export loading states, pagination, search filters, and service calls compatible with current APIs.
+
+## 3. Verification
+
+- [x] 3.1 Run the frontend type check, lint, or available validation command for the UI project.
+- [x] 3.2 Manually verify the page supports selecting a dictionary type and loading scoped dictionary items.
+- [x] 3.3 Manually verify item create, import, export, and delete actions are unavailable before selecting a dictionary type.
+- [x] 3.4 Manually verify authorized and unauthorized operations continue to follow existing `useAccess` permission checks.
+- [x] 3.5 Manually verify the page remains usable on desktop and narrow responsive widths.

--- a/openspec/specs/data-dictionary/spec.md
+++ b/openspec/specs/data-dictionary/spec.md
@@ -51,12 +51,20 @@
 - **THEN** 系统 MUST 拒绝请求并返回业务错误，不得产生歧义字典值
 
 ### Requirement: 数据字典前端工作台
-系统 SHALL 在 Umi Max 前端提供 `/sys/base/dict` 数据字典页面，并挂载到 `系统管理 / 基础数据 / 数据字典`。页面 MUST 使用 React 函数组件、TypeScript、Ant Design Pro 组件，复用 `ui/src/services/admin/dict.ts` 与 `ui/src/services/admin/dictItem.ts`，并遵循项目现有 `ProTable`、`DrawerForm`、`useAccess`、`useIntl` 模式。
+系统 SHALL 在 Umi Max 前端提供 `/sys/base/dict` 数据字典页面，并挂载到 `系统管理 / 基础数据 / 数据字典`。页面 MUST 使用 React 函数组件、TypeScript、Ant Design Pro 组件，复用 `ui/src/services/admin/dict.ts` 与 `ui/src/services/admin/dictItem.ts`，并遵循项目现有 `ProTable`、`DrawerForm`、`useAccess`、`useIntl` 模式。页面 SHALL 在同一个页面内提供字典类型和字典项的主从管理体验：字典类型作为主列表，字典项作为当前选中字典类型的明细列表；字典项查询、新增、删除、导入和导出 MUST 以当前选中字典类型为上下文。
 
 #### Scenario: 打开数据字典页面
 - **GIVEN** 当前用户可访问系统管理基础数据菜单
 - **WHEN** 用户进入 `/sys/base/dict`
-- **THEN** 前端 SHALL 展示字典类型列表，并在选择字典类型后展示对应字典项列表
+- **THEN** 前端 SHALL 展示字典类型列表和字典项管理区域
+- **AND** 前端 SHALL 在未选择字典类型时提示用户先选择字典类型
+
+#### Scenario: 选择字典类型后展示字典项
+- **GIVEN** 当前用户拥有 `read` scope、`sys:dict:page` 权限和 `sys:dict-item:page` 权限
+- **WHEN** 用户在字典类型列表中选择一个字典类型
+- **THEN** 前端 SHALL 记录当前选中字典类型
+- **AND** 前端 SHALL 使用该字典类型的 `id` 作为 `typeId` 查询字典项列表
+- **AND** 前端 SHALL 在字典项区域展示当前字典类型名称或标识
 
 #### Scenario: 页面按权限展示操作
 - **GIVEN** 当前用户仅拥有部分 `sys:dict:*` 或 `sys:dict-item:*` 权限
@@ -66,12 +74,31 @@
 #### Scenario: 字典类型表单提交
 - **GIVEN** 用户打开新增或修改字典类型抽屉
 - **WHEN** 用户提交表单
-- **THEN** 前端 MUST 校验必填字段，新增时携带幂等请求标识，成功后关闭抽屉并刷新列表
+- **THEN** 前端 MUST 校验必填字段，新增时携带幂等请求标识，成功后关闭抽屉并刷新字典类型列表
+- **AND** 前端 SHALL 清理可能失效的选中字典类型和字典项选择状态
+
+#### Scenario: 字典项操作依赖选中字典类型
+- **GIVEN** 用户尚未选择字典类型
+- **WHEN** 前端渲染字典项新增、批量删除、导入或导出操作
+- **THEN** 前端 MUST 禁用这些操作或提示用户先选择字典类型
+- **AND** 前端 MUST NOT 发起缺少 `typeId` 的字典项查询、导入或导出请求
 
 #### Scenario: 字典项表单提交
 - **GIVEN** 用户已选择一个字典类型并打开新增或修改字典项抽屉
 - **WHEN** 用户提交字典项表单
 - **THEN** 前端 MUST 自动携带当前字典类型 `typeId`，成功后关闭抽屉并刷新当前字典项列表
+
+#### Scenario: 字典项导入导出限定当前字典类型
+- **GIVEN** 用户已选择一个字典类型并拥有对应导入或导出权限
+- **WHEN** 用户导入或导出字典项
+- **THEN** 前端 MUST 在请求中携带当前字典类型 `typeId`
+- **AND** 操作完成后前端 SHALL 刷新当前字典类型的字典项列表或保持当前查询上下文
+
+#### Scenario: 响应式管理布局
+- **GIVEN** 用户在不同宽度的浏览器中访问 `/sys/base/dict`
+- **WHEN** 前端渲染数据字典页面
+- **THEN** 页面 SHALL 在桌面宽度下同时展示字典类型和字典项管理区域
+- **AND** 页面 SHALL 在较窄宽度下保持表格、工具栏和抽屉操作可用且不遮挡关键内容
 
 ### Requirement: 数据完整性与迁移
 系统 SHALL 保持现有 API 路径、表名和基础数据兼容。数据库变更 MUST 使用幂等迁移或初始化脚本维护 `sys_dict`、`sys_dict_item`、`sys_menu`、`sys_i18n_menu` 及权限数据，且生产环境不得直接手工修改 schema。

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <!-- taos-jdbcdriver版本 -->
     <taos-jdbcdriver.version>3.8.4</taos-jdbcdriver.version>
     <!-- fory版本 -->
-    <fory.version>1.2.0</fory.version>
+    <fory.version>1.1.0</fory.version>
     <!-- browscap-java版本 -->
     <browscap-java.version>1.5.1</browscap-java.version>
     <!-- flyway版本 -->

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -18,7 +18,5 @@ LABEL maintainer="laokou"
 LABEL description="ui"
 COPY dist /usr/share/nginx/dist
 COPY nginx/conf/nginx.conf /etc/nginx/nginx.conf
-COPY nginx/ssl/cert.pem /etc/nginx/ssl/cert.pem
-COPY nginx/ssl/key.pem /etc/nginx/ssl/key.pem
 EXPOSE 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/ui/config/routes.ts
+++ b/ui/config/routes.ts
@@ -182,6 +182,12 @@ export default [
 				path: '/iot/device',
 				routes: [
 					{
+						name: 'menu.iot.device.thingModel',
+						title: 'menu.iot.device.thingModel',
+						path: '/iot/device/thingModel',
+						component: './IoT/Device/thingModel',
+					},
+					{
 						name: 'menu.iot.device.productCategory',
 						title: 'menu.iot.device.productCategory',
 						path: '/iot/device/productCategory',

--- a/ui/src/locales/en-US.ts
+++ b/ui/src/locales/en-US.ts
@@ -613,7 +613,7 @@ export default {
 	'menu.iot.device.productCategory': 'Product Category',
 	'menu.iot.device.product': 'Products',
 	'menu.iot.device.device': 'Devices',
-	'menu.iot.network.connection': 'Connections',
+	'menu.iot.network.connection': 'Network Connection',
 	'menu.sys.tenant': 'Tenants',
 	'menu.sys.tenant.package': 'Packages',
 	'menu.sys.tenant.tenant': 'Tenants',

--- a/ui/src/locales/zh-CN.ts
+++ b/ui/src/locales/zh-CN.ts
@@ -613,7 +613,7 @@ export default {
 	'menu.iot.device.productCategory': '产品类别',
 	'menu.iot.device.product': '产品',
 	'menu.iot.device.device': '设备',
-	'menu.iot.network.connection': '连接管理',
+	'menu.iot.network.connection': '网络连接',
 	'menu.sys.tenant': '租户管理',
 	'menu.sys.tenant.package': '套餐',
 	'menu.sys.tenant.tenant': '租户',

--- a/ui/src/pages/IoT/Device/ThingModelDrawer.tsx
+++ b/ui/src/pages/IoT/Device/ThingModelDrawer.tsx
@@ -1,0 +1,406 @@
+import { modifyThingModel, saveThingModel } from '@/services/iot/thingModel';
+import { useIntl } from '@@/exports';
+import {
+	DrawerForm,
+	ProFormDigit,
+	ProFormSelect,
+	ProFormText,
+} from '@ant-design/pro-components';
+import { ProFormTextArea } from '@ant-design/pro-form';
+import { Col, message, Row } from 'antd';
+import React, { useState } from 'react';
+import { v7 as uuidV7 } from 'uuid';
+
+interface ThingModelDrawerProps {
+	modalVisit: boolean;
+	setModalVisit: (visible: boolean) => void;
+	title: string;
+	readOnly: boolean;
+	dataSource: TableColumns;
+	onComponent: () => void;
+	dataType: string;
+	setDataType: (type: string) => void;
+	requestId: string;
+	setRequestId: (requestId: string) => void;
+}
+
+type TableColumns = {
+	id: number;
+	code: string | undefined;
+	name: string | undefined;
+	sort: number | undefined;
+	dataType: string | undefined;
+	category: number | undefined;
+	type: string | undefined;
+	specs: string | undefined;
+	remark: string | undefined;
+	createTime: string | undefined;
+};
+
+export const ThingModelDrawer: React.FC<ThingModelDrawerProps> = ({
+																	  modalVisit,
+																	  setModalVisit,
+																	  title,
+																	  readOnly,
+																	  dataSource,
+																	  onComponent,
+																	  dataType,
+																	  setDataType,
+																	  requestId,
+																	  setRequestId,
+																  }) => {
+	const intl = useIntl();
+	const t = (id: string, values?: Record<string, any>) =>
+		intl.formatMessage({ id }, values);
+	const [loading, setLoading] = useState(false);
+
+	const getSpecs = (value: any) => {
+		switch (value.dataType) {
+			case 'integer':
+				return {
+					length: value.length,
+					unit: value.unit,
+				};
+			case 'decimal':
+				return {
+					integerLength: value.integerLength,
+					decimalLength: value.decimalLength,
+					unit: value.unit,
+				};
+			case 'boolean':
+				return {
+					trueText: value?.trueText,
+					falseText: value?.falseText,
+				};
+			case 'string':
+				return {
+					length: value.length,
+				};
+			default:
+				return {};
+		}
+	};
+
+	return (
+		<DrawerForm<TableColumns>
+			open={modalVisit}
+			title={title}
+			drawerProps={{
+				destroyOnClose: true,
+				closable: true,
+				maskClosable: true,
+			}}
+			initialValues={dataSource}
+			onOpenChange={setModalVisit}
+			autoFocusFirstInput
+			submitter={{
+				submitButtonProps: {
+					disabled: loading,
+					style: {
+						display: readOnly ? 'none' : 'inline-block',
+					},
+				},
+			}}
+			onFinish={async (value) => {
+				setLoading(true);
+				value.specs = JSON.stringify(getSpecs(value));
+				// @ts-ignore
+				value.type = value.type.join(',');
+				if (value.id === undefined) {
+					saveThingModel({ co: value }, requestId)
+						.then((res) => {
+							if (res.code === 'OK') {
+								message.success(t('toast.saveSuccess')).then();
+								setModalVisit(false);
+								onComponent();
+							}
+						})
+						.finally(() => {
+							setRequestId(uuidV7());
+							setLoading(false);
+						});
+				} else {
+					modifyThingModel({ co: value })
+						.then((res) => {
+							if (res.code === 'OK') {
+								message.success(t('toast.modifySuccess')).then();
+								setModalVisit(false);
+								onComponent();
+							}
+						})
+						.finally(() => {
+							setLoading(false);
+						});
+				}
+			}}
+		>
+			<ProFormText
+				disabled={loading}
+				name="id"
+				label="ID"
+				hidden={true}
+			/>
+
+			<ProFormText
+				disabled={loading}
+				readonly={readOnly}
+				name="code"
+				label={t('iot.thingModel.code')}
+				rules={[
+					{ required: true, message: t('iot.thingModel.required.code') },
+				]}
+			/>
+
+			<ProFormText
+				disabled={loading}
+				readonly={readOnly}
+				name="name"
+				label={t('iot.thingModel.name')}
+				rules={[
+					{ required: true, message: t('iot.thingModel.required.name') },
+				]}
+			/>
+
+			<ProFormSelect
+				disabled={loading}
+				name="category"
+				label={t('iot.thingModel.category')}
+				readonly={readOnly}
+				placeholder={t('iot.thingModel.placeholder.category')}
+				rules={[
+					{
+						required: true,
+						message: t('iot.thingModel.required.category'),
+					},
+				]}
+				options={[
+					{
+						value: 1,
+						label: t('iot.thingModel.category.property'),
+					},
+					{
+						value: 2,
+						label: t('iot.thingModel.category.event'),
+					},
+				]}
+			/>
+
+			<ProFormSelect
+				disabled={loading}
+				name="type"
+				label={t('iot.thingModel.type')}
+				mode={'multiple'}
+				readonly={readOnly}
+				placeholder={t('iot.thingModel.placeholder.type')}
+				rules={[
+					{ required: true, message: t('iot.thingModel.required.type') },
+				]}
+				options={[
+					{ value: 'read', label: t('iot.thingModel.type.read') },
+					{ value: 'write', label: t('iot.thingModel.type.write') },
+					{ value: 'report', label: t('iot.thingModel.type.report') },
+				]}
+			/>
+
+			<ProFormDigit
+				disabled={loading}
+				name="sort"
+				label={t('iot.thingModel.sort')}
+				readonly={readOnly}
+				placeholder={t('iot.thingModel.placeholder.sort')}
+				min={1}
+				max={99999}
+				rules={[
+					{ required: true, message: t('iot.thingModel.required.sort') },
+				]}
+			/>
+
+			<ProFormSelect
+				disabled={loading}
+				name="dataType"
+				label={t('iot.thingModel.dataType')}
+				readonly={readOnly}
+				placeholder={t('iot.thingModel.placeholder.dataType')}
+				rules={[
+					{
+						required: true,
+						message: t('iot.thingModel.required.dataType'),
+					},
+				]}
+				options={[
+					{
+						value: 'integer',
+						label: t('iot.thingModel.dataType.integer'),
+					},
+					{
+						value: 'decimal',
+						label: t('iot.thingModel.dataType.decimal'),
+					},
+					{
+						value: 'boolean',
+						label: t('iot.thingModel.dataType.boolean'),
+					},
+					{
+						value: 'string',
+						label: t('iot.thingModel.dataType.string'),
+					},
+				]}
+				onChange={setDataType}
+			/>
+
+			{dataType === 'string' && (
+				<ProFormText
+					disabled={loading}
+					readonly={readOnly}
+					name="length"
+					label={t('iot.thingModel.length')}
+					rules={[
+						{
+							required: true,
+							message: t('iot.thingModel.required.length'),
+						},
+						{
+							pattern: /^(2000|1\d{3}|[1-9]\d{0,2})$/,
+							message: t('iot.thingModel.validate.length1To2000'),
+						},
+					]}
+				/>
+			)}
+
+			{dataType === 'boolean' && (
+				<Row gutter={24}>
+					<Col span={12}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="trueText"
+							label={t('iot.thingModel.trueText')}
+							rules={[
+								{
+									required: true,
+									message: t('iot.thingModel.required.trueText'),
+								},
+							]}
+						/>
+					</Col>
+					<Col span={12}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="falseText"
+							label={t('iot.thingModel.falseText')}
+							rules={[
+								{
+									required: true,
+									message: t('iot.thingModel.required.falseText'),
+								},
+							]}
+						/>
+					</Col>
+				</Row>
+			)}
+
+			{dataType === 'integer' && (
+				<Row gutter={24}>
+					<Col span={12}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="length"
+							label={t('iot.thingModel.length')}
+							rules={[
+								{
+									required: true,
+									message: t('iot.thingModel.required.length'),
+								},
+								{
+									pattern: /^(8|16|32|64)$/,
+									message: t('iot.thingModel.validate.intLength'),
+								},
+							]}
+						/>
+					</Col>
+					<Col span={12}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="unit"
+							label={t('iot.thingModel.unit')}
+						/>
+					</Col>
+				</Row>
+			)}
+
+			{dataType === 'decimal' && (
+				<Row gutter={24}>
+					<Col span={8}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="integerLength"
+							label={t('iot.thingModel.integerLength')}
+							rules={[
+								{
+									required: true,
+									message: t('iot.thingModel.required.integerLength'),
+								},
+								{
+									pattern: /^([1-9]|[1-5][0-9]|6[0-4])$/,
+									message: t('iot.thingModel.validate.integerLength'),
+								},
+							]}
+						/>
+					</Col>
+					<Col span={8}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="decimalLength"
+							label={t('iot.thingModel.decimalLength')}
+							rules={[
+								{
+									required: true,
+									message: t('iot.thingModel.required.decimalLength'),
+								},
+								{
+									pattern: /^[1-4]$/,
+									message: t('iot.thingModel.validate.decimalLength'),
+								},
+							]}
+						/>
+					</Col>
+					<Col span={8}>
+						<ProFormText
+							disabled={loading}
+							readonly={readOnly}
+							name="unit"
+							label={t('iot.thingModel.unit')}
+						/>
+					</Col>
+				</Row>
+			)}
+
+			<ProFormTextArea
+				disabled={loading}
+				readonly={readOnly}
+				name="remark"
+				label={t('iot.thingModel.remark')}
+			/>
+
+			{readOnly && (
+				<ProFormText
+					disabled={loading}
+					readonly={true}
+					name="createTime"
+					rules={[
+						{
+							required: true,
+							message: t('sys.role.validate.createTimeRequired'),
+						},
+					]}
+					label={t('common.createTime')}
+				/>
+			)}
+		</DrawerForm>
+	);
+};

--- a/ui/src/pages/IoT/Device/thingModel.tsx
+++ b/ui/src/pages/IoT/Device/thingModel.tsx
@@ -1,0 +1,504 @@
+import { ThingModelDrawer } from '@/pages/IoT/Device/ThingModelDrawer';
+import {
+	getThingModelById,
+	pageThingModel,
+	removeThingModel,
+} from '@/services/iot/thingModel';
+import { trim } from '@/utils/format';
+import { useAccess, useIntl } from '@@/exports';
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { ProColumns, ProTable } from '@ant-design/pro-components';
+import type { ActionType } from '@ant-design/pro-components';
+import { Button, message, Modal, Space, Tag } from 'antd';
+import { TableRowSelection } from 'antd/es/table/interface';
+import { useRef, useState } from 'react';
+import { v7 as uuidV7 } from 'uuid';
+
+export default () => {
+	const access = useAccess();
+	const intl = useIntl();
+	const t = (id: string, values?: Record<string, any>) =>
+		intl.formatMessage({ id }, values);
+	const actionRef = useRef<ActionType | null>(null);
+	const [modalVisit, setModalVisit] = useState(false);
+	const [dataSource, setDataSource] = useState<any>({});
+	const [title, setTitle] = useState('');
+	const [readOnly, setReadOnly] = useState(false);
+	const [ids, setIds] = useState<any>([]);
+	const [dataType, setDataType] = useState('integer');
+	const [requestId, setRequestId] = useState('');
+
+	type TableColumns = {
+		id: number;
+		code: string | undefined;
+		name: string | undefined;
+		sort: number | undefined;
+		dataType: string | undefined;
+		category: number | undefined;
+		type: string | undefined;
+		specs: string | undefined;
+		remark: string | undefined;
+		createTime: string | undefined;
+	};
+
+	const getPageQueryParam = (params: any) => {
+		return {
+			pageSize: params?.pageSize,
+			pageNum: params?.current,
+			pageIndex: params?.pageSize * (params?.current - 1),
+			code: trim(params?.code),
+			name: trim(params?.name),
+			dataType: params?.dataType,
+			category: params?.category,
+			type: params?.typeValue ? params?.typeValue.join(',') : '',
+			params: {
+				startTime: params?.startDate
+					? `${params.startDate} 00:00:00`
+					: undefined,
+				endTime: params?.endDate
+					? `${params.endDate} 23:59:59`
+					: undefined,
+			},
+		};
+	};
+
+	const getData = (data: any) => {
+		const specs = JSON.parse(data?.specs);
+		data.length = specs?.length;
+		data.integerLength = specs?.integerLength;
+		data.decimalLength = specs?.decimalLength;
+		data.unit = specs?.unit;
+		data.trueText = specs?.trueText;
+		data.falseText = specs?.falseText;
+		data.type = data?.type?.split(',');
+		return data;
+	};
+
+	const rowSelection: TableRowSelection<TableColumns> = {
+		onChange: (selectedRowKeys) => {
+			const ids: number[] = [];
+			selectedRowKeys.forEach((item) => {
+				ids.push(item as number);
+			});
+			setIds(ids);
+		},
+	};
+
+	const columns: ProColumns<TableColumns>[] = [
+		{
+			title: t('common.number'),
+			dataIndex: 'index',
+			valueType: 'indexBorder',
+			width: 85,
+		},
+		{
+			title: t('iot.thingModel.code'),
+			dataIndex: 'code',
+			valueType: 'text',
+			ellipsis: true,
+			fieldProps: {
+				placeholder: t('iot.thingModel.placeholder.code'),
+			},
+		},
+		{
+			title: t('iot.thingModel.name'),
+			dataIndex: 'name',
+			valueType: 'text',
+			ellipsis: true,
+			fieldProps: {
+				placeholder: t('iot.thingModel.placeholder.name'),
+			},
+		},
+		{
+			title: t('iot.thingModel.dataType'),
+			key: 'dataType',
+			dataIndex: 'dataType',
+			valueType: 'select',
+			fieldProps: {
+				valueType: 'select',
+				mode: 'single',
+				placeholder: t('iot.thingModel.placeholder.dataType'),
+				options: [
+					{
+						value: 'integer',
+						label: t('iot.thingModel.dataType.integer'),
+					},
+					{
+						value: 'decimal',
+						label: t('iot.thingModel.dataType.decimal'),
+					},
+					{
+						value: 'boolean',
+						label: t('iot.thingModel.dataType.boolean'),
+					},
+					{
+						value: 'string',
+						label: t('iot.thingModel.dataType.string'),
+					},
+				],
+			},
+			ellipsis: true,
+		},
+		{
+			title: t('iot.thingModel.category'),
+			key: 'category',
+			dataIndex: 'category',
+			valueType: 'select',
+			fieldProps: {
+				valueType: 'select',
+				mode: 'single',
+				placeholder: t('iot.thingModel.placeholder.category'),
+				options: [
+					{
+						value: 1,
+						label: t('iot.thingModel.category.property'),
+					},
+					{
+						value: 2,
+						label: t('iot.thingModel.category.event'),
+					},
+				],
+			},
+			ellipsis: true,
+		},
+		{
+			title: t('iot.thingModel.type'),
+			key: 'typeValue',
+			dataIndex: 'typeValue',
+			valueType: 'select',
+			ellipsis: true,
+			hideInTable: true,
+			fieldProps: {
+				valueType: 'select',
+				mode: 'multiple',
+				placeholder: t('iot.thingModel.placeholder.type'),
+				options: [
+					{
+						value: 'read',
+						label: t('iot.thingModel.type.read'),
+					},
+					{
+						value: 'write',
+						label: t('iot.thingModel.type.write'),
+					},
+					{
+						value: 'report',
+						label: t('iot.thingModel.type.report'),
+					},
+				],
+			},
+		},
+		{
+			title: t('iot.thingModel.type'),
+			dataIndex: 'type',
+			disable: true,
+			hideInSearch: true,
+			renderFormItem: (_, { defaultRender }) => {
+				return defaultRender(_);
+			},
+			render: (_, record) => {
+				const element: any = [];
+				record?.type?.split(',').forEach((item) => {
+					if (item === 'read') {
+						element.push(
+							<Tag color={'green-inverse'} key={'read'}>
+								{t('iot.thingModel.type.read')}
+							</Tag>,
+						);
+					} else if (item === 'write') {
+						element.push(
+							<Tag color={'#fd5251'} key={'write'}>
+								{t('iot.thingModel.type.write')}
+							</Tag>,
+						);
+					} else if (item === 'report') {
+						element.push(
+							<Tag color={'#f4a300'} key={'report'}>
+								{t('iot.thingModel.type.report')}
+							</Tag>,
+						);
+					}
+				});
+				return <Space>{element}</Space>;
+			},
+		},
+		{
+			title: t('iot.thingModel.specs'),
+			dataIndex: 'specs',
+			valueType: 'text',
+			hideInSearch: true,
+			renderFormItem: (_, { defaultRender }) => {
+				return defaultRender(_);
+			},
+			render: (_, record) => {
+				const data = JSON.parse(
+					typeof record?.specs === 'string' ? record?.specs : '{}',
+				);
+				return (
+					<>
+						{(record?.dataType === 'integer' ||
+							record?.dataType === 'string') && (
+							<div>
+								{t('iot.thingModel.specs.length')}：
+								<span style={{ color: '#fd5251' }}>
+									{data?.length}
+								</span>
+							</div>
+						)}
+						{record?.dataType === 'decimal' && (
+							<div>
+								{t('iot.thingModel.specs.integerLength')}：
+								<span style={{ color: '#fd5251' }}>
+									{data?.integerLength}
+								</span>
+							</div>
+						)}
+						{record?.dataType === 'decimal' && (
+							<div>
+								{t('iot.thingModel.specs.decimalLength')}：
+								<span style={{ color: '#fd5251' }}>
+									{data?.decimalLength}
+								</span>
+							</div>
+						)}
+						{(record?.dataType === 'decimal' ||
+							record?.dataType === 'integer') && (
+							<div>
+								{t('iot.thingModel.specs.unit')}：
+								<span style={{ color: '#fd5251' }}>
+									{data?.unit ? data?.unit : t('common.none')}
+								</span>
+							</div>
+						)}
+						{record?.dataType === 'boolean' && (
+							<div>
+								0：
+								<span style={{ color: '#fd5251' }}>
+									{data?.falseText}
+								</span>
+							</div>
+						)}
+						{record?.dataType === 'boolean' && (
+							<div>
+								1：
+								<span style={{ color: '#fd5251' }}>
+									{data?.trueText}
+								</span>
+							</div>
+						)}
+					</>
+				);
+			},
+		},
+		{
+			title: t('common.createTime'),
+			key: 'createTime',
+			dataIndex: 'createTime',
+			valueType: 'dateTime',
+			hideInSearch: true,
+			width: 160,
+			ellipsis: true,
+		},
+		{
+			title: t('common.createTime'),
+			dataIndex: 'createTimeValue',
+			valueType: 'dateRange',
+			hideInTable: true,
+			fieldProps: {
+				placeholder: [t('common.selectStartTime'), t('common.selectEndTime')],
+			},
+			search: {
+				transform: (value) => {
+					return {
+						startDate: value[0],
+						endDate: value[1],
+					};
+				},
+			},
+		},
+		{
+			title: t('common.operation'),
+			valueType: 'option',
+			key: 'option',
+			render: (_, record) => [
+				access.canThingModelGetDetail && (
+					<a
+						key="get"
+						onClick={() => {
+							getThingModelById({ id: record?.id }).then(
+								(res) => {
+									setTitle(t('iot.thingModel.view'));
+									const data = getData(res?.data);
+									setDataSource(data);
+									setModalVisit(true);
+									setReadOnly(true);
+									setDataType(data?.dataType);
+								},
+							);
+						}}
+					>
+						{t('common.view')}
+					</a>
+				),
+				access.canThingModelModify && (
+					<a
+						key="modify"
+						onClick={() => {
+							getThingModelById({ id: record?.id }).then(
+								(res) => {
+									setTitle(t('iot.thingModel.modify'));
+									const data = getData(res?.data);
+									setDataSource(data);
+									setModalVisit(true);
+									setReadOnly(false);
+									setDataType(data?.dataType);
+								},
+							);
+						}}
+					>
+						{t('common.modify')}
+					</a>
+				),
+				access.canThingModelRemove && (
+					<a
+						key="remove"
+						onClick={() => {
+							Modal.confirm({
+								title: t('confirm.deleteTitle'),
+								content: t('confirm.deleteContent'),
+								okText: t('common.ok'),
+								cancelText: t('common.cancel'),
+								onOk: () => {
+									removeThingModel([record?.id]).then(
+										(res) => {
+											if (res.code === 'OK') {
+												message
+													.success(t('toast.deleteSuccess'))
+													.then();
+												// @ts-ignore
+												actionRef?.current?.reload();
+											}
+										},
+									);
+								},
+							});
+						}}
+					>
+						{t('common.delete')}
+					</a>
+				),
+			],
+		},
+	];
+
+	return (
+		<>
+			<ThingModelDrawer
+				modalVisit={modalVisit}
+				setModalVisit={setModalVisit}
+				title={title}
+				readOnly={readOnly}
+				dataSource={dataSource}
+				onComponent={async () => {
+					// @ts-ignore
+					actionRef?.current?.reload();
+				}}
+				setDataType={setDataType}
+				dataType={dataType}
+				requestId={requestId}
+				setRequestId={setRequestId}
+			/>
+
+			<ProTable<TableColumns>
+				actionRef={actionRef}
+				columns={columns}
+				request={async (params) => {
+					// 表单搜索项会从 params 传入，传递给后端接口。
+					return pageThingModel(getPageQueryParam(params)).then(
+						(res) => {
+							return Promise.resolve({
+								data: res?.data?.records,
+								total: parseInt(res?.data?.total || 0),
+								success: true,
+							});
+						},
+					);
+				}}
+				rowKey="id"
+				pagination={{
+					showQuickJumper: true,
+					showSizeChanger: false,
+					pageSize: 10,
+				}}
+				search={{
+					layout: 'vertical',
+					defaultCollapsed: true,
+				}}
+				rowSelection={{ ...rowSelection }}
+				toolBarRender={() => [
+					access.canThingModelSave && (
+						<Button
+							key="save"
+							type="primary"
+							icon={<PlusOutlined />}
+							onClick={() => {
+								setTitle(t('iot.thingModel.insert'));
+								setRequestId(uuidV7());
+								setReadOnly(false);
+								setModalVisit(true);
+								setDataSource({
+									id: undefined,
+									sort: 1,
+									dataType: 'integer',
+									category: 1,
+								});
+							}}
+						>
+							{t('common.insert')}
+						</Button>
+					),
+					access.canThingModelRemove && (
+						<Button
+							key="remove"
+							type="primary"
+							danger
+							icon={<DeleteOutlined />}
+							onClick={() => {
+								Modal.confirm({
+									title: t('confirm.deleteTitle'),
+									content: t('confirm.deleteContent'),
+									okText: t('common.ok'),
+									cancelText: t('common.cancel'),
+									onOk: async () => {
+										if (ids.length === 0) {
+											message
+												.warning(t('toast.selectAtLeastOne'))
+												.then();
+											return;
+										}
+										removeThingModel(ids).then((res) => {
+											if (res.code === 'OK') {
+												message
+													.success(t('toast.deleteSuccess'))
+													.then();
+												// @ts-ignore
+												actionRef?.current?.reload();
+											}
+										});
+									},
+								});
+							}}
+						>
+							{t('common.delete')}
+						</Button>
+					),
+				]}
+				dateFormatter="string"
+				toolbar={{
+					title: t('menu.iot.device.thingModel'),
+					tooltip: t('menu.iot.device.thingModel'),
+				}}
+			/>
+		</>
+	);
+};

--- a/ui/src/pages/IoT/Network/connection.tsx
+++ b/ui/src/pages/IoT/Network/connection.tsx
@@ -346,8 +346,8 @@ export default () => {
 				]}
 				dateFormatter="string"
 				toolbar={{
-					title: t('menu.network.connection'),
-					tooltip: t('menu.network.connection'),
+					title: t('menu.iot.network.connection'),
+					tooltip: t('menu.iot.network.connection'),
 				}}
 			/>
 		</>

--- a/ui/src/pages/Sys/Base/dict.tsx
+++ b/ui/src/pages/Sys/Base/dict.tsx
@@ -34,6 +34,7 @@ import {
 	Row,
 	Space,
 	Switch,
+	Typography,
 	Upload,
 } from 'antd';
 import type { TableRowSelection } from 'antd/es/table/interface';
@@ -70,6 +71,8 @@ export default () => {
 	const [dictItemParam, setDictItemParam] = useState<any>({});
 	const [dictItemExportLoading, setDictItemExportLoading] = useState(false);
 	const [dictItemImportLoading, setDictItemImportLoading] = useState(false);
+	const selectedDictId = selectedDict?.id;
+	const hasSelectedDict = !!selectedDictId;
 
 	const getDictPageQueryParam = (params: any) => {
 		const param = {
@@ -100,7 +103,7 @@ export default () => {
 			label: trim(params?.label),
 			value: trim(params?.value),
 			status: params?.statusValue,
-			typeId: selectedDict?.id,
+			typeId: selectedDictId,
 			params: {
 				startTime: params?.startDate
 					? `${params.startDate} 00:00:00`
@@ -122,29 +125,42 @@ export default () => {
 		dictItemActionRef?.current?.reload();
 	};
 
-	const refreshDictItemAfterDictChange = () => {
+	const reloadDictItemWithLatestSelection = () => {
+		setTimeout(() => {
+			reloadDictItem();
+		});
+	};
+
+	const clearDictSelection = () => {
 		setSelectedDict(undefined);
 		setDictIds([]);
 		setDictItemIds([]);
+		setDictItemParam({});
+	};
+
+	const selectDict = (record?: API.DictCO) => {
+		setSelectedDict(record);
+		setDictIds(record?.id ? [record.id] : []);
+		setDictItemIds([]);
+		reloadDictItemWithLatestSelection();
+	};
+
+	const refreshDictItemAfterDictChange = () => {
+		clearDictSelection();
 		reloadDict();
-		reloadDictItem();
+		reloadDictItemWithLatestSelection();
 	};
 
 	const dictRowSelection: TableRowSelection<API.DictCO> = {
-		selectedRowKeys: selectedDict?.id ? [selectedDict.id] : [],
+		selectedRowKeys: selectedDictId ? [selectedDictId] : [],
 		type: 'radio',
 		onChange: (_, selectedRows) => {
-			const record = selectedRows?.[0];
-			setSelectedDict(record);
-			setDictIds(record?.id ? [record.id] : []);
-			setDictItemIds([]);
-			setTimeout(() => {
-				reloadDictItem();
-			});
+			selectDict(selectedRows?.[0]);
 		},
 	};
 
 	const dictItemRowSelection: TableRowSelection<API.DictItemCO> = {
+		selectedRowKeys: dictItemIds,
 		onChange: (selectedRowKeys) => {
 			const ids: number[] = [];
 			selectedRowKeys.forEach((item) => {
@@ -220,12 +236,12 @@ export default () => {
 		showUploadList: false,
 		accept: '.xls,.xlsx',
 		beforeUpload: (file) => {
-			if (!selectedDict?.id) {
+			if (!selectedDictId) {
 				message.warning(t('sys.dictItem.selectDictFirst')).then();
 				return false;
 			}
 			setDictItemImportLoading(true);
-			importDictItem({ typeId: selectedDict.id }, [file])
+			importDictItem({ typeId: selectedDictId }, [file])
 				.then((res) => {
 					if (res.code === 'OK') {
 						message.success(t('toast.importSuccess')).then();
@@ -258,6 +274,36 @@ export default () => {
 		},
 		ellipsis: true,
 	});
+
+	const renderSelectedDictContext = () => {
+		if (!selectedDictId) {
+			return (
+				<Typography.Text key="selected" type="secondary">
+					{t('sys.dictItem.selectDictFirst')}
+				</Typography.Text>
+			);
+		}
+
+		return (
+			<Space key="selected" size={6} wrap>
+				<Typography.Text type="secondary">
+					{t('sys.dictItem.currentDict')}
+				</Typography.Text>
+				<Typography.Text
+					strong
+					ellipsis
+					style={{ display: 'inline-block', maxWidth: 180 }}
+				>
+					{selectedDict?.name || '-'}
+				</Typography.Text>
+				{selectedDict?.type && (
+					<Typography.Text type="secondary">
+						{selectedDict.type}
+					</Typography.Text>
+				)}
+			</Space>
+		);
+	};
 
 	const dictColumns: ProColumns<API.DictCO>[] = [
 		{
@@ -350,7 +396,8 @@ export default () => {
 				access.canDictGetDetail && (
 					<a
 						key="get"
-						onClick={() => {
+						onClick={(event) => {
+							event.stopPropagation();
 							getDictById({ id: record?.id as number }).then(
 								(res) => {
 									if (res.code === 'OK') {
@@ -369,7 +416,8 @@ export default () => {
 				access.canDictModify && (
 					<a
 						key="modify"
-						onClick={() => {
+						onClick={(event) => {
+							event.stopPropagation();
 							getDictById({ id: record?.id as number }).then(
 								(res) => {
 									if (res.code === 'OK') {
@@ -388,7 +436,8 @@ export default () => {
 				access.canDictRemove && (
 					<a
 						key="remove"
-						onClick={() => {
+						onClick={(event) => {
+							event.stopPropagation();
 							showDictRemoveConfirm([record?.id as number]);
 						}}
 					>
@@ -575,8 +624,8 @@ export default () => {
 					reloadDictItem();
 				}}
 			/>
-			<Row gutter={[16, 16]}>
-				<Col xs={24} xl={10}>
+			<Row gutter={[16, 16]} align="top">
+				<Col xs={24} xl={9} style={{ minWidth: 0 }}>
 					<ProTable<API.DictCO>
 						actionRef={dictActionRef}
 						columns={dictColumns}
@@ -599,7 +648,14 @@ export default () => {
 							);
 						}}
 						rowSelection={{ ...dictRowSelection }}
+						onRow={(record) => ({
+							onClick: () => {
+								selectDict(record);
+							},
+							style: { cursor: 'pointer' },
+						})}
 						rowKey="id"
+						scroll={{ x: 860 }}
 						pagination={{
 							showQuickJumper: true,
 							showSizeChanger: false,
@@ -680,12 +736,12 @@ export default () => {
 						}}
 					/>
 				</Col>
-				<Col xs={24} xl={14}>
+				<Col xs={24} xl={15} style={{ minWidth: 0 }}>
 					<ProTable<API.DictItemCO>
 						actionRef={dictItemActionRef}
 						columns={dictItemColumns}
 						request={async (params) => {
-							if (!selectedDict?.id || !access.canDictItemPage) {
+							if (!selectedDictId || !access.canDictItemPage) {
 								setDictItemParam({});
 								return Promise.resolve({
 									data: [],
@@ -705,6 +761,7 @@ export default () => {
 						}}
 						rowSelection={{ ...dictItemRowSelection }}
 						rowKey="id"
+						scroll={{ x: 1000 }}
 						pagination={{
 							showQuickJumper: true,
 							showSizeChanger: false,
@@ -727,18 +784,15 @@ export default () => {
 							),
 						}}
 						toolBarRender={() => [
-							<Space key="selected" size={4}>
-								<span>{t('sys.dictItem.currentDict')}</span>
-								<strong>{selectedDict?.name || '-'}</strong>
-							</Space>,
+							renderSelectedDictContext(),
 							access.canDictItemSave && (
 								<Button
 									key="save"
 									type="primary"
 									icon={<PlusOutlined />}
-									disabled={!selectedDict?.id}
+									disabled={!hasSelectedDict}
 									onClick={() => {
-										if (!selectedDict?.id) {
+										if (!selectedDictId) {
 											message
 												.warning(
 													t(
@@ -761,7 +815,7 @@ export default () => {
 											sort: 1,
 											remark: '',
 											status: 0,
-											typeId: selectedDict.id,
+											typeId: selectedDictId,
 										});
 									}}
 								>
@@ -774,7 +828,7 @@ export default () => {
 									type="primary"
 									danger
 									icon={<DeleteOutlined />}
-									disabled={!selectedDict?.id}
+									disabled={!hasSelectedDict}
 									onClick={() => {
 										showDictItemRemoveConfirm(dictItemIds);
 									}}
@@ -786,7 +840,7 @@ export default () => {
 								<Upload key="import" {...uploadDictItemProps}>
 									<Button
 										loading={dictItemImportLoading}
-										disabled={!selectedDict?.id}
+										disabled={!hasSelectedDict}
 										icon={<UploadOutlined />}
 									>
 										{t('common.import')}
@@ -798,11 +852,11 @@ export default () => {
 									key="export"
 									type="primary"
 									ghost
-									disabled={!selectedDict?.id}
+									disabled={!hasSelectedDict}
 									loading={dictItemExportLoading}
 									icon={<DownloadOutlined />}
 									onClick={() => {
-										if (!selectedDict?.id) {
+										if (!selectedDictId) {
 											message
 												.warning(
 													t(
@@ -815,7 +869,7 @@ export default () => {
 										setDictItemExportLoading(true);
 										exportDictItem({
 											...dictItemParam,
-											typeId: selectedDict.id,
+											typeId: selectedDictId,
 										}).finally(() => {
 											setDictItemExportLoading(false);
 										});
@@ -827,9 +881,14 @@ export default () => {
 						]}
 						dateFormatter="string"
 						toolbar={{
-							title: t('sys.dictItem.title'),
+							title: selectedDict?.name
+								? `${t('sys.dictItem.title')} - ${
+										selectedDict.name
+								  }`
+								: t('sys.dictItem.title'),
 							tooltip:
-								selectedDict?.type || t('sys.dictItem.title'),
+								selectedDict?.type ||
+								t('sys.dictItem.selectDictFirst'),
 						}}
 					/>
 				</Col>

--- a/ui/src/pages/Sys/Base/dict.tsx
+++ b/ui/src/pages/Sys/Base/dict.tsx
@@ -625,7 +625,7 @@ export default () => {
 				}}
 			/>
 			<Row gutter={[16, 16]} align="top">
-				<Col xs={24} xl={9} style={{ minWidth: 0 }}>
+				<Col xs={24} xl={12} style={{ minWidth: 0 }}>
 					<ProTable<API.DictCO>
 						actionRef={dictActionRef}
 						columns={dictColumns}
@@ -736,7 +736,7 @@ export default () => {
 						}}
 					/>
 				</Col>
-				<Col xs={24} xl={15} style={{ minWidth: 0 }}>
+				<Col xs={24} xl={12} style={{ minWidth: 0 }}>
 					<ProTable<API.DictItemCO>
 						actionRef={dictItemActionRef}
 						columns={dictItemColumns}

--- a/ui/src/pages/Sys/Permission/user.tsx
+++ b/ui/src/pages/Sys/Permission/user.tsx
@@ -2,7 +2,7 @@ import { UserDrawer } from '@/pages/Sys/Permission/UserDrawer';
 import { UserModifyAuthorityDrawer } from '@/pages/Sys/Permission/UserModifyAuthorityDrawer';
 import { UserResetPwdDrawer } from '@/pages/Sys/Permission/UserResetPwdDrawer';
 import { listSelectTreeDept } from '@/services/admin/dept';
-import { pageRole } from '@/services/admin/role';
+import {listRole, pageRole} from '@/services/admin/role';
 import { getUserById, pageUser, removeUser } from '@/services/admin/user';
 import { trim } from '@/utils/format';
 import { useAccess, useIntl } from '@@/exports';
@@ -53,8 +53,8 @@ export default () => {
 	};
 
 	const getRoleList = async () => {
-		pageRole({ pageSize: 10000, pageNum: 1, pageIndex: 0 }).then((res) => {
-			setRoleList(res?.data?.records);
+		listRole({}).then((res) => {
+			setRoleList(res?.data);
 		});
 	};
 

--- a/ui/src/services/admin/role.ts
+++ b/ui/src/services/admin/role.ts
@@ -128,6 +128,21 @@ export async function pageRole(
 	});
 }
 
+/** 查询角色列表 分页查询角色列表 POST /api/v1/roles/list */
+export async function listRole(
+	body: API.RoleListQry,
+	options?: { [key: string]: any },
+) {
+	return request<API.Result>('/api-proxy/admin/api/v1/roles/list', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		data: body,
+		...(options || {}),
+	});
+}
+
 /** 修改角色权限 修改角色权限 PUT /api/v1/roles/authority */
 export async function modifyRoleAuthority(
 	body: API.RoleModifyAuthorityCmd,

--- a/ui/src/services/admin/typings.d.ts
+++ b/ui/src/services/admin/typings.d.ts
@@ -315,6 +315,8 @@ declare namespace API {
 		params?: Record<string, any>;
 	};
 
+	type RoleListQry = NonNullable<unknown>;
+
 	type RoleSaveCmd = {
 		co?: RoleCO;
 	};


### PR DESCRIPTION
## Summary by Sourcery

优化数据字典单页管理用户体验，新增物联网物模型管理，引入无分页的角色列表，并简化管理员 mapper/gateway 命名，同时更新菜单、规范和构建配置。

New Features:
- 新增物联网物模型管理页面，使用抽屉式 CRUD 和校验逻辑，并接入物联网设备路由和权限体系。
- 提供无分页的角色列表 API 以及前端服务，用于在不带分页参数的情况下加载角色选项。

Bug Fixes:
- 通过对请求加上条件限制并禁用工具栏按钮，防止在未选择字典类型时执行字典条目相关操作。
- 通过控制事件传播，避免行级操作点击影响字典表格行的选中状态。
- 修复用户、菜单、角色和部门相关的校验/查询代码，使其一致使用重命名后的 mappers。

Enhancements:
- 将 `/sys/base/dict` 页面重构为主从（主详情）布局，提供更清晰的“已选字典”上下文、更安全的条目操作以及更好的响应式表现。
- 优化网络连接菜单命名和本地化配置，使其与物联网菜单结构保持一致。
- 通过移除 `admin*` 前缀并调整依赖的服务和校验器，简化管理员 gateway、mapper 和实体 bean 的命名。

Build:
- 从独立的 admin infrastructure adapter 依赖中排除 `laokou-common-grpc-client`，并下调 `fory` 库版本以保证兼容性。

Deployment:
- 调整 UI Docker 镜像，停止复制 TLS 证书/密钥文件，同时仍然开放 HTTPS 端口以支持外部的 TLS 终止。

Documentation:
- 扩展数据字典规范和变更文档，定义单页主从（主详情）用户体验以及响应式行为。
- 新增 OpenSpec 变更集，用于记录字典页面优化的设计、任务以及调整后的需求。

Chores:
- 初始化并调整菜单和 i18n 菜单相关 SQL，涵盖物联网物模型、物联网网络连接以及 i18n 菜单权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize data dictionary single-page management UX, add IoT Thing Model management, introduce non-paged role listing, and simplify admin mapper/gateway naming while updating menus, specs, and build config.

New Features:
- Add IoT Thing Model management page with drawer-based CRUD and validation, wired into IoT device routing and permissions.
- Expose a non-paginated role list API and frontend service for loading role options without page parameters.

Bug Fixes:
- Prevent dictionary item actions from running without a selected dictionary type by gating requests and disabling toolbar buttons.
- Stop row action clicks from interfering with dictionary row selection via event propagation control.
- Fix user, menu, role, and dept validation/query code to consistently use the renamed mappers.

Enhancements:
- Refine `/sys/base/dict` page into a master-detail layout with clearer selected-dictionary context, safer item operations, and better responsive behavior.
- Improve network connection menu naming and localization to align with IoT menu structure.
- Simplify admin gateway, mapper, and entity bean names by removing `admin*` prefixes and adjusting dependent services and validators.

Build:
- Exclude `laokou-common-grpc-client` from the standalone admin infrastructure adapter dependency and downgrade the `fory` library version for compatibility.

Deployment:
- Adjust UI Docker image to stop copying TLS cert/key files while still exposing HTTPS port for external TLS termination.

Documentation:
- Extend data dictionary spec and change docs to define the single-page master-detail UX and responsive behavior.
- Add OpenSpec change set documenting the dictionary page optimization design, tasks, and modified requirements.

Chores:
- Seed and adjust menu and i18n menu SQL for IoT Thing Model, IoT network connection, and i18n menu permissions.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added IoT Thing Model management for device model configuration
  * Enhanced dictionary management with master-detail single-page workflow

* **Improvements**
  * Updated network connection menu label to clarify navigation
  * Improved dictionary item operations to enforce type selection context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->