### PR TITLE
feat: 增加正则表达式，用来规范

### DIFF
--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dict/service/validator/DictParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dict/service/validator/DictParamValidator.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import org.laokou.admin.dict.gatewayimpl.database.DictMapper;
 import org.laokou.admin.dict.gatewayimpl.database.dataobject.DictDO;
 import org.laokou.admin.dict.model.DictA;
+import org.laokou.common.core.util.RegexUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.laokou.common.i18n.util.StringExtUtils;
@@ -45,11 +46,11 @@ final class DictParamValidator {
 		String name = dictA.getDictE().getName();
 		String code = dictA.getDictE().getCode();
 		Long id = dictA.getId();
-		if (StringExtUtils.isEmpty(name)) {
-			return ParamValidator.invalidate("字典名称不能为空");
+		if (StringExtUtils.isEmpty(code) || StringExtUtils.isEmpty(name)) {
+			return ParamValidator.invalidate("字典编码和字典名称不能为空");
 		}
-		if (StringExtUtils.isEmpty(code)) {
-			return ParamValidator.invalidate("字典编码不能为空");
+		if (RegexUtils.matches("^[a-z]+(?:_[a-z]+)*$", code)) {
+			return ParamValidator.invalidate("字典编码只能使用小写字母和下划线，必须以小写字母开头和结尾，下划线不能连续");
 		}
 		if (dictA.isSave() && dictMapper
 			.selectCount(Wrappers.lambdaQuery(DictDO.class).eq(DictDO::getCode, code).eq(DictDO::getName, name)) > 0) {

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dictItem/service/validator/DictItemParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dictItem/service/validator/DictItemParamValidator.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import org.laokou.admin.dictItem.gatewayimpl.database.DictItemMapper;
 import org.laokou.admin.dictItem.gatewayimpl.database.dataobject.DictItemDO;
 import org.laokou.admin.dictItem.model.DictItemA;
+import org.laokou.common.core.util.RegexUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.laokou.common.i18n.util.StringExtUtils;
@@ -45,11 +46,11 @@ final class DictItemParamValidator {
 		String name = dictItemA.getDictItemE().getName();
 		String code = dictItemA.getDictItemE().getCode();
 		Long id = dictItemA.getId();
-		if (StringExtUtils.isEmpty(name)) {
-			return ParamValidator.invalidate("字典项名称不能为空");
+		if (StringExtUtils.isEmpty(code) || StringExtUtils.isEmpty(name)) {
+			return ParamValidator.invalidate("字典项编码和字典项名称不能为空");
 		}
-		if (StringExtUtils.isEmpty(code)) {
-			return ParamValidator.invalidate("字典项编码不能为空");
+		if (RegexUtils.matches("^[a-z]+(?:_[a-z]+)*$", code)) {
+			return ParamValidator.invalidate("字典项编码只能使用小写字母和下划线，必须以小写字母开头和结尾，下划线不能连续");
 		}
 		if (dictItemA.isSave() && dictItemMapper.selectCount(Wrappers.lambdaQuery(DictItemDO.class)
 			.eq(DictItemDO::getCode, code)

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dictItem/service/validator/ModifyDictItemParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dictItem/service/validator/ModifyDictItemParamValidator.java
@@ -41,7 +41,7 @@ public class ModifyDictItemParamValidator implements DictItemParamValidator {
 				// 校验字典项编码和字典项名称
 				org.laokou.admin.dictItem.service.validator.DictItemParamValidator.validateCodeAndName(dictItemA,
 						dictItemMapper),
-				// 校验排序
+				// 校验字典项排序
 				org.laokou.admin.dictItem.service.validator.DictItemParamValidator.validateSort(dictItemA),
 				// 校验字典项状态
 				org.laokou.admin.dictItem.service.validator.DictItemParamValidator.validateStatus(dictItemA));

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dictItem/service/validator/SaveDictItemParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dictItem/service/validator/SaveDictItemParamValidator.java
@@ -39,7 +39,7 @@ public class SaveDictItemParamValidator implements DictItemParamValidator {
 				// 校验字典项编码和字典项名称
 				org.laokou.admin.dictItem.service.validator.DictItemParamValidator.validateCodeAndName(dictItemA,
 						dictItemMapper),
-				// 校验排序
+				// 校验字典排序
 				org.laokou.admin.dictItem.service.validator.DictItemParamValidator.validateSort(dictItemA),
 				// 校验字典项状态
 				org.laokou.admin.dictItem.service.validator.DictItemParamValidator.validateStatus(dictItemA));

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/i18nMenu/service/validator/I18nMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/i18nMenu/service/validator/I18nMenuParamValidator.java
@@ -22,6 +22,7 @@ import org.laokou.admin.i18nMenu.gatewayimpl.database.I18nMenuMapper;
 import org.laokou.admin.i18nMenu.gatewayimpl.database.dataobject.I18nMenuDO;
 import org.laokou.admin.i18nMenu.model.I18nMenuA;
 import org.laokou.admin.i18nMenu.model.entity.I18nMenuE;
+import org.laokou.common.core.util.RegexUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ParamValidator;
 import org.laokou.common.i18n.util.StringExtUtils;
@@ -35,24 +36,8 @@ final class I18nMenuParamValidator {
 	}
 
 	static ParamValidator.Validate validateId(I18nMenuA i18nMenuA) {
-		if (i18nMenuA.isModify() && ObjectUtils.isNull(i18nMenuA.getI18nMenuE().getId())) {
+		if (ObjectUtils.isNull(i18nMenuA.getI18nMenuE().getId())) {
 			return ParamValidator.invalidate("国际化菜单ID不能为空");
-		}
-		return ParamValidator.validate();
-	}
-
-	static ParamValidator.Validate validateCode(I18nMenuA i18nMenuA) {
-		String code = i18nMenuA.getI18nMenuE().getCode();
-		if (StringExtUtils.isEmpty(code)) {
-			return ParamValidator.invalidate("国际化菜单编码不能为空");
-		}
-		return ParamValidator.validate();
-	}
-
-	static ParamValidator.Validate validateName(I18nMenuA i18nMenuA) {
-		String name = i18nMenuA.getI18nMenuE().getName();
-		if (StringExtUtils.isEmpty(name)) {
-			return ParamValidator.invalidate("国际化菜单名称不能为空");
 		}
 		return ParamValidator.validate();
 	}
@@ -62,17 +47,23 @@ final class I18nMenuParamValidator {
 		String code = i18nMenuE.getCode();
 		String name = i18nMenuE.getName();
 		Long id = i18nMenuE.getId();
+		if (StringExtUtils.isEmpty(code) || StringExtUtils.isEmpty(name)) {
+			return ParamValidator.invalidate("国际化菜单编码和国际化菜单名称不能为空");
+		}
+		if (RegexUtils.matches("^[a-z]+(?:\\.[a-z]+)*$", code)) {
+			return ParamValidator.invalidate("国际化菜单编码只能使用小写字母和小数点，必须以小写字母开头和结尾，小数点不能连续");
+		}
 		if (StringExtUtils.isNotEmpty(code) && StringExtUtils.isNotEmpty(name)) {
 			if (i18nMenuA.isSave() && i18nMenuMapper.selectCount(Wrappers.lambdaQuery(I18nMenuDO.class)
 				.eq(I18nMenuDO::getCode, code)
 				.eq(I18nMenuDO::getName, name)) > 0) {
-				return ParamValidator.invalidate("国际化菜单编码和名称已存在");
+				return ParamValidator.invalidate("国际化菜单编码和国际化菜单名称已存在");
 			}
 			if (i18nMenuA.isModify() && i18nMenuMapper.selectCount(Wrappers.lambdaQuery(I18nMenuDO.class)
 				.eq(I18nMenuDO::getCode, code)
 				.eq(I18nMenuDO::getName, name)
 				.ne(I18nMenuDO::getId, id)) > 0) {
-				return ParamValidator.invalidate("国际化菜单编码和名称已存在");
+				return ParamValidator.invalidate("国际化菜单编码和国际化菜单名称已存在");
 			}
 		}
 		return ParamValidator.validate();

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/i18nMenu/service/validator/ModifyI18nMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/i18nMenu/service/validator/ModifyI18nMenuParamValidator.java
@@ -38,11 +38,7 @@ public class ModifyI18nMenuParamValidator implements I18nMenuParamValidator {
 		ParamValidator.validate(i18nMenuA.getValidateName(),
 				// 校验ID
 				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateId(i18nMenuA),
-				// 校验编码
-				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateCode(i18nMenuA),
-				// 校验名称
-				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateName(i18nMenuA),
-				// 校验编码和名称
+				// 校验国际化菜单编码和国际化菜单名称
 				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateCodeAndName(i18nMenuA,
 						i18nMenuMapper));
 	}

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/i18nMenu/service/validator/SaveI18nMenuParamValidator.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/i18nMenu/service/validator/SaveI18nMenuParamValidator.java
@@ -36,13 +36,7 @@ public class SaveI18nMenuParamValidator implements I18nMenuParamValidator {
 	@Override
 	public void validateI18nMenu(I18nMenuA i18nMenuA) {
 		ParamValidator.validate(i18nMenuA.getValidateName(),
-				// 校验ID
-				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateId(i18nMenuA),
-				// 校验编码
-				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateCode(i18nMenuA),
-				// 校验名称
-				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateName(i18nMenuA),
-				// 校验编码和名称
+				// 校验国际化菜单编码和国际化菜单名称
 				org.laokou.admin.i18nMenu.service.validator.I18nMenuParamValidator.validateCodeAndName(i18nMenuA,
 						i18nMenuMapper));
 	}

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/ModifyThingModelParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/ModifyThingModelParamValidator.java
@@ -36,12 +36,18 @@ public class ModifyThingModelParamValidator implements ThingModelParamValidator 
 	@Override
 	public void validateThingModel(ThingModelA thingModelA) {
 		ParamValidator.validate("System",
+				// 校验物模型ID
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateId(thingModelA),
+				// 校验物模型编码和物模型名称
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateCodeAndName(thingModelA,
 						thingModelMapper),
+				// 校验物模型数据类型
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateDataType(thingModelA),
+				// 校验物模型规格
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateSpec(thingModelA),
+				// 校验物模型类型
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateType(thingModelA),
+				// 校验物模型排序
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateSort(thingModelA));
 	}
 

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/SaveThingModelParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/SaveThingModelParamValidator.java
@@ -36,11 +36,16 @@ public class SaveThingModelParamValidator implements ThingModelParamValidator {
 	@Override
 	public void validateThingModel(ThingModelA thingModelA) {
 		ParamValidator.validate(thingModelA.getValidateName(),
+				// 校验物模型编码和物模型名称
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateCodeAndName(thingModelA,
 						thingModelMapper),
+				// 校验物模型数据类型
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateDataType(thingModelA),
+				// 校验物模型规格
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateSpec(thingModelA),
+				// 校验物模型类型
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateType(thingModelA),
+				// 校验物模型排序
 				org.laokou.iot.thingModel.service.validator.ThingModelParamValidator.validateSort(thingModelA));
 	}
 

--- a/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/ThingModelParamValidator.java
+++ b/laokou-service/laokou-iot/laokou-iot-app/src/main/java/org/laokou/iot/thingModel/service/validator/ThingModelParamValidator.java
@@ -19,6 +19,7 @@ package org.laokou.iot.thingModel.service.validator;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import org.laokou.common.core.util.CollectionExtUtils;
+import org.laokou.common.core.util.RegexUtils;
 import org.laokou.common.i18n.common.constant.StringConstants;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.ParamValidator;
@@ -53,11 +54,11 @@ final class ThingModelParamValidator {
 		ThingModelE thingModelE = thingModelA.getThingModelE();
 		String code = thingModelE.getCode();
 		String name = thingModelE.getName();
-		if (!StringUtils.hasText(name)) {
-			return ParamValidator.invalidate("物模型名称不能为空");
+		if (!StringUtils.hasText(code) || !StringUtils.hasText(name)) {
+			return ParamValidator.invalidate("物模型编码和物模型名称不能为空");
 		}
-		if (!StringUtils.hasText(code)) {
-			return ParamValidator.invalidate("物模型编码不能为空");
+		if (RegexUtils.matches("^[a-z]+(?:_[a-z]+)*$", code)) {
+			return ParamValidator.invalidate("物模型编码只能使用小写字母和下划线，必须以小写字母开头和结尾，下划线不能连续");
 		}
 		if (thingModelA.isSave() && thingModelMapper.selectCount(Wrappers.lambdaQuery(ThingModelDO.class)
 			.eq(ThingModelDO::getCode, code)


### PR DESCRIPTION
## Summary by Sourcery

对字典、字典项、i18n 菜单和物模型强制使用一致且非空的编码和名称，新增基于正则表达式的格式约束，并统一相关的校验器和提示信息。

New Features:
- 为字典、字典项、i18n 菜单和物模型的编码新增基于正则表达式的格式校验。

Enhancements:
- 将 i18n 菜单的 ID、编码和名称校验合并为统一的「编码与名称」联合校验，并提供更清晰的错误信息。
- 统一字典、字典项、i18n 菜单和物模型的校验规则，要求同时提供编码和名称，并改进校验注释以提升可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce consistent, non-empty codes and names for dictionaries, dictionary items, i18n menus, and thing models, adding regex-based format constraints and aligning related validators and messages.

New Features:
- Introduce regex-based format validation for dictionary, dictionary item, i18n menu, and thing model codes.

Enhancements:
- Consolidate i18n menu ID, code, and name validation into a combined code-and-name check with clearer error messages.
- Align dictionary, dictionary item, i18n menu, and thing model validators to require both code and name simultaneously and improve validation comments for readability.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for dictionary, dictionary item, i18n menu, and thing model entries.
  * Code fields now require a consistent lowercase format with allowed separators, reducing invalid saves.
  * Empty code/name input now returns clearer combined error messages.
  * i18n menu IDs are now always required when submitting changes.

* **Style**
  * Updated several validation labels and comments for clearer, more consistent messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->