### PR TITLE
fix: maven构建失败

### DIFF
--- a/archive/docs/00.二开指南/02.指南/08.项目配置.md
+++ b/archive/docs/00.二开指南/02.指南/08.项目配置.md
@@ -96,7 +96,7 @@ mvn versions:revert -P dev
 	<module name="TreeWalker">
 
 		<!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-		<module name="JavadocStyleCheck">
+		<module name="JavadocStyle">
 			<property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
 		</module>
 

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-cloud/checkstyle/checkstyle.xml
+++ b/laokou-cloud/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-cloud/laokou-gateway/checkstyle/checkstyle.xml
+++ b/laokou-cloud/laokou-gateway/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-cloud/laokou-monitor/checkstyle/checkstyle.xml
+++ b/laokou-cloud/laokou-monitor/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/checkstyle/checkstyle.xml
+++ b/laokou-common/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-ai/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-ai/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-algorithm/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-algorithm/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-banner/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-banner/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-context/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-context/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-core/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-core/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-cors/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-cors/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-crypto/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-crypto/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-csv/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-csv/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-data-cache/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-data-cache/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-domain/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-elasticsearch/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-elasticsearch/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-excel/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-excel/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-fory/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-fory/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-grpc-client/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-grpc-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-grpc-server/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-grpc-server/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-i18n/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-i18n/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-idempotent/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-idempotent/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-influxdb/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-influxdb/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-kafka/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-kafka/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-lock/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-lock/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-log/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-log/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-log4j2/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-log4j2/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-mail/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-mail/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-mongodb/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-mongodb/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-mybatis-plus/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-mybatis-plus/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-nacos/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-nacos/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-openapi-doc/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-openapi-doc/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-oss/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-oss/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-prometheus/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-prometheus/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-pulsar/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-pulsar/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-rate-limiter/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-rate-limiter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-reactor/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-reactor/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-redis/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-redis/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-secret/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-secret/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-security/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-security/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-sensitive/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-sensitive/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-sentinel/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-sentinel/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-sftp/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-sftp/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-sms/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-sms/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-snail-job/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-snail-job/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-storage/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-storage/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-tdengine/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-tdengine/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-tenant/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-tenant/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-test/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-test/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-testcontainers/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-testcontainers/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-trace/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-trace/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-websocket/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-websocket/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-common/laokou-common-xss/checkstyle/checkstyle.xml
+++ b/laokou-common/laokou-common-xss/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/checkstyle/checkstyle.xml
+++ b/laokou-service/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/laokou-admin-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/laokou-admin-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/laokou-admin-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/laokou-admin-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/laokou-admin-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/laokou-admin-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/laokou-admin-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/laokou-admin-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-admin/laokou-admin-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-admin/laokou-admin-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/laokou-auth-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/laokou-auth-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/laokou-auth-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/laokou-auth-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/laokou-auth-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/laokou-auth-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/laokou-auth-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/laokou-auth-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-auth/laokou-auth-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-auth/laokou-auth-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/laokou-cola-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/laokou-cola-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/laokou-cola-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/laokou-cola-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/laokou-cola-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/laokou-cola-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/laokou-cola-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/laokou-cola-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/laokou-cola-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/laokou-cola-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-cola/laokou-cola-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-cola/laokou-cola-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/laokou-generator-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/laokou-generator-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/laokou-generator-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/laokou-generator-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/laokou-generator-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/laokou-generator-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/laokou-generator-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/laokou-generator-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/laokou-generator-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/laokou-generator-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-generator/laokou-generator-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-generator/laokou-generator-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/laokou-iot-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/laokou-iot-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/laokou-iot-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/laokou-iot-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/laokou-iot-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/laokou-iot-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/laokou-iot-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/laokou-iot-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-iot/laokou-iot-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-iot/laokou-iot-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/laokou-logstash-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/laokou-logstash-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/laokou-logstash-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/laokou-logstash-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-logstash/laokou-logstash-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-client/laokou-mcp-client-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-mcp/laokou-mcp-server/laokou-mcp-server-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-proto/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-proto/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-oss/laokou-oss-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-oss/laokou-oss-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-report/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-report/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-report/laokou-report-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-report/laokou-report-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-report/laokou-report-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-report/laokou-report-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-report/laokou-report-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-report/laokou-report-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-report/laokou-report-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-report/laokou-report-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-proto/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-proto/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-adapter/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-adapter/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-app/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-app/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-client/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-client/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-domain/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-domain/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-infrastructure/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-infrastructure/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/checkstyle/checkstyle.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>

--- a/laokou-tool/checkstyle/checkstyle.xml
+++ b/laokou-tool/checkstyle/checkstyle.xml
@@ -51,7 +51,7 @@
   <module name="TreeWalker">
 
     <!-- 匹配句子末尾的格式 https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle -->
-    <module name="JavadocStyleCheck">
+    <module name="JavadocStyle">
       <property name="endOfSentenceFormat" value="([.?!。？！][ \t\n\r\f&lt;])|([.?!。？！]$)"/>
       <property name="checkHtml" value="false"/>
     </module>


### PR DESCRIPTION
## Summary by Sourcery

在所有模块中统一 Checkstyle 配置中 Javadoc 风格模块的名称，以恢复与当前 Checkstyle/Maven 设置的兼容性。

Bug 修复：
- 通过将所有 `checkstyle.xml` 文件中的 Javadoc 风格模块从已弃用的 `JavadocStyleCheck` 更新为 `JavadocStyle`，修复 Maven/Checkstyle 构建失败问题。

文档：
- 将文档归档结构中已归档的文档路径片段从 `a` 重命名为 `b`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Checkstyle configuration with the correct Javadoc style module name across all modules to restore compatibility with the current Checkstyle/Maven setup.

Bug Fixes:
- Fix Maven/Checkstyle build failures by updating the Javadoc style module from the deprecated JavadocStyleCheck to JavadocStyle in all checkstyle.xml files.

Documentation:
- Rename an archived documentation path segment from 'a' to 'b' in the docs archive structure.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Javadoc style guidance to reflect the current validation rule configuration.

* **Bug Fixes**
  * Standardized Javadoc style validation across project modules, improving consistency and compatibility of code-quality checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->