### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/OAuth2AuthenticatedExtPrincipal.java
+++ b/laokou-common/laokou-common-context/src/main/java/org/laokou/common/context/util/OAuth2AuthenticatedExtPrincipal.java
@@ -121,6 +121,7 @@ public final class OAuth2AuthenticatedExtPrincipal implements OAuth2Authenticate
 	 * @return the OAuth 2.0 token attributes
 	 */
 	@Override
+	@NullMarked
 	public Map<String, Object> getAttributes() {
 		return Collections.emptyMap();
 	}

--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/SystemSettingsProperties.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/config/SystemSettingsProperties.java
@@ -55,6 +55,8 @@ public class SystemSettingsProperties implements Serializable {
 
 	private Long tenantValue = 1L;
 
+	private String anonymousAuthToken = "48aA4CD5uithlID8GaDffYtOYeY8Fa5TB7S4RyXzfH313WYlAxUBR3tHoA93seZT";
+
 	private Mode appMode = Mode.MICROSERVICE;
 
 	@Getter

--- a/laokou-common/laokou-common-grpc-client/pom.xml
+++ b/laokou-common/laokou-common-grpc-client/pom.xml
@@ -32,10 +32,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-oauth2-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-grpc-server</artifactId>
       <scope>test</scope>
       <optional>true</optional>

--- a/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/config/GrpcClientConfig.java
+++ b/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/config/GrpcClientConfig.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.NonNull;
 import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.common.core.util.RequestUtils;
 import org.laokou.common.grpc.client.annotation.GrpcClientBeanPostProcessor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.laokou.common.grpc.client.constant.GrpcClientConstants;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
@@ -60,7 +60,6 @@ final class GrpcClientConfig {
 	}
 
 	@Bean
-	@ConditionalOnBean(GrpcClientFactory.class)
 	GrpcClientBeanPostProcessor grpcClientBeanPostProcessor(GrpcClientFactory grpcClientFactory) {
 		return new GrpcClientBeanPostProcessor(grpcClientFactory);
 	}
@@ -81,7 +80,7 @@ final class GrpcClientConfig {
 	private String getAccessToken(SystemSettingsProperties systemSettingsProperties) {
 		HttpServletRequest request = RequestUtils.getHttpServletRequest();
 		String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-		if (StringUtils.hasText(authorization)) {
+		if (StringUtils.hasText(authorization) && authorization.startsWith(GrpcClientConstants.BEARER_PREFIX)) {
 			return authorization.substring(7);
 		}
 		return systemSettingsProperties.getAnonymousAuthToken();

--- a/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/config/GrpcClientConfig.java
+++ b/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/config/GrpcClientConfig.java
@@ -19,8 +19,12 @@ package org.laokou.common.grpc.client.config;
 
 import io.grpc.ClientInterceptor;
 import io.grpc.netty.NettyChannelBuilder;
+import jakarta.servlet.http.HttpServletRequest;
 import org.jspecify.annotations.NonNull;
+import org.laokou.common.core.config.SystemSettingsProperties;
+import org.laokou.common.core.util.RequestUtils;
 import org.laokou.common.grpc.client.annotation.GrpcClientBeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
@@ -31,15 +35,8 @@ import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
 import org.springframework.grpc.client.GrpcClientFactory;
 import org.springframework.grpc.client.ImportGrpcClients;
 import org.springframework.grpc.client.interceptor.security.BearerTokenAuthenticationInterceptor;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.util.Assert;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -63,6 +60,7 @@ final class GrpcClientConfig {
 	}
 
 	@Bean
+	@ConditionalOnBean(GrpcClientFactory.class)
 	GrpcClientBeanPostProcessor grpcClientBeanPostProcessor(GrpcClientFactory grpcClientFactory) {
 		return new GrpcClientBeanPostProcessor(grpcClientFactory);
 	}
@@ -75,28 +73,18 @@ final class GrpcClientConfig {
 	}
 
 	@Bean
-	OAuth2AuthorizedClientManager authorizedClientManager(ClientRegistrationRepository registrations,
-			OAuth2AuthorizedClientService service) {
-		OAuth2AuthorizedClientProvider provider = OAuth2AuthorizedClientProviderBuilder.builder()
-			.clientCredentials()
-			.build();
-		AuthorizedClientServiceOAuth2AuthorizedClientManager manager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(
-				registrations, service);
-		manager.setAuthorizedClientProvider(provider);
-		return manager;
+	@GlobalClientInterceptor
+	ClientInterceptor clientInterceptor(SystemSettingsProperties systemSettingsProperties) {
+		return new BearerTokenAuthenticationInterceptor(() -> getAccessToken(systemSettingsProperties));
 	}
 
-	@Bean
-	@GlobalClientInterceptor
-	ClientInterceptor clientInterceptor(OAuth2AuthorizedClientManager authorizedClientManager) {
-		return new BearerTokenAuthenticationInterceptor(() -> {
-			OAuth2AuthorizeRequest request = OAuth2AuthorizeRequest.withClientRegistrationId("default")
-				.principal("system")
-				.build();
-			OAuth2AuthorizedClient client = authorizedClientManager.authorize(request);
-			Assert.notNull(client, "authorized client is null");
-			return client.getAccessToken().getTokenValue();
-		});
+	private String getAccessToken(SystemSettingsProperties systemSettingsProperties) {
+		HttpServletRequest request = RequestUtils.getHttpServletRequest();
+		String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (StringUtils.hasText(authorization)) {
+			return authorization.substring(7);
+		}
+		return systemSettingsProperties.getAnonymousAuthToken();
 	}
 
 }

--- a/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/constant/GrpcClientConstants.java
+++ b/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/constant/GrpcClientConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.client.constant;
+
+/**
+ * @author laokou
+ */
+public final class GrpcClientConstants {
+
+	private GrpcClientConstants() {
+	}
+
+	public static final String BEARER_PREFIX = "Bearer ";
+
+}

--- a/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/exception/handler/StatusExceptionHandler.java
+++ b/laokou-common/laokou-common-grpc-client/src/main/java/org/laokou/common/grpc/client/exception/handler/StatusExceptionHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.grpc.client.exception.handler;
+
+import io.grpc.StatusException;
+import org.laokou.common.i18n.common.exception.BizException;
+import org.laokou.common.i18n.common.exception.StatusCode;
+import org.laokou.common.i18n.util.MessageUtils;
+import org.laokou.common.i18n.util.ObjectUtils;
+
+/**
+ * @author laokou
+ */
+public final class StatusExceptionHandler {
+
+	private static final String UNAUTHENTICATED = "UNAUTHENTICATED: Authentication failed";
+
+	private static final String FORBIDDEN_MESSAGE = MessageUtils.getMessage(StatusCode.FORBIDDEN);
+
+	private StatusExceptionHandler() {
+	}
+
+	public static BizException handle(StatusException ex1, BizException ex2, String serviceId) {
+		String message = ex1.getMessage();
+		if (ObjectUtils.equals(UNAUTHENTICATED, message)) {
+			return new BizException(StatusCode.FORBIDDEN, String.format("【%s】" + FORBIDDEN_MESSAGE, serviceId));
+		}
+		return ex2;
+	}
+
+}

--- a/laokou-common/laokou-common-grpc-client/src/test/java/org/laokou/common/grpc/client/GrpcClientTest.java
+++ b/laokou-common/laokou-common-grpc-client/src/test/java/org/laokou/common/grpc/client/GrpcClientTest.java
@@ -17,12 +17,8 @@
 
 package org.laokou.common.grpc.client;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.grpc.StatusException;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.grpc.client.annotation.GrpcClient;
 import org.laokou.common.grpc.proto.HelloWorldProto;
@@ -30,16 +26,7 @@ import org.laokou.common.grpc.proto.SimpleGrpc;
 import org.laokou.common.testcontainers.util.DockerImageNames;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.consul.ConsulContainer;
@@ -50,7 +37,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * @author laokou
  */
 @Testcontainers
-@Import(GrpcClientTest.MockOAuth2Config.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = GrpcClientTest.GrpcTest.class)
 class GrpcClientTest {
 
@@ -70,19 +56,6 @@ class GrpcClientTest {
 	@GrpcClient(serviceId = "laokou-common-grpc")
 	private SimpleGrpc.SimpleBlockingV2Stub simpleBlockingV2Stub;
 
-	@BeforeEach
-	void setUp() {
-		WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.options().port(8887).httpsPort(8889));
-		wireMockServer.start();
-		wireMockServer.stubFor(WireMock.post("/oauth2/token").willReturn(WireMock.okJson("""
-				{
-				  "access_token":"mock-token",
-				  "token_type":"Bearer",
-				  "expires_in":300
-				}
-				""")));
-	}
-
 	@Test
 	void test() throws StatusException {
 		HelloWorldProto.HelloRequest request = HelloWorldProto.HelloRequest.newBuilder().setName("test").build();
@@ -94,27 +67,6 @@ class GrpcClientTest {
 	@EnableDiscoveryClient
 	@SpringBootApplication(scanBasePackages = { "org.laokou" })
 	static class GrpcTest {
-
-	}
-
-	@TestConfiguration
-	static class MockOAuth2Config {
-
-		@Bean
-		ClientRegistrationRepository clientRegistrationRepository() {
-			ClientRegistration registration = ClientRegistration.withRegistrationId("default")
-				.clientId("grpc-client")
-				.clientSecret("secret")
-				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-				.tokenUri("http://localhost:8887/oauth2/token")
-				.build();
-			return new InMemoryClientRegistrationRepository(registration);
-		}
-
-		@Bean
-		OAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository repository) {
-			return new InMemoryOAuth2AuthorizedClientService(repository);
-		}
 
 	}
 

--- a/laokou-common/laokou-common-grpc-server/pom.xml
+++ b/laokou-common/laokou-common-grpc-server/pom.xml
@@ -36,8 +36,9 @@
       <artifactId>spring-grpc-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+      <groupId>org.laokou</groupId>
+      <artifactId>laokou-common-security</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-grpc-server/src/main/java/org/laokou/common/grpc/server/config/GrpcOAuth2Config.java
+++ b/laokou-common/laokou-common-grpc-server/src/main/java/org/laokou/common/grpc/server/config/GrpcOAuth2Config.java
@@ -17,7 +17,6 @@
 
 package org.laokou.common.grpc.server.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.grpc.server.GlobalServerInterceptor;
@@ -46,8 +45,8 @@ class GrpcOAuth2Config {
 
 	@Bean
 	@GlobalServerInterceptor
-	@ConditionalOnBean(OpaqueTokenIntrospector.class)
-	AuthenticationProcessInterceptor jwtAuthenticationProcessInterceptor(GrpcSecurity grpc, OpaqueTokenIntrospector opaqueTokenIntrospector) throws Exception {
+	AuthenticationProcessInterceptor opaqueTokenAuthenticationProcessIntrospector(GrpcSecurity grpc,
+			OpaqueTokenIntrospector opaqueTokenIntrospector) throws Exception {
 		return grpc.authorizeRequests(requests -> requests.allRequests().authenticated())
 			.oauth2ResourceServer(
 					resource -> resource.opaqueToken(token -> token.introspector(opaqueTokenIntrospector)))

--- a/laokou-common/laokou-common-grpc-server/src/main/java/org/laokou/common/grpc/server/config/GrpcOAuth2Config.java
+++ b/laokou-common/laokou-common-grpc-server/src/main/java/org/laokou/common/grpc/server/config/GrpcOAuth2Config.java
@@ -17,13 +17,14 @@
 
 package org.laokou.common.grpc.server.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.grpc.server.GlobalServerInterceptor;
 import org.springframework.grpc.server.security.AuthenticationProcessInterceptor;
 import org.springframework.grpc.server.security.GrpcSecurity;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 
 /**
  *
@@ -45,9 +46,11 @@ class GrpcOAuth2Config {
 
 	@Bean
 	@GlobalServerInterceptor
-	AuthenticationProcessInterceptor jwtAuthenticationProcessInterceptor(GrpcSecurity grpc) throws Exception {
+	@ConditionalOnBean(OpaqueTokenIntrospector.class)
+	AuthenticationProcessInterceptor jwtAuthenticationProcessInterceptor(GrpcSecurity grpc, OpaqueTokenIntrospector opaqueTokenIntrospector) throws Exception {
 		return grpc.authorizeRequests(requests -> requests.allRequests().authenticated())
-			.oauth2ResourceServer((resourceServer) -> resourceServer.jwt(Customizer.withDefaults()))
+			.oauth2ResourceServer(
+					resource -> resource.opaqueToken(token -> token.introspector(opaqueTokenIntrospector)))
 			.build();
 	}
 

--- a/laokou-common/laokou-common-log/src/main/java/org/laokou/common/log/config/OperateLogConfig.java
+++ b/laokou-common/laokou-common-log/src/main/java/org/laokou/common/log/config/OperateLogConfig.java
@@ -19,6 +19,7 @@ package org.laokou.common.log.config;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.laokou.common.i18n.common.IdGenerator;
+import org.laokou.common.i18n.util.SpringUtils;
 import org.laokou.common.log.model.enums.Mq;
 import org.laokou.common.log.rpc.IdGeneratorMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -42,8 +43,8 @@ public class OperateLogConfig {
 	@Bean(name = "idGenerator")
 	@ConditionalOnProperty(prefix = "system-settings", name = "app-mode", havingValue = "MICROSERVICE",
 			matchIfMissing = true)
-	IdGenerator idGeneratorMapper() {
-		return new IdGeneratorMapper();
+	IdGenerator idGeneratorMapper(SpringUtils springUtils) {
+		return new IdGeneratorMapper(springUtils);
 	}
 
 }

--- a/laokou-common/laokou-common-log/src/main/java/org/laokou/common/log/rpc/IdGeneratorMapper.java
+++ b/laokou-common/laokou-common-log/src/main/java/org/laokou/common/log/rpc/IdGeneratorMapper.java
@@ -18,10 +18,13 @@
 package org.laokou.common.log.rpc;
 
 import io.grpc.StatusException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.grpc.client.annotation.GrpcClient;
 import org.laokou.common.grpc.client.exception.ServiceNotFoundException;
+import org.laokou.common.grpc.client.exception.handler.StatusExceptionHandler;
 import org.laokou.common.i18n.common.IdGenerator;
+import org.laokou.common.i18n.util.SpringUtils;
 import org.laokou.snowflake.id.proto.GenerateBatchIdsRequest;
 import org.laokou.snowflake.id.proto.GenerateBatchIdsResponse;
 import org.laokou.snowflake.id.proto.GenerateIdRequest;
@@ -34,7 +37,10 @@ import java.util.List;
  * @author laokou
  */
 @Slf4j
+@RequiredArgsConstructor
 public class IdGeneratorMapper implements IdGenerator {
+
+	private final SpringUtils springUtils;
 
 	@GrpcClient(serviceId = "laokou-snowflake-id")
 	private SnowflakeIdServiceIGrpc.SnowflakeIdServiceIBlockingV2Stub snowflakeIdServiceIBlockingV2Stub;
@@ -48,7 +54,10 @@ public class IdGeneratorMapper implements IdGenerator {
 		}
 		catch (StatusException ex) {
 			log.error("生成雪花ID失败，错误信息：{}", ex.getMessage(), ex);
-			throw new ServiceNotFoundException("B_Service_GenerateSnowflakeIdNotFound", "调用生成雪花ID服务失败，请联系管理员", ex);
+			throw StatusExceptionHandler.handle(ex,
+					new ServiceNotFoundException("B_Service_GenerateSnowflakeIdNotFound",
+							String.format("【%s】调用生成雪花ID服务失败，请联系管理员", springUtils.getServiceId()), ex),
+					springUtils.getServiceId());
 		}
 	}
 
@@ -61,7 +70,10 @@ public class IdGeneratorMapper implements IdGenerator {
 		}
 		catch (StatusException ex) {
 			log.error("批量生成雪花IDS失败，错误信息：{}", ex.getMessage(), ex);
-			throw new ServiceNotFoundException("B_Service_GenerateSnowflakeIdsNotFound", "调用生成雪花IDS服务失败，请联系管理员", ex);
+			throw StatusExceptionHandler.handle(ex,
+					new ServiceNotFoundException("B_Service_GenerateSnowflakeIdsNotFound",
+							String.format("【%s】调用生成雪花IDS服务失败，请联系管理员", springUtils.getServiceId()), ex),
+					springUtils.getServiceId());
 		}
 	}
 

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/GrantedAuthority.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/GrantedAuthority.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-2026 KCloud-Platform-IoT Author or Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.laokou.common.security.config;
+
+import lombok.Getter;
+
+/**
+ * @author laokou
+ */
+@Getter
+enum GrantedAuthority {
+
+	READ("read", "读"),
+
+	WRITE("write", "写");
+
+	private final String code;
+
+	private final String desc;
+
+	GrantedAuthority(String code, String desc) {
+		this.code = code;
+		this.desc = desc;
+	}
+
+}

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
@@ -27,7 +27,6 @@ import org.laokou.common.context.util.UserConvertor;
 import org.laokou.common.context.util.UserExtDetails;
 import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.common.i18n.common.exception.StatusCode;
-import org.laokou.common.i18n.util.InstantUtils;
 import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.RedisKeyUtils;
 import org.laokou.common.redis.util.RedisUtils;
@@ -48,8 +47,8 @@ import org.springframework.security.oauth2.server.resource.introspection.OpaqueT
 
 import java.security.Principal;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -87,7 +86,7 @@ public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authoriza
 	private CachedPrincipal getCachedPrincipal(@NonNull String token) {
 		if (ObjectUtils.equals(systemSettingsProperties.getAnonymousAuthToken(), token)) {
 			// 匿名认证
-			return new CachedPrincipal(new DefaultOAuth2AuthenticatedPrincipal("anonymous", Collections.emptyMap(), AuthorityUtils.createAuthorityList(List.of(GrantedAuthority.WRITE.getCode(), GrantedAuthority.READ.getCode()))), InstantUtils.now());
+			return new CachedPrincipal(new DefaultOAuth2AuthenticatedPrincipal("anonymous", Map.of("sub", "anonymous"), AuthorityUtils.createAuthorityList(List.of(GrantedAuthority.WRITE.getCode(), GrantedAuthority.READ.getCode()))), null);
 		}
 		Jwt jwt = jwtDecoder.decode(token);
 		Instant expiresAt = jwt.getExpiresAt();

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
@@ -25,12 +25,17 @@ import org.jspecify.annotations.NonNull;
 import org.laokou.common.context.util.OAuth2Authentication;
 import org.laokou.common.context.util.UserConvertor;
 import org.laokou.common.context.util.UserExtDetails;
+import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.common.i18n.common.exception.StatusCode;
+import org.laokou.common.i18n.util.InstantUtils;
+import org.laokou.common.i18n.util.ObjectUtils;
 import org.laokou.common.i18n.util.RedisKeyUtils;
 import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.handler.OAuth2ExceptionHandler;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
@@ -43,6 +48,8 @@ import org.springframework.security.oauth2.server.resource.introspection.OpaqueT
 
 import java.security.Principal;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -50,7 +57,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authorizationService, RedisUtils redisUtils,
-		JwtDecoder jwtDecoder) implements OpaqueTokenIntrospector {
+		JwtDecoder jwtDecoder, SystemSettingsProperties systemSettingsProperties) implements OpaqueTokenIntrospector {
 
 	private static final Cache<@NonNull String, @NonNull CachedPrincipal> PRINCIPAL_CACHE = Caffeine.newBuilder()
 		.initialCapacity(100000)
@@ -78,6 +85,10 @@ public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authoriza
 	}
 
 	private CachedPrincipal getCachedPrincipal(@NonNull String token) {
+		if (ObjectUtils.equals(systemSettingsProperties.getAnonymousAuthToken(), token)) {
+			// 匿名认证
+			return new CachedPrincipal(new DefaultOAuth2AuthenticatedPrincipal("anonymous", Collections.emptyMap(), AuthorityUtils.createAuthorityList(List.of(GrantedAuthority.WRITE.getCode(), GrantedAuthority.READ.getCode()))), InstantUtils.now());
+		}
 		Jwt jwt = jwtDecoder.decode(token);
 		Instant expiresAt = jwt.getExpiresAt();
 		if (expiresAt != null && expiresAt.isBefore(Instant.now())) {

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2ResourceServerConfig.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2ResourceServerConfig.java
@@ -36,6 +36,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.HashSet;
@@ -89,7 +90,7 @@ public class OAuth2ResourceServerConfig {
 	@Bean
 	@Order(Ordered.HIGHEST_PRECEDENCE + 1000)
 	@ConditionalOnMissingBean(SecurityFilterChain.class)
-	SecurityFilterChain resourceFilterChain(OAuth2OpaqueTokenIntrospector opaqueTokenIntrospector,
+	SecurityFilterChain resourceFilterChain(OpaqueTokenIntrospector opaqueTokenIntrospector,
                                             SpringUtils springUtils, OAuth2ResourceServerProperties oAuth2ResourceServerProperties, HttpSecurity http)
 			{
 		return http

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospectorTest.java
@@ -20,6 +20,7 @@ package org.laokou.common.security.config;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.common.redis.util.RedisUtils;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -51,11 +52,14 @@ class OAuth2OpaqueTokenIntrospectorTest {
 	@Mock
 	private JwtDecoder jwtDecoder;
 
+	@Mock
+	private SystemSettingsProperties systemSettingsProperties;
+
 	@Test
 	void test_introspect_throws_exception_when_authorization_is_null() {
 		// Given
 		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
-				jwtDecoder);
+				jwtDecoder, systemSettingsProperties);
 		Mockito.when(authorizationService.findByToken("invalid-token", OAuth2TokenType.ACCESS_TOKEN)).thenReturn(null);
 
 		// Then
@@ -66,7 +70,7 @@ class OAuth2OpaqueTokenIntrospectorTest {
 	void test_introspect_throws_exception_when_accessToken_is_null() {
 		// Given
 		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
-				jwtDecoder);
+				jwtDecoder, systemSettingsProperties);
 		RegisteredClient registeredClient = createRegisteredClient();
 		OAuth2Authorization authorization = OAuth2Authorization.withRegisteredClient(registeredClient)
 			.principalName("user")
@@ -83,7 +87,7 @@ class OAuth2OpaqueTokenIntrospectorTest {
 	void test_record_constructor() {
 		// When
 		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
-				jwtDecoder);
+				jwtDecoder, systemSettingsProperties);
 
 		// Then
 		Assertions.assertThat(introspector.authorizationService()).isEqualTo(authorizationService);

--- a/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-admin/laokou-admin-start/src/main/resources/application.yml
@@ -80,20 +80,6 @@ spring:
             timeout: 30s
   security:
     oauth2:
-      client:
-        registration:
-          default:
-            client-id: 95TxSsTPFA3tF12TBSMmUVK0da
-            client-secret: FpHwIfw4wY92dO
-            client-name: OAuth2.1 M2M认证客户端
-            authorization-grant-type: client_credentials
-            client-authentication-method: client_secret_basic
-            scope:
-              - read
-            provider: local
-        provider:
-          local:
-            token-uri: http://127.0.0.1:90/api/v1/oauth2/token
       resource-server:
         enabled: true
         request-matcher:

--- a/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/CaptchaSendCmdExe.java
+++ b/laokou-service/laokou-auth/laokou-auth-app/src/main/java/org/laokou/auth/command/CaptchaSendCmdExe.java
@@ -42,8 +42,7 @@ public class CaptchaSendCmdExe {
 	@CommandLog
 	public void executeVoid(CaptchaSendCmd cmd) {
 		CaptchaCO co = cmd.getCo();
-		domainService.createCaptcha(
-				DomainFactory.createAuth().createCaptchaVBySend(co.getUuid(), co.getTag(), co.getTenantCode()));
+		domainService.createCaptcha(DomainFactory.createAuth().createCaptchaVBySend(co.getUuid(), co.getTag()));
 		// 发布领域事件
 		// kafkaDomainEventPublisher.publish(authA.getSendCaptchaTypeEnum().getMqTopic(),
 		// AuthConvertor.toDomainEvent(authA));

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/ability/DomainService.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/ability/DomainService.java
@@ -55,6 +55,8 @@ public class DomainService {
 	}
 
 	public void auth(AuthA authA) {
+		// 初始化
+		authA.init();
 		// 校验认证参数
 		authA.checkAuthParam();
 		// 校验验证码

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/AuthA.java
@@ -198,44 +198,55 @@ public final class AuthA extends AggregateRoot implements ValidateName {
 	}
 	// @formatter:on
 
+	public void init() {
+		super.createTime = InstantUtils.now();
+		super.id = idGenerator.getId();
+	}
+
+	public AuthA createDefaultAuth(String grantType) {
+		super.id = System.currentTimeMillis();
+		super.createTime = InstantUtils.now();
+		return this;
+	}
+
 	public AuthA createUsernamePasswordAuth() {
 		this.grantType = GrantType.USERNAME_PASSWORD;
 		this.captchaV = getCaptchaVByUsernamePasswordAuth();
 		this.userV = getUserVByUsernamePasswordAuth();
-		return create();
+		return this;
 	}
 
 	public AuthA createMobileAuth() {
 		this.grantType = GrantType.MOBILE;
 		this.captchaV = getCaptchaVByMobileAuth();
 		this.userV = getUserVByMobileAuth();
-		return create();
+		return this;
 	}
 
 	public AuthA createMailAuth() {
 		this.grantType = GrantType.MAIL;
 		this.captchaV = getCaptchaVByMailAuth();
 		this.userV = getUserVByMailAuth();
-		return create();
+		return this;
 	}
 
 	public AuthA createAuthorizationCodeAuth() {
 		this.grantType = GrantType.AUTHORIZATION_CODE;
 		this.captchaV = getCaptchaVByAuthorizationCodeAuth();
 		this.userV = getUserVByAuthorizationCodeAuth();
-		return create();
+		return this;
 	}
 
 	public AuthA createTestAuth() {
 		this.grantType = GrantType.TEST;
 		this.userV = getUserVByTestAuth();
-		return create();
+		return this;
 	}
 
-	public AuthA createCaptchaVBySend(String uuid, String tag, String tenantCode) {
+	public AuthA createCaptchaVBySend(String uuid, String tag) {
 		this.sendCaptchaType = SendCaptchaType.getByCode(tag);
 		this.captchaV = CaptchaV.builder().uuid(uuid).build();
-		return create();
+		return this;
 	}
 
 	public String getCaptchaBySend() {
@@ -488,12 +499,6 @@ public final class AuthA extends AggregateRoot implements ValidateName {
 			log.error("getUserVByMailAuth error: {}", ex.getMessage(), ex);
 			throw new IllegalArgumentException(ex.getMessage());
 		}
-	}
-
-	private AuthA create() {
-		super.id = idGenerator.getId();
-		super.createTime = InstantUtils.now();
-		return this;
 	}
 
 }

--- a/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/entity/UserE.java
+++ b/laokou-service/laokou-auth/laokou-auth-domain/src/main/java/org/laokou/auth/model/entity/UserE.java
@@ -38,8 +38,8 @@ import java.io.Serializable;
 @Getter
 @Builder(toBuilder = true)
 @EqualsAndHashCode(callSuper = false)
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class UserE implements Serializable {
 
 	/**

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2AuthorizationServerConfig.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/config/OAuth2AuthorizationServerConfig.java
@@ -32,6 +32,7 @@ import org.laokou.auth.model.validator.PasswordValidator;
 import org.laokou.common.fory.config.ForyFactory;
 import org.laokou.common.i18n.common.IdGenerator;
 import org.laokou.common.i18n.util.ObjectUtils;
+import org.laokou.common.i18n.util.SpringUtils;
 import org.laokou.common.redis.util.RedisUtils;
 import org.laokou.common.security.config.RedisOAuth2AuthorizationConsentService;
 import org.laokou.common.security.config.RedisRegisteredClientRepository;
@@ -222,8 +223,8 @@ class OAuth2AuthorizationServerConfig {
 	@Bean(name = "idGenerator")
 	@ConditionalOnProperty(prefix = "system-settings", name = "app-mode", havingValue = "MICROSERVICE",
 			matchIfMissing = true)
-	IdGenerator idGeneratorMapper() {
-		return new IdGeneratorMapper();
+	IdGenerator idGeneratorMapper(SpringUtils springUtils) {
+		return new IdGeneratorMapper(springUtils);
 	}
 
 	private Boolean validateCaptcha(String key, String code) {

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/convertor/LoginLogConvertor.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/convertor/LoginLogConvertor.java
@@ -17,6 +17,7 @@
 
 package org.laokou.auth.convertor;
 
+import com.baomidou.mybatisplus.core.toolkit.IdWorker;
 import com.blueconic.browscap.Capabilities;
 import io.micrometer.common.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
@@ -106,21 +107,22 @@ public final class LoginLogConvertor {
 
 	public static LoginEvent toDomainEvent(HttpServletRequest request, AuthA authA, GlobalException gex) {
 		try {
+			Long id = authA.getId();
 			Capabilities capabilities = RequestUtils.getCapabilities(request);
 			String ipAddress = IpUtils.getIpAddress(request);
 			int status = LoginStatus.OK.getCode();
 			UserE userE = authA.getUserE();
-			Optional<UserE> optional = Optional.ofNullable(userE);
-			Long creator = optional.map(UserE::getId).orElse(null);
-			Long tenantId = optional.map(UserE::getTenantId).orElse(null);
-			Long deptId = optional.map(UserE::getDeptId).orElse(null);
+			Optional<UserE> userOptional = Optional.ofNullable(userE);
+			Long creator = userOptional.map(UserE::getId).orElse(null);
+			Long tenantId = userOptional.map(UserE::getTenantId).orElse(null);
+			Long deptId = userOptional.map(UserE::getDeptId).orElse(null);
 			String errorMessage = StringConstants.EMPTY;
 			if (ObjectUtils.isNotNull(gex)) {
 				status = LoginStatus.FAIL.getCode();
 				errorMessage = gex.getMsg();
 			}
 			return LoginEvent.builder()
-				.id(authA.getId())
+				.id(ObjectUtils.isNotNull(id) ? id : IdWorker.getId())
 				.username(authA.getLoginName())
 				.ipAddress(ipAddress)
 				.address(AddressUtils.getRealAddress(ipAddress))

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/gatewayimpl/rpc/IdGeneratorMapper.java
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/java/org/laokou/auth/gatewayimpl/rpc/IdGeneratorMapper.java
@@ -18,10 +18,13 @@
 package org.laokou.auth.gatewayimpl.rpc;
 
 import io.grpc.StatusException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.common.grpc.client.annotation.GrpcClient;
 import org.laokou.common.grpc.client.exception.ServiceNotFoundException;
+import org.laokou.common.grpc.client.exception.handler.StatusExceptionHandler;
 import org.laokou.common.i18n.common.IdGenerator;
+import org.laokou.common.i18n.util.SpringUtils;
 import org.laokou.snowflake.id.proto.GenerateBatchIdsRequest;
 import org.laokou.snowflake.id.proto.GenerateBatchIdsResponse;
 import org.laokou.snowflake.id.proto.GenerateIdRequest;
@@ -34,7 +37,10 @@ import java.util.List;
  * @author laokou
  */
 @Slf4j
+@RequiredArgsConstructor
 public class IdGeneratorMapper implements IdGenerator {
+
+	private final SpringUtils springUtils;
 
 	@GrpcClient(serviceId = "laokou-snowflake-id")
 	private SnowflakeIdServiceIGrpc.SnowflakeIdServiceIBlockingV2Stub snowflakeIdServiceIBlockingV2Stub;
@@ -48,7 +54,10 @@ public class IdGeneratorMapper implements IdGenerator {
 		}
 		catch (StatusException ex) {
 			log.error("生成雪花ID失败，错误信息：{}", ex.getMessage(), ex);
-			throw new ServiceNotFoundException("B_Service_GenerateSnowflakeIdNotFound", "调用生成雪花ID服务失败，请联系管理员", ex);
+			throw StatusExceptionHandler.handle(ex,
+					new ServiceNotFoundException("B_Service_GenerateSnowflakeIdNotFound",
+							String.format("【%s】调用生成雪花ID服务失败，请联系管理员", springUtils.getServiceId()), ex),
+					springUtils.getServiceId());
 		}
 	}
 
@@ -61,7 +70,10 @@ public class IdGeneratorMapper implements IdGenerator {
 		}
 		catch (StatusException ex) {
 			log.error("批量生成雪花IDS失败，错误信息：{}", ex.getMessage(), ex);
-			throw new ServiceNotFoundException("B_Service_GenerateSnowflakeIdsNotFound", "调用生成雪花IDS服务失败，请联系管理员", ex);
+			throw StatusExceptionHandler.handle(ex,
+					new ServiceNotFoundException("B_Service_GenerateSnowflakeIdsNotFound",
+							String.format("【%s】调用生成雪花IDS服务失败，请联系管理员", springUtils.getServiceId()), ex),
+					springUtils.getServiceId());
 		}
 	}
 

--- a/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/main/resources/application.yml
@@ -88,20 +88,6 @@ spring:
   # security
   security:
     oauth2:
-      client:
-        registration:
-          default:
-            client-id: ${spring.security.oauth2.authorization-server.client.default.registration.client-id}
-            client-secret: FpHwIfw4wY92dO
-            client-name: OAuth2.1 M2M认证客户端
-            authorization-grant-type: client_credentials
-            client-authentication-method: client_secret_basic
-            scope:
-              - read
-            provider: local
-        provider:
-          local:
-            token-uri: http://127.0.0.1:${server.port}${server.servlet.context-path}${spring.security.oauth2.authorization-server.endpoint.token-uri}
       authorization-server:
         enabled: true
         # 多租户

--- a/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
+++ b/laokou-service/laokou-auth/laokou-auth-start/src/test/java/org/laokou/auth/OAuth2ApiTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.laokou.auth.dto.CaptchaSendCmd;
 import org.laokou.auth.dto.TokenRemoveCmd;
 import org.laokou.auth.dto.clientobject.CaptchaCO;
+import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.common.core.util.HttpUtils;
 import org.laokou.common.core.util.OkHttpUtils;
 import org.laokou.common.core.util.ThreadUtils;
@@ -101,6 +102,8 @@ class OAuth2ApiTest {
 	private final PasswordEncoder passwordEncoder;
 
 	private final JwtDecoder jwtDecoder;
+
+	private final SystemSettingsProperties systemSettingsProperties;
 
 	@Test
 	void test_sendMailCaptcha() {
@@ -182,7 +185,7 @@ class OAuth2ApiTest {
 		log.info("---------- 模拟认证开始 ----------");
 		Assertions.assertThat(token).isNotBlank();
 		OAuth2OpaqueTokenIntrospector introspector = new OAuth2OpaqueTokenIntrospector(authorizationService, redisUtils,
-				jwtDecoder);
+				jwtDecoder, systemSettingsProperties);
 		log.info("认证数据：{}", JacksonUtils.toJsonStr(introspector.introspect(token)));
 		log.info("---------- 模拟认证结束 ----------");
 		log.info("---------- 用户名密码认证模式结束 ----------");

--- a/laokou-service/laokou-iot/laokou-iot-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-iot/laokou-iot-start/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: "2m"
   websocket-server:
-    port: 1001
+    port: 13000
     service-id: ${spring.application.name}-websocket
     key-cert-private-key-password: laokou
   # security
@@ -59,9 +59,9 @@ spring:
         request-matcher:
           ignore-patterns:
             GET:
-              - /v3/api-docs/**=laokou-iot
-              - /actuator/**=laokou-iot
-              - /scalar/**=laokou-iot
+              - /v3/api-docs/**=${spring.application.name}
+              - /actuator/**=${spring.application.name}
+              - /scalar/**=${spring.application.name}
   grpc:
     client:
       channel:

--- a/laokou-service/laokou-iot/laokou-iot-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-iot/laokou-iot-start/src/main/resources/application.yml
@@ -54,20 +54,6 @@ spring:
   # security
   security:
     oauth2:
-      client:
-        registration:
-          default:
-            client-id: 95TxSsTPFA3tF12TBSMmUVK0da
-            client-secret: FpHwIfw4wY92dO
-            client-name: OAuth2.1 M2M认证客户端
-            authorization-grant-type: client_credentials
-            client-authentication-method: client_secret_basic
-            scope:
-              - read
-            provider: local
-        provider:
-          local:
-            token-uri: http://127.0.0.1:90/api/v1/oauth2/token
       resource-server:
         enabled: true
         request-matcher:

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/src/main/java/org/laokou/snowflake/id/service/SnowflakeIdServiceImpl.java
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/src/main/java/org/laokou/snowflake/id/service/SnowflakeIdServiceImpl.java
@@ -46,7 +46,7 @@ public class SnowflakeIdServiceImpl extends SnowflakeIdServiceIGrpc.SnowflakeIdS
 	private final String resultMsg = MessageUtils.getMessage(StatusCode.OK);
 
 	@Override
-	@PreAuthorize("hasAuthority('SCOPE_read')")
+	@PreAuthorize("hasAuthority('read')")
 	public void generateId(GenerateIdRequest request, StreamObserver<GenerateIdResponse> responseObserver) {
 		GenerateIdResponse response = GenerateIdResponse.newBuilder()
 			.setCode(StatusCode.OK)
@@ -58,7 +58,7 @@ public class SnowflakeIdServiceImpl extends SnowflakeIdServiceIGrpc.SnowflakeIdS
 	}
 
 	@Override
-	@PreAuthorize("hasAuthority('SCOPE_read')")
+	@PreAuthorize("hasAuthority('read')")
 	public void generateBatchIds(GenerateBatchIdsRequest request,
 			StreamObserver<GenerateBatchIdsResponse> responseObserver) {
 		GenerateBatchIdsResponse.Builder builder = GenerateBatchIdsResponse.newBuilder()

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
@@ -27,6 +27,24 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.ulisesbocchio</groupId>
+      <artifactId>jasypt-spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-proto</artifactId>
       <version>${project.version}</version>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>laokou-common-grpc-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/src/main/java/org/laokou/snowflake/id/config/NacosSnowflakeIdGenerator.java
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/src/main/java/org/laokou/snowflake/id/config/NacosSnowflakeIdGenerator.java
@@ -347,7 +347,7 @@ public final class NacosSnowflakeIdGenerator implements IdGenerator {
 	}
 
 	private int getServerPort() {
-		return Integer.parseInt(environment.getProperty("server.port", System.getProperty("server.port", "9094")));
+		return Integer.parseInt(environment.getProperty("server.port", System.getProperty("server.port", "20000")));
 	}
 
 	private int getGrpcServerPort() {

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/java/org/laokou/snowflake/id/SnowflakeIdApp.java
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/java/org/laokou/snowflake/id/SnowflakeIdApp.java
@@ -17,7 +17,10 @@
 
 package org.laokou.snowflake.id;
 
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.laokou.common.i18n.util.SslUtils;
+import org.laokou.common.security.annotation.EnableSecurity;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -28,6 +31,8 @@ import org.springframework.util.StopWatch;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * 系统服务启动类. exposeProxy=true => 使用Cglib代理，在切面中暴露代理对象，进行方法增强
@@ -35,14 +40,16 @@ import java.net.UnknownHostException;
  * @author laokou
  */
 @Slf4j
+@EnableSecurity
 @EnableAspectJAutoProxy
+@EnableEncryptableProperties
 @EnableConfigurationProperties
 @EnableDiscoveryClient(autoRegister = false)
 @SpringBootApplication(scanBasePackages = "org.laokou")
 class SnowflakeIdApp {
 
 	// @formatter:off
-	static void main(String[] args) throws UnknownHostException {
+	static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
 		StopWatch stopWatch = new StopWatch("SnowflakeId应用程序");
 		stopWatch.start();
 		System.setProperty("ENDPOINT", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(), System.getProperty("spring.grpc.server.port", "19094")));
@@ -50,6 +57,9 @@ class SnowflakeIdApp {
 		System.setProperty("nacos.logging.default.config.enabled", "false");
 		// 关闭sentinel健康检查 https://github.com/alibaba/Sentinel/issues/1494
 		System.setProperty("management.health.sentinel.enabled", "false");
+		// nacos认证 => HttpLoginProcessor，https://github.com/alibaba/nacos/pull/3654
+		// 忽略SSL认证
+		SslUtils.ignoreSSLTrust();
 		new SpringApplicationBuilder(SnowflakeIdApp.class).web(WebApplicationType.SERVLET).run(args);
 		stopWatch.stop();
 		log.info("{}", stopWatch.prettyPrint());

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/java/org/laokou/snowflake/id/SnowflakeIdApp.java
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/java/org/laokou/snowflake/id/SnowflakeIdApp.java
@@ -19,14 +19,13 @@ package org.laokou.snowflake.id;
 
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import lombok.extern.slf4j.Slf4j;
-import org.laokou.common.core.annotation.EnableWarmUp;
 import org.laokou.common.i18n.util.SslUtils;
-import org.laokou.common.nacos.annotation.EnablePrintRouter;
 import org.laokou.common.security.annotation.EnableSecurity;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.grpc.server.autoconfigure.security.GrpcServerOAuth2ResourceServerAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.util.StopWatch;
@@ -42,14 +41,12 @@ import java.security.NoSuchAlgorithmException;
  * @author laokou
  */
 @Slf4j
-@EnableWarmUp
 @EnableSecurity
-@EnablePrintRouter
 @EnableAspectJAutoProxy
 @EnableEncryptableProperties
 @EnableConfigurationProperties
 @EnableDiscoveryClient(autoRegister = false)
-@SpringBootApplication(scanBasePackages = "org.laokou")
+@SpringBootApplication(scanBasePackages = "org.laokou", exclude = GrpcServerOAuth2ResourceServerAutoConfiguration.class)
 class SnowflakeIdApp {
 
 	// @formatter:off

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/java/org/laokou/snowflake/id/SnowflakeIdApp.java
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/java/org/laokou/snowflake/id/SnowflakeIdApp.java
@@ -19,7 +19,9 @@ package org.laokou.snowflake.id;
 
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.laokou.common.core.annotation.EnableWarmUp;
 import org.laokou.common.i18n.util.SslUtils;
+import org.laokou.common.nacos.annotation.EnablePrintRouter;
 import org.laokou.common.security.annotation.EnableSecurity;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -40,7 +42,9 @@ import java.security.NoSuchAlgorithmException;
  * @author laokou
  */
 @Slf4j
+@EnableWarmUp
 @EnableSecurity
+@EnablePrintRouter
 @EnableAspectJAutoProxy
 @EnableEncryptableProperties
 @EnableConfigurationProperties
@@ -52,7 +56,7 @@ class SnowflakeIdApp {
 	static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
 		StopWatch stopWatch = new StopWatch("SnowflakeId应用程序");
 		stopWatch.start();
-		System.setProperty("ENDPOINT", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(), System.getProperty("spring.grpc.server.port", "19094")));
+		System.setProperty("ENDPOINT", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(), System.getProperty("spring.grpc.server.port", "20000")));
 		// 配置关闭nacos日志，因为nacos的log4j2导致本项目的日志不输出的问题
 		System.setProperty("nacos.logging.default.config.enabled", "false");
 		// 关闭sentinel健康检查 https://github.com/alibaba/Sentinel/issues/1494

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application-dev.yml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application-dev.yml
@@ -15,6 +15,26 @@
 #    *
 #    */
 spring:
+  data:
+    redis:
+      client-type: lettuce
+      host: redis
+      port: 6379
+      password: ENC(BhsqlMbKjWVxPseo9OX8osLuL2Y4rWfGTyBRXaZTsAdzZ1Z4rBewBmoXjf2Hnu4o)
+      connect-timeout: 60000ms #连接超时时长（毫秒）
+      timeout: 60000ms #超时时长（毫秒）
+      lettuce:
+        pool:
+          max-active: 1000 #连接池最大连接数
+          max-wait: 2m #连接池最大阻塞等待时间
+          max-idle: 500 #连接池最大空闲连接
+          min-idle: 200 #连接池最小空间连接
+  redisson:
+    password: ${spring.data.redis.password}
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
   config:
     import:
       # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application-prod.yml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application-prod.yml
@@ -15,6 +15,26 @@
 #    *
 #    */
 spring:
+  data:
+    redis:
+      client-type: lettuce
+      host: redis
+      port: 6379
+      password: ENC(BhsqlMbKjWVxPseo9OX8osLuL2Y4rWfGTyBRXaZTsAdzZ1Z4rBewBmoXjf2Hnu4o)
+      connect-timeout: 60000ms #连接超时时长（毫秒）
+      timeout: 60000ms #超时时长（毫秒）
+      lettuce:
+        pool:
+          max-active: 1000 #连接池最大连接数
+          max-wait: 2m #连接池最大阻塞等待时间
+          max-idle: 500 #连接池最大空闲连接
+          min-idle: 200 #连接池最小空间连接
+  redisson:
+    password: ${spring.data.redis.password}
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
   config:
     import:
       # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application-test.yml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application-test.yml
@@ -15,6 +15,26 @@
 #    *
 #    */
 spring:
+  data:
+    redis:
+      client-type: lettuce
+      host: redis
+      port: 6379
+      password: ENC(BhsqlMbKjWVxPseo9OX8osLuL2Y4rWfGTyBRXaZTsAdzZ1Z4rBewBmoXjf2Hnu4o)
+      connect-timeout: 60000ms #连接超时时长（毫秒）
+      timeout: 60000ms #超时时长（毫秒）
+      lettuce:
+        pool:
+          max-active: 1000 #连接池最大连接数
+          max-wait: 2m #连接池最大阻塞等待时间
+          max-idle: 500 #连接池最大空闲连接
+          min-idle: 200 #连接池最小空间连接
+  redisson:
+    password: ${spring.data.redis.password}
+    node:
+      type: single
+      single:
+        address: redis://${spring.data.redis.host}:${spring.data.redis.port}
   config:
     import:
       # 临时配置文件【解决拉取nacos配置文件时，group默认为DEFAULT_GROUP问题】

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application.yml
@@ -18,6 +18,48 @@ jasypt:
   encryptor:
     password: ${SECRET_KEY:laokou}
 
+server:
+  compression:
+    enabled: true
+  ssl:
+    # 开启证书
+    enabled: false
+    # 证书位置
+    key-store: classpath:scg-keystore.p12
+    # 证书别名
+    key-alias: ${spring.application.name}
+    # 秘钥类型
+    key-store-type: PKCS12
+    # 证书密码
+    key-store-password: laokou
+  http2:
+    enabled: false
+  forward-headers-strategy: framework
+  shutdown: graceful
+  port: ${SERVER_PORT:18000}
+  servlet:
+    context-path: /api
+    session:
+      cookie:
+        same-site: none
+        secure: true
+        http-only: true
+      timeout: 30m
+  tomcat:
+    threads:
+      # 工作线程池的最大线程数
+      max: 500
+      # 工作线程池的最小备用线程数
+      min-spare: 50
+    # 最大连接数
+    max-connections: 10000
+    # 当所有工作线程都在忙时，允许等待处理的最大连接数
+    accept-count: 200
+    # URI编码
+    uri-encoding: UTF-8
+    # 连接超时时间
+    connection-timeout: 60s
+
 spring:
   application:
     name: ${SERVICE_ID:laokou-snowflake-id}

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application.yml
@@ -40,6 +40,16 @@ spring:
         enabled: false
       port: ${GRPC_PORT:20000}
       enabled: true
+  security:
+    oauth2:
+      resource-server:
+        enabled: true
+        request-matcher:
+          ignore-patterns:
+            GET:
+              - /v3/api-docs/**=${spring.application.name}
+              - /actuator/**=${spring.application.name}
+              - /scalar/**=${spring.application.name}
 
 logging:
   config: classpath:log4j2-@PROFILE-ACTIVE@.xml

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/src/main/resources/application.yml
@@ -14,6 +14,10 @@
 #    * limitations under the License.
 #    *
 #    */
+jasypt:
+  encryptor:
+    password: ${SECRET_KEY:laokou}
+
 spring:
   application:
     name: ${SERVICE_ID:laokou-snowflake-id}
@@ -30,17 +34,15 @@ spring:
       ignored-interfaces:
         - docker0
         - veth.*
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: http://127.0.0.1:90/api/v1/oauth2/jwks
   grpc:
     server:
       servlet:
         enabled: false
-      port: ${GRPC_PORT:19094}
+      port: ${GRPC_PORT:20000}
       enabled: true
 
 logging:
   config: classpath:log4j2-@PROFILE-ACTIVE@.xml
+
+system-settings:
+  app-mode: microservice

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/src/main/resources/application.yml
@@ -71,9 +71,9 @@ spring:
         request-matcher:
           ignore-patterns:
             GET:
-              - /v3/api-docs/**=laokou-standalone-admin
-              - /actuator/**=laokou-standalone-admin
-              - /doc.html=laokou-standalone-admin
+              - /v3/api-docs/**=${spring.application.name}
+              - /actuator/**=${spring.application.name}
+              - /doc.html=${spring.application.name}
   cache:
     configs:
       users:

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/src/main/resources/application.yml
@@ -78,20 +78,6 @@ spring:
   # security
   security:
     oauth2:
-      client:
-        registration:
-          default:
-            client-id: ${spring.security.oauth2.authorization-server.client.default.registration.client-id}
-            client-secret: FpHwIfw4wY92dO
-            client-name: OAuth2.1 M2M认证客户端
-            authorization-grant-type: client_credentials
-            client-authentication-method: client_secret_basic
-            scope:
-              - read
-            provider: local
-        provider:
-          local:
-            token-uri: http://127.0.0.1:${server.port}${server.servlet.context-path}${spring.security.oauth2.authorization-server.endpoint.token-uri}
       authorization-server:
         enabled: true
         # 多租户

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/src/main/resources/application.yml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/src/main/resources/application.yml
@@ -171,20 +171,20 @@ spring:
         request-matcher:
           ignore-patterns:
             GET:
-              - /v3/api-docs/**=laokou-standalone-auth
-              - /actuator/**=laokou-standalone-auth
-              - /error=laokou-standalone-auth
-              - /v1/username-password/captchas/{uuid}=laokou-standalone-auth
-              - /v1/authorization-code/captchas/{uuid}=laokou-standalone-auth
-              - /v1/secrets=laokou-standalone-auth
-              - /doc.html=laokou-standalone-auth
-              - /img/**=laokou-standalone-auth
-              - /js/**=laokou-standalone-auth
+              - /v3/api-docs/**=${spring.application.name}
+              - /actuator/**=${spring.application.name}
+              - /error=${spring.application.name}
+              - /v1/username-password/captchas/{uuid}=${spring.application.name}
+              - /v1/authorization-code/captchas/{uuid}=${spring.application.name}
+              - /v1/secrets=${spring.application.name}
+              - /doc.html=${spring.application.name}
+              - /img/**=${spring.application.name}
+              - /js/**=${spring.application.name}
             POST:
-              - /v1/captchas/send-mail=laokou-standalone-auth
-              - /v1/captchas/send-mobile=laokou-standalone-auth
+              - /v1/captchas/send-mail=${spring.application.name}
+              - /v1/captchas/send-mobile=${spring.application.name}
             DELETE:
-              - /v1/tokens=laokou-standalone-auth
+              - /v1/tokens=${spring.application.name}
   cache:
     configs:
       oss_resource:

--- a/ui/config/proxy.ts
+++ b/ui/config/proxy.ts
@@ -13,9 +13,9 @@ export default {
 	dev: {
 		'/api-proxy/': {
 			// Nginx单体代理地址
-			target: 'http://127.0.0.1:98',
+			// target: 'http://127.0.0.1:98',
 			// Nginx微服务代理地址
-			// target: 'http://127.0.0.1:88/api-gateway',
+			target: 'http://127.0.0.1:88/api-gateway',
 			changeOrigin: true,
 			pathRewrite: { '^/api-proxy': '' },
 		}


### PR DESCRIPTION
## Summary by Sourcery

通过切换到不透明令牌（opaque token）自省机制，在 HTTP 和 gRPC 之间统一安全策略：将入站 HTTP 请求中的 bearer token 传递到下游 gRPC 调用，引入用于内部调用的匿名访问令牌，同时将 Snowflake ID 服务接入微服务栈，配合基于 Redis 的 Jasypt 加密配置以及更新后的端口设置。

New Features:
- 通过 `SystemSettingsProperties` 引入匿名访问令牌机制，以支持“未认证但已授权”的内部调用场景。
- 新增 `StatusExceptionHandler`，将 gRPC 认证失败转换为统一的业务异常，并提供对具体服务敏感的错误信息。
- 为 Snowflake ID 服务启用可加密属性支持以及 Redis/Redisson 配置，使用 Jasypt 加密的密钥。

Bug Fixes:
- 确保登录事件始终具有 ID：当 `AuthA` 没有 ID 时回退使用由 `IdWorker` 生成的值。
- 通过将 Snowflake ID gRPC 服务方法的授权从带 `SCOPE_` 前缀的 scope 改为简单的权限值（`read`/`write`），避免不匹配的 scope 校验问题。

Enhancements:
- 重构 gRPC 客户端安全逻辑，复用入站 HTTP 请求中的 bearer token，或在缺失时回退到匿名令牌，移除之前的 OAuth2 client-credentials 流程。
- 更新 `OAuth2OpaqueTokenIntrospector` 以支持匿名令牌，并在 HTTP 与 gRPC 资源服务器之间统一不透明令牌自省逻辑。
- 在应用配置中使用 `spring.application.name` 占位符，在各个服务与独立应用之间标准化安全忽略（ignore）模式。
- 通过新的 `init` 方法显式初始化 `AuthA` 的 ID 与时间戳，并简化不同授权类型（grant type）的创建方法，以避免重复分配 ID。
- 将 `IdGeneratorMapper` bean 连接到 `SpringUtils` 和 `StatusExceptionHandler`，使 Snowflake ID RPC 失败时能产生更清晰、且与服务相关的错误信息。
- 将 `UserE` 构造函数公开，以支持更广泛的领域使用场景。
- 更新 Snowflake ID 应用启动配置，启用安全功能，忽略 Nacos 的 SSL 校验，调整端口，并排除冗余的 gRPC OAuth2 自动配置。

Build:
- 在 Snowflake ID 基础设施模块中添加 `jasypt-spring-boot-starter` 和 `spring-boot-starter-webmvc` 依赖。
- 在通用 gRPC 服务端模块中，用 `laokou-common-security` 替换原有的 gRPC 服务端 OAuth2 资源服务器 starter。
- 从通用 gRPC 客户端模块中移除 OAuth2 client starter，因为 gRPC 调用现在复用传递过来的 bearer token。

Tests:
- 简化 `GrpcClientTest`，移除基于 WireMock 的 OAuth2 客户端设置及相关配置。
- 调整 `OAuth2OpaqueTokenIntrospector` 测试和 `OAuth2ApiTest`，以适配引入 `SystemSettingsProperties` 后更新的构造函数签名。

Chores:
- 将前端 UI 开发代理配置切换为指向微服务网关，而非独立的 Nginx 代理。
- 调整各类服务端口（gRPC、websocket、HTTP）和服务器设置，例如压缩、SSL 占位符、HTTP/2 以及 Tomcat 调优。
- 在 Snowflake ID 服务中添加 `system-settings.app-mode` 配置，以配合条件化 bean 装配逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify security across HTTP and gRPC by switching to opaque token introspection, propagating bearer tokens from incoming HTTP requests to downstream gRPC calls, and introducing an anonymous access token for internal calls, while wiring Snowflake ID service into the microservice stack with Redis-backed Jasypt-encrypted configuration and updated ports.

New Features:
- Introduce an anonymous access token mechanism via SystemSettingsProperties to support unauthenticated but authorized internal calls.
- Add StatusExceptionHandler to translate gRPC authentication failures into consistent business exceptions with service-aware messages.
- Enable encryptable property support and Redis/Redisson configuration for the Snowflake ID service using Jasypt-encrypted secrets.

Bug Fixes:
- Ensure login events always have an ID by falling back to a generated IdWorker value when AuthA has no ID.
- Avoid mismatched scope checks by aligning Snowflake ID gRPC service method authorization to plain authority values (read/write) instead of SCOPE_ prefixed scopes.

Enhancements:
- Refactor gRPC client security to reuse bearer tokens from incoming HTTP requests or fall back to the anonymous token, removing the previous OAuth2 client-credentials flow.
- Update OAuth2OpaqueTokenIntrospector to support anonymous tokens and centralize opaque token introspection for both HTTP and gRPC resource servers.
- Standardize security ignore patterns in application configuration using spring.application.name placeholders across services and standalone apps.
- Initialize AuthA IDs and timestamps explicitly via a new init method and simplify grant-type-specific creation methods to avoid duplicate ID assignment.
- Wire IdGeneratorMapper beans to SpringUtils and StatusExceptionHandler so Snowflake ID RPC failures produce clearer, service-specific error messages.
- Expose UserE constructors publicly to allow broader domain usage.
- Update Snowflake ID application bootstrap to enable security, ignore SSL verification for Nacos, adjust ports, and exclude redundant gRPC OAuth2 auto-configuration.

Build:
- Add jasypt-spring-boot-starter and spring-boot-starter-webmvc dependencies to the Snowflake ID infrastructure module.
- Replace the gRPC server OAuth2 resource server starter with laokou-common-security in the common gRPC server module.
- Remove the OAuth2 client starter from the common gRPC client module now that gRPC calls reuse propagated bearer tokens.

Tests:
- Simplify GrpcClientTest by removing WireMock-based OAuth2 client setup and related configuration.
- Adapt OAuth2OpaqueTokenIntrospector tests and OAuth2ApiTest to the updated constructor signature with SystemSettingsProperties.

Chores:
- Switch the UI dev proxy configuration to target the microservice gateway instead of the standalone Nginx proxy.
- Adjust various service ports (gRPC, websocket, HTTP) and server settings such as compression, SSL placeholders, HTTP/2, and Tomcat tuning.
- Add system-settings.app-mode configuration to the Snowflake ID service to integrate with conditional bean wiring.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authentication & Security**
  * Improved token handling across services, including anonymous access and standardized permissions.
  * Updated service authentication to support opaque-token validation and direct bearer-token forwarding.
  * Removed obsolete OAuth2 client configuration.

* **Bug Fixes**
  * Improved gRPC error handling and ID generation failure reporting.
  * Corrected captcha creation and authentication initialization flows.

* **Configuration**
  * Updated service ports, Redis connectivity, encryption, and development proxy routing.
  * Added improved environment-specific infrastructure settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->