### PR TITLE
style: 优化mqtt client配置

### DIFF
--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/AbstractMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/AbstractMessageHandler.java
@@ -15,14 +15,20 @@
  *
  */
 
-package org.laokou.iot.session.dto.mqtt;
+package org.laokou.iot.common.config.mqtt;
 
-import io.vertx.core.buffer.Buffer;
-import lombok.Builder;
+import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.session.dto.mqtt.MqttMessageType;
 
 /**
  * @author laokou
  */
-@Builder(toBuilder = true)
-public record MqttMessageV(Buffer payload, String topic) {
+public abstract class AbstractMessageHandler implements MessageHandler {
+
+	protected boolean isSubscribe(String topic) {
+		return VertxMqttUtils.matchTopic(getMatchTopic().getTopic(), topic);
+	}
+
+	protected abstract MqttMessageType getMatchTopic();
+
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/MessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/MessageHandler.java
@@ -18,7 +18,6 @@
 package org.laokou.iot.common.config.mqtt;
 
 import io.vertx.mqtt.messages.MqttPublishMessage;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 
 /**
  * 消息处理器.
@@ -27,8 +26,6 @@ import org.laokou.iot.session.dto.mqtt.MqttMessageV;
  */
 public interface MessageHandler {
 
-	void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV);
-
-	boolean isSubscribe(String topic);
+	void handle(MqttPublishMessage publishMessage);
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClient.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClient.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.iot.common.util.VertxMqttUtils;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 
 import java.util.List;
 import java.util.Map;
@@ -208,11 +207,10 @@ public final class VertxMqttClient extends AbstractVertxService<Void> {
 				String topic = publishMessage.topicName();
 				log.debug("【Vertx-MQTT-Client】 => MQTT接收到消息，Topic：{}，QoS：{}，数据包ID：{}", topic, publishMessage.qosLevel(),
 						publishMessage.messageId());
-				MqttMessageV messageV = MqttMessageV.builder().topic(topic).payload(publishMessage.payload()).build();
 				for (MessageHandler messageHandler : messageHandlers) {
 					Thread.startVirtualThread(() -> {
 						try {
-							messageHandler.handle(publishMessage, messageV);
+							messageHandler.handle(publishMessage);
 						}
 						catch (Exception ex) {
 							log.error("【Vertx-MQTT-Client】 => MQTT消息处理失败，Topic：{}，处理器：{}，错误信息：{}", topic,

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/DownCommandGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/DownCommandGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DownCommandGatewayMessageHandler implements MessageHandler {
+public class DownCommandGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.DOWN_COMMAND_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.DOWN_COMMAND_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/DownReportOtaReplyGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/DownReportOtaReplyGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DownReportOtaReplyGatewayMessageHandler implements MessageHandler {
+public class DownReportOtaReplyGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.DOWN_REPORT_OTA_REPLY_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.DOWN_REPORT_OTA_REPLY_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/DownUpgradeOtaReplyGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/DownUpgradeOtaReplyGatewayMessageHandler.java
@@ -21,10 +21,8 @@ import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -36,16 +34,16 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Data
-public class DownUpgradeOtaReplyGatewayMessageHandler implements MessageHandler {
+public class DownUpgradeOtaReplyGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.DOWN_UPGRADE_OTA_REPLY_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.DOWN_UPGRADE_OTA_REPLY_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpAlarmEventGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpAlarmEventGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpAlarmEventGatewayMessageHandler implements MessageHandler {
+public class UpAlarmEventGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_ALARM_EVENT_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_ALARM_EVENT_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpCommandReplyGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpCommandReplyGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpCommandReplyGatewayMessageHandler implements MessageHandler {
+public class UpCommandReplyGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_COMMAND_REPLY_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_COMMAND_REPLY_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpHeartbeatGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpHeartbeatGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpHeartbeatGatewayMessageHandler implements MessageHandler {
+public class UpHeartbeatGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_HEARTBEAT_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_HEARTBEAT_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpReportOtaGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpReportOtaGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpReportOtaGatewayMessageHandler implements MessageHandler {
+public class UpReportOtaGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_REPORT_OTA_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_REPORT_OTA_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpReportPropertiesGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpReportPropertiesGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpReportPropertiesGatewayMessageHandler implements MessageHandler {
+public class UpReportPropertiesGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_REPORT_PROPERTIES_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_REPORT_PROPERTIES_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpUpgradeOtaGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpUpgradeOtaGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,15 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpUpgradeOtaGatewayMessageHandler implements MessageHandler {
+public class UpUpgradeOtaGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
-	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_UPGRADE_OTA_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_UPGRADE_OTA_GATEWAY_MESSAGE;
 	}
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpUpgradeOtaProcessGatewayMessageHandler.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/handler/UpUpgradeOtaProcessGatewayMessageHandler.java
@@ -20,10 +20,8 @@ package org.laokou.iot.common.config.mqtt.handler;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.iot.common.config.mqtt.MessageHandler;
-import org.laokou.iot.common.util.VertxMqttUtils;
+import org.laokou.iot.common.config.mqtt.AbstractMessageHandler;
 import org.laokou.iot.session.dto.mqtt.MqttMessageType;
-import org.laokou.iot.session.dto.mqtt.MqttMessageV;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,16 +32,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UpUpgradeOtaProcessGatewayMessageHandler implements MessageHandler {
+public class UpUpgradeOtaProcessGatewayMessageHandler extends AbstractMessageHandler {
 
 	@Override
-	public void handle(MqttPublishMessage publishMessage, MqttMessageV mqttMessageV) {
+	public void handle(MqttPublishMessage publishMessage) {
 
 	}
 
 	@Override
-	public boolean isSubscribe(String topic) {
-		return VertxMqttUtils.matchTopic(MqttMessageType.UP_UPGRADE_OTA_PROGRESS_GATEWAY_MESSAGE.getTopic(), topic);
+	protected MqttMessageType getMatchTopic() {
+		return MqttMessageType.UP_UPGRADE_OTA_PROGRESS_GATEWAY_MESSAGE;
 	}
 
 }


### PR DESCRIPTION
## Summary by Sourcery

重构 MQTT 消息处理，以集中管理主题订阅逻辑并简化处理器接口。

增强内容：
- 引入 `AbstractMessageHandler` 抽象基类，用于封装主题匹配和共享的 MQTT 处理行为。
- 简化 `MessageHandler` 接口，使其直接处理 `MqttPublishMessage`，不再使用 `MqttMessageV` 包装器，也无需显式的订阅检查。
- 更新所有网关 MQTT 处理器，使其继承新的抽象基类，并通过 `MqttMessageType` 定义其订阅的主题。
- 调整 `VertxMqttClient`，使其仅使用接收到的 `MqttPublishMessage` 调用处理器，移除 `MqttMessageV` 的构造和使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor MQTT message handling to centralize topic subscription logic and simplify handler interfaces.

Enhancements:
- Introduce an AbstractMessageHandler base class that encapsulates topic matching and shared MQTT handling behavior.
- Simplify the MessageHandler interface to operate directly on MqttPublishMessage without the MqttMessageV wrapper or explicit subscription checks.
- Update all gateway MQTT handlers to extend the new abstract base class and define their subscribed topic via MqttMessageType.
- Adjust VertxMqttClient to invoke handlers with only the received MqttPublishMessage, removing construction and use of MqttMessageV.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined MQTT message processing by standardizing how incoming messages are handled.
  * Improved topic-based routing across gateway commands, reports, alarms, heartbeats, and OTA events.
  * Removed unnecessary intermediate message wrapping for more direct message delivery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->