### PR TITLE
feat: 修改国际化菜单，增加批量删除

### DIFF
--- a/laokou-common/laokou-common-excel/pom.xml
+++ b/laokou-common/laokou-common-excel/pom.xml
@@ -45,4 +45,27 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+          <testFailureIgnore>false</testFailureIgnore>
+          <argLine>
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          </argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/laokou-common/laokou-common-kafka/pom.xml
+++ b/laokou-common/laokou-common-kafka/pom.xml
@@ -45,4 +45,27 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+          <testFailureIgnore>false</testFailureIgnore>
+          <argLine>
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          </argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/laokou-common/laokou-common-mybatis-plus/pom.xml
+++ b/laokou-common/laokou-common-mybatis-plus/pom.xml
@@ -114,4 +114,28 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+          <testFailureIgnore>false</testFailureIgnore>
+          <argLine>
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          </argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/laokou-common/laokou-common-pulsar/pom.xml
+++ b/laokou-common/laokou-common-pulsar/pom.xml
@@ -59,4 +59,27 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+          <testFailureIgnore>false</testFailureIgnore>
+          <argLine>
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          </argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/ui/src/pages/Sys/Base/i18nMenu.tsx
+++ b/ui/src/pages/Sys/Base/i18nMenu.tsx
@@ -5,13 +5,14 @@ import {
 } from '@/services/admin/i18nMenu';
 import {trim} from '@/utils/format';
 import {useAccess, useIntl} from '@@/exports';
-import {PlusOutlined} from '@ant-design/icons';
+import {DeleteOutlined, PlusOutlined} from '@ant-design/icons';
 import type {ActionType, ProColumns} from '@ant-design/pro-components';
 import {ProTable} from '@ant-design/pro-components';
 import {Button, message, Modal} from 'antd';
 import {useRef, useState} from 'react';
 import {I18nMenuDrawer} from "@/pages/Sys/Base/I18nMenuDrawer";
 import {v7 as uuidV7} from "uuid";
+import {TableRowSelection} from "antd/es/table/interface";
 
 export default () => {
 	type TableColumns = {
@@ -32,6 +33,16 @@ export default () => {
 	const [ids, setIds] = useState<number[]>([]);
 	const [title, setTitle] = useState('');
 	const [requestId, setRequestId] = useState('');
+
+	const rowSelection: TableRowSelection<TableColumns> = {
+		onChange: (selectedRowKeys) => {
+			const ids: number[] = [];
+			selectedRowKeys.forEach((item) => {
+				ids.push(item as number);
+			});
+			setIds(ids);
+		},
+	};
 
 	const getPageQueryParam = (params: any) => {
 		return {
@@ -199,6 +210,7 @@ export default () => {
 					});
 				}}
 				rowKey="id"
+				rowSelection={{ ...rowSelection }}
 				pagination={{
 					showQuickJumper: true,
 					showSizeChanger: false,
@@ -229,6 +241,47 @@ export default () => {
 							{t('common.insert')}
 						</Button>
 					),
+					access.canI18nMenuRemove && (
+						<Button
+							key="remove"
+							type="primary"
+							danger
+							icon={<DeleteOutlined />}
+							onClick={() => {
+								Modal.confirm({
+									title: t('confirm.deleteTitle'),
+									content: t('confirm.deleteContent'),
+									okText: t('common.ok'),
+									cancelText: t('common.cancel'),
+									onOk: async () => {
+										if (ids.length === 0) {
+											message
+												.warning(
+													t('toast.selectAtLeastOne'),
+												)
+												.then();
+											return;
+										}
+										removeI18nMenu(ids).then((res) => {
+											if (res.code === 'OK') {
+												message
+													.success(
+														t(
+															'toast.deleteSuccess',
+														),
+													)
+													.then();
+												// @ts-ignore
+												actionRef?.current?.reload();
+											}
+										});
+									},
+								});
+							}}
+						>
+							{t('common.delete')}
+						</Button>
+					)
 				]}
 				dateFormatter="string"
 				toolbar={{


### PR DESCRIPTION
## Summary by Sourcery

在 i18n 菜单界面中添加批量删除支持，并为通用 Java 模块配置测试执行方式。

新特性：
- 在 i18n 菜单表格中启用多行选择和批量删除操作，并提供专用工具栏按钮。

构建：
- 在通用的 MyBatis-Plus、Excel、Kafka 和 Pulsar 模块中配置 maven-surefire-plugin，以使用所需的 JVM `add-opens` 设置运行测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add batch deletion support to the i18n menu UI and configure test execution for common Java modules.

New Features:
- Enable multi-row selection and batch delete operation in the i18n menu table with a dedicated toolbar action.

Build:
- Configure maven-surefire-plugin in common MyBatis-Plus, Excel, Kafka, and Pulsar modules to run tests with required JVM add-opens settings.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk selection and deletion for i18n menu items, with feedback when no rows are selected.
* **Bug Fixes**
  * Improved test execution consistency across several modules by ensuring tests run during builds and failures are surfaced.
  * Added a JVM compatibility setting to help tests run reliably in newer Java environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->