### PR TITLE
feat: 提交pulsar配置，自动创建topic

### DIFF
--- a/laokou-service/laokou-iot/laokou-iot-client/src/main/java/org/laokou/iot/session/dto/mqtt/MqttMessageType.java
+++ b/laokou-service/laokou-iot/laokou-iot-client/src/main/java/org/laokou/iot/session/dto/mqtt/MqttMessageType.java
@@ -375,11 +375,10 @@ public enum MqttMessageType {
 
 	public abstract MessageType getMessageType();
 
-	public static final MqttMessageType[] VALUES = values();
-
 	public static Map<String, Integer> getTopics(String tenantCode) {
-		Map<String, Integer> topics = Maps.newHashMapWithExpectedSize(VALUES.length);
-		for (MqttMessageType messageType : VALUES) {
+		MqttMessageType[] values = values();
+		Map<String, Integer> topics = Maps.newHashMapWithExpectedSize(values.length);
+		for (MqttMessageType messageType : values) {
 			String topic = messageType.getTopic();
 			int plusIndex = topic.indexOf('+');
 			String replacedTopic = plusIndex > 0

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/pulsar/DefaultPulsarTopicFactory.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/pulsar/DefaultPulsarTopicFactory.java
@@ -65,7 +65,7 @@ final class DefaultPulsarTopicFactory implements PulsarTopicFactory {
 			namespaces.createNamespace(namespace);
 		}
 		log.info("create topic for namespace {}", namespace);
-		for (MqttMessageType mqttMessageType : Arrays.stream(MqttMessageType.VALUES)
+		for (MqttMessageType mqttMessageType : Arrays.stream(MqttMessageType.values())
 			.filter(item -> item.getMessageType() == MessageType.GATEWAY)
 			.toList()) {
 			createTopic(topics, namespace, mqttMessageType);


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 在构建主题映射和创建 Pulsar 主题时，用直接调用枚举的 `values()` 来替换缓存的 MQTT 消息类型数组，以确保主题与枚举定义保持同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace cached MQTT message type array with direct enum values() usage in topic map construction and Pulsar topic creation to keep topics in sync with enum definitions.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT topic handling to reliably discover all supported message types.
  * Fixed Pulsar topic creation to remain compatible with the updated MQTT message type definitions.
  * Removed an exposed internal message-type array from the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->