### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-security/pom.xml
+++ b/laokou-common/laokou-common-security/pom.xml
@@ -57,6 +57,10 @@
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <optional>true</optional>

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/CachedPrincipal.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/CachedPrincipal.java
@@ -15,28 +15,16 @@
  *
  */
 
-package org.laokou.common.security.filter;
+package org.laokou.common.security.config;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.jspecify.annotations.NonNull;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+
+import java.time.Instant;
 
 /**
- * 令牌拦截器.
- *
  * @author laokou
+ * @param principal 认证对象
+ * @param expiresAt 过期时间
  */
-@Order(Ordered.HIGHEST_PRECEDENCE + 1000)
-public final class TokenFilter extends OncePerRequestFilter {
-
-	@Override
-	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
-			@NonNull FilterChain chain) {
-
-	}
-
+record CachedPrincipal(OAuth2AuthenticatedPrincipal principal, Instant expiresAt) {
 }

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
@@ -17,6 +17,8 @@
 
 package org.laokou.common.security.config;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NonNull;
@@ -24,7 +26,6 @@ import org.laokou.common.context.util.OAuth2Authentication;
 import org.laokou.common.context.util.UserConvertor;
 import org.laokou.common.context.util.UserExtDetails;
 import org.laokou.common.i18n.common.exception.StatusCode;
-import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.RedisKeyUtils;
 import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.handler.OAuth2ExceptionHandler;
@@ -33,45 +34,83 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 
 import java.security.Principal;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author laokou
  */
 @Slf4j
-public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authorizationService,
-		RedisUtils redisUtils) implements OpaqueTokenIntrospector {
+public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authorizationService, RedisUtils redisUtils,
+		JwtDecoder jwtDecoder) implements OpaqueTokenIntrospector {
+
+	private static final Cache<@NonNull String, @NonNull CachedPrincipal> PRINCIPAL_CACHE = Caffeine.newBuilder()
+		.initialCapacity(100000)
+		.maximumSize(300000)
+		.expireAfterWrite(5, TimeUnit.MINUTES)
+		.build();
 
 	// @formatter:off
 	@NotNull
 	@Override
 	public OAuth2AuthenticatedPrincipal introspect(@NonNull String token) {
+		try {
+			CachedPrincipal cachedPrincipal = PRINCIPAL_CACHE.get(token, _ -> getCachedPrincipal(token));
+			Instant expiresAt = cachedPrincipal.expiresAt();
+			if (expiresAt != null && expiresAt.isBefore(Instant.now())) {
+				invalidate(token);
+				throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
+			}
+			return cachedPrincipal.principal();
+		} catch (Exception e) {
+			invalidate(token);
+			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
+		}
+	}
+
+	private CachedPrincipal getCachedPrincipal(@NonNull String token) {
+		Jwt jwt = jwtDecoder.decode(token);
+		Instant expiresAt = jwt.getExpiresAt();
+		if (expiresAt != null && expiresAt.isBefore(Instant.now())) {
+			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
+		}
 		OAuth2Authorization authorization = authorizationService.findByToken(token, OAuth2TokenType.ACCESS_TOKEN);
-		if (ObjectUtils.isNull(authorization)) {
+		if (authorization == null) {
 			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
 		}
 		OAuth2Authorization.Token<@NonNull OAuth2AccessToken> accessToken = authorization.getAccessToken();
 		OAuth2Authorization.Token<@NonNull OAuth2RefreshToken> refreshToken = authorization.getRefreshToken();
-		if (ObjectUtils.isNull(accessToken) || ObjectUtils.isNull(refreshToken)) {
+		if (accessToken == null || refreshToken == null) {
 			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
 		}
 		if (accessToken.isActive() && refreshToken.isActive()
 			&& authorization.getAttribute(Principal.class.getName()) instanceof OAuth2Authentication authentication) {
-			return UserConvertor.toPrincipal(authentication, authorization.getAuthorizedScopes());
+			return new CachedPrincipal(UserConvertor.toPrincipal(authentication, authorization.getAuthorizedScopes()), expiresAt);
 		}
 		if (accessToken.isActive() && refreshToken.isActive()
 			&& authorization.getAttribute(Principal.class.getName()) instanceof UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken
 			&& usernamePasswordAuthenticationToken.getPrincipal() instanceof User user
 			&& redisUtils.get(RedisKeyUtils.getUserDetailKey(user.getUsername())) instanceof UserExtDetails userExtDetails) {
-			return UserConvertor.toPrincipal(userExtDetails, authorization.getAuthorizedScopes());
+			return new CachedPrincipal(UserConvertor.toPrincipal(userExtDetails, authorization.getAuthorizedScopes()), expiresAt);
 		}
 		authorizationService.remove(authorization);
 		throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
+	}
+
+	private void invalidate(String token) {
+		PRINCIPAL_CACHE.invalidate(token);
+		OAuth2Authorization authorization = authorizationService.findByToken(token, OAuth2TokenType.ACCESS_TOKEN);
+		if (authorization != null) {
+			authorizationService.remove(authorization);
+		}
 	}
 	// @formatter:on
 

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
@@ -47,11 +48,14 @@ class OAuth2OpaqueTokenIntrospectorTest {
 	@Mock
 	private RedisUtils redisUtils;
 
+	@Mock
+	private JwtDecoder jwtDecoder;
+
 	@Test
 	void test_introspect_throws_exception_when_authorization_is_null() {
 		// Given
-		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService,
-				redisUtils);
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
+				jwtDecoder);
 		Mockito.when(authorizationService.findByToken("invalid-token", OAuth2TokenType.ACCESS_TOKEN)).thenReturn(null);
 
 		// Then
@@ -61,8 +65,8 @@ class OAuth2OpaqueTokenIntrospectorTest {
 	@Test
 	void test_introspect_throws_exception_when_accessToken_is_null() {
 		// Given
-		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService,
-				redisUtils);
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
+				jwtDecoder);
 		RegisteredClient registeredClient = createRegisteredClient();
 		OAuth2Authorization authorization = OAuth2Authorization.withRegisteredClient(registeredClient)
 			.principalName("user")
@@ -78,8 +82,8 @@ class OAuth2OpaqueTokenIntrospectorTest {
 	@Test
 	void test_record_constructor() {
 		// When
-		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService,
-				redisUtils);
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
+				jwtDecoder);
 
 		// Then
 		Assertions.assertThat(introspector.authorizationService()).isEqualTo(authorizationService);

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -46,6 +46,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.util.Assert;
@@ -98,6 +99,8 @@ class OAuth2ApiTest {
 	private final RestClient restClient;
 
 	private final PasswordEncoder passwordEncoder;
+
+	private final JwtDecoder jwtDecoder;
 
 	@Test
 	void test_sendMailCaptcha() {
@@ -178,8 +181,8 @@ class OAuth2ApiTest {
 		log.info("刷新token：{}", token);
 		log.info("---------- 模拟认证开始 ----------");
 		Assertions.assertThat(token).isNotBlank();
-		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService,
-				redisUtils);
+		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
+				jwtDecoder);
 		log.info("认证数据：{}", JacksonUtils.toJsonStr(introspector.introspect(token)));
 		log.info("---------- 模拟认证结束 ----------");
 		log.info("---------- 用户名密码认证模式结束 ----------");


### PR DESCRIPTION
## Summary by Sourcery

为 OAuth2 不透明令牌（opaque token）解析引入带缓存的 principal 处理，并通过基于 JWT 的过期校验实现失效控制，同时移除未使用的令牌过滤器。

**New Features:**
- 为 `OAuth2AuthenticatedPrincipal` 实例添加一个基于 Caffeine 的内存缓存，以访问令牌作为键，并通过 `JwtDecoder` 进行令牌过期校验。

**Bug Fixes:**
- 确保过期或无效的访问令牌能够被一致地拒绝，并在解析失败时移除相关的授权信息。

**Enhancements:**
- 优化 OAuth2 不透明令牌解析逻辑，通过缓存减少重复的授权查询和 principal 重建。
- 简化安全配置中的空值检查和授权失效处理逻辑。
- 用 `CachedPrincipal` 记录类型替换未使用的 `TokenFilter`，以封装 principal 及其过期元数据。

**Build:**
- 引入 Caffeine 作为依赖，以支持已认证 principal 的内存缓存。

**Tests:**
- 更新与安全相关的测试，使其在构造 `OAuth2OpaqueTokenIntrospector` 时包含新的 `JwtDecoder` 依赖，并验证引入缓存后的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce cached principal handling for OAuth2 opaque token introspection with JWT-based expiry validation and remove an unused token filter.

New Features:
- Add an in-memory Caffeine cache for OAuth2AuthenticatedPrincipal instances keyed by access token, with token expiry validation via JwtDecoder.

Bug Fixes:
- Ensure expired or invalid access tokens are consistently rejected and associated authorizations are removed when introspection fails.

Enhancements:
- Refine OAuth2 opaque token introspection logic to reduce repeated authorization lookups and principal reconstruction through caching.
- Simplify null checks and authorization invalidation handling in the security configuration.
- Replace the unused TokenFilter with a CachedPrincipal record to encapsulate principal and expiry metadata.

Build:
- Add Caffeine as a dependency to support in-memory caching of authenticated principals.

Tests:
- Update security-related tests to construct OAuth2OpaqueTokenIntrospector with the new JwtDecoder dependency and verify behavior with the caching changes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high-performance caching layer for OAuth2 principals to improve authentication response times and reduce token processing overhead
  * Implemented automatic token expiration validation with intelligent cache invalidation to ensure only valid, non-expired tokens are used for authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->