### PR TITLE
fix: maven构建失败

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,6 +47,10 @@ jobs:
             </servers>
           </settings>
           EOF
+      - name: Pull Elasticsearch Image
+        run: docker pull koushenhai/elasticsearch9:latest
+      - name: Pull OAuth2 Test Image
+        run: docker pull koushenhai/oauth2-test:latest
       - name: Build with Maven Mvnd
         run: mvnd -T 1.5C clean install -Ptest -U
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Summary by Sourcery

更新 Maven CI 工作流程，以确保在运行构建之前所需的 Docker 镜像可用。

CI：
- 在执行构建之前，在 Maven GitHub Actions 工作流程中拉取 Elasticsearch Docker 镜像。
- 在执行构建之前，在 Maven GitHub Actions 工作流程中拉取 OAuth2 测试 Docker 镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Maven CI workflow to ensure required Docker images are available before running the build.

CI:
- Pull Elasticsearch Docker image in the Maven GitHub Actions workflow before executing the build.
- Pull OAuth2 test Docker image in the Maven GitHub Actions workflow before executing the build.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Maven CI workflow to retrieve Elasticsearch 9 and OAuth2 test images before building.
  * Improved automated build setup for integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->