### PR TITLE
fix: maven构建报错

### DIFF
--- a/laokou-common/laokou-common-elasticsearch/src/test/java/org/laokou/common/elasticsearch/ElasticsearchApiTest.java
+++ b/laokou-common/laokou-common-elasticsearch/src/test/java/org/laokou/common/elasticsearch/ElasticsearchApiTest.java
@@ -28,7 +28,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.ThreadUtils;
@@ -43,10 +42,10 @@ import org.laokou.common.elasticsearch.annotation.Setting;
 import org.laokou.common.elasticsearch.annotation.SubField;
 import org.laokou.common.elasticsearch.annotation.Type;
 import org.laokou.common.elasticsearch.config.ElasticsearchAutoConfig;
-import org.laokou.common.elasticsearch.template.Search;
 import org.laokou.common.elasticsearch.template.ElasticsearchDocumentTemplate;
 import org.laokou.common.elasticsearch.template.ElasticsearchIndexTemplate;
 import org.laokou.common.elasticsearch.template.ElasticsearchSearchTemplate;
+import org.laokou.common.elasticsearch.template.Search;
 import org.laokou.common.i18n.dto.Page;
 import org.laokou.common.testcontainers.util.DockerImageNames;
 import org.springframework.boot.ssl.DefaultSslBundleRegistry;
@@ -57,6 +56,8 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestConstructor;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -71,6 +72,7 @@ import java.util.Set;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @RequiredArgsConstructor
 @TestConfiguration
+@Testcontainers
 @ContextConfiguration(classes = { ElasticsearchAutoConfig.class, DefaultSslBundleRegistry.class })
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class ElasticsearchApiTest {
@@ -81,19 +83,9 @@ class ElasticsearchApiTest {
 
 	private final ElasticsearchDocumentTemplate elasticsearchDocumentTemplate;
 
+	@Container
 	static final ElasticsearchContainer elasticsearch = new ElasticsearchContainer(DockerImageNames.elasticsearch())
 		.withPassword("laokou123");
-
-	@BeforeAll
-	static void beforeAll() throws InterruptedException {
-		elasticsearch.start();
-		Thread.sleep(Duration.ofSeconds(10L));
-	}
-
-	@AfterAll
-	static void afterAll() {
-		elasticsearch.stop();
-	}
 
 	@DynamicPropertySource
 	static void configureProperties(DynamicPropertyRegistry registry) {
@@ -104,6 +96,11 @@ class ElasticsearchApiTest {
 		registry.add("spring.data.elasticsearch.version", () -> "9.5.1");
 		registry.add("spring.data.elasticsearch.connection-timeout", () -> "60s");
 		registry.add("spring.data.elasticsearch.socket-timeout", () -> "60s");
+	}
+
+	@BeforeAll
+	static void beforeAll() throws InterruptedException {
+		Thread.sleep(Duration.ofSeconds(30));
 	}
 
 	@Test

--- a/laokou-common/laokou-common-excel/src/test/java/org/laokou/common/excel/ExcelTest.java
+++ b/laokou-common/laokou-common-excel/src/test/java/org/laokou/common/excel/ExcelTest.java
@@ -20,8 +20,6 @@ package org.laokou.common.excel;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.FileUtils;
 import org.laokou.common.core.util.ThreadUtils;
@@ -38,6 +36,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestConstructor;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.io.FileOutputStream;
@@ -47,6 +47,7 @@ import java.util.List;
 /**
  * @author laokou
  */
+@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @RequiredArgsConstructor
 @SpringBootApplication(scanBasePackages = "org.laokou")
@@ -58,20 +59,11 @@ class ExcelTest {
 
 	private final MybatisUtils mybatisUtils;
 
+	@Container
 	static PostgreSQLContainer postgres = new PostgreSQLContainer(DockerImageNames.postgresql()).withUsername("root")
 		.withPassword("laokou123")
 		.withInitScripts("init.sql")
 		.withDatabaseName("kcloud_platform_test");
-
-	@BeforeAll
-	static void beforeAll() {
-		postgres.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		postgres.stop();
-	}
 
 	@DynamicPropertySource
 	static void configureProperties(DynamicPropertyRegistry registry) {

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
@@ -22,8 +22,6 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.core.config.SystemSettingsProperties;
 import org.laokou.common.core.util.ThreadUtils;
@@ -39,6 +37,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestConstructor;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.util.List;
@@ -47,6 +47,7 @@ import java.util.Set;
 /**
  * @author laokou
  */
+@Testcontainers
 @SpringBootConfiguration
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @RequiredArgsConstructor
@@ -59,20 +60,11 @@ class MybatisUtilsTest {
 
 	private final MybatisUtils mybatisUtils;
 
+	@Container
 	static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:latest").withUsername("root")
 		.withPassword("laokou123")
 		.withInitScript("init.sql")
 		.withDatabaseName("kcloud_platform_test");
-
-	@BeforeAll
-	static void beforeAll() {
-		postgres.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		postgres.stop();
-	}
 
 	@DynamicPropertySource
 	static void configureProperties(DynamicPropertyRegistry registry) {

--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TransactionalUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/TransactionalUtilsTest.java
@@ -20,8 +20,6 @@ package org.laokou.common.mybatisplus;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.util.InstantUtils;
 import org.laokou.common.mybatisplus.util.TransactionalUtils;
@@ -31,6 +29,8 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.TransactionDefinition;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.util.List;
@@ -38,6 +38,7 @@ import java.util.List;
 /**
  * @author laokou
  */
+@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @RequiredArgsConstructor
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
@@ -47,20 +48,11 @@ class TransactionalUtilsTest {
 
 	private final TransactionalUtils transactionalUtils;
 
+	@Container
 	static PostgreSQLContainer postgres = new PostgreSQLContainer(DockerImageNames.postgresql()).withUsername("root")
 		.withPassword("laokou123")
 		.withInitScripts("init.sql")
 		.withDatabaseName("kcloud_platform_test");
-
-	@BeforeAll
-	static void beforeAll() {
-		postgres.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		postgres.stop();
-	}
 
 	@DynamicPropertySource
 	static void configureProperties(DynamicPropertyRegistry registry) {

--- a/laokou-common/laokou-common-oss/src/test/java/org/laokou/common/oss/OssUploadTest.java
+++ b/laokou-common/laokou-common-oss/src/test/java/org/laokou/common/oss/OssUploadTest.java
@@ -18,8 +18,6 @@
 package org.laokou.common.oss;
 
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.i18n.util.ResourceExtUtils;
@@ -33,6 +31,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestConstructor;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +40,7 @@ import java.io.InputStream;
 /**
  * @author laokou
  */
+@Testcontainers
 @ContextConfiguration(classes = { StorageAutoConfig.class })
 @RequiredArgsConstructor
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -50,18 +51,9 @@ class OssUploadTest {
 
 	private File file;
 
+	@Container
 	static final MinIOContainer minIO = new MinIOContainer(DockerImageNames.minIO()).withUsername("minio")
 		.withPassword("laokou123");
-
-	@BeforeAll
-	static void beforeAll() {
-		minIO.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		minIO.stop();
-	}
 
 	@BeforeEach
 	void setUp() throws IOException {

--- a/laokou-common/laokou-common-sftp/src/test/java/org/laokou/common/ftp/SFtpTest.java
+++ b/laokou-common/laokou-common-sftp/src/test/java/org/laokou/common/ftp/SFtpTest.java
@@ -19,8 +19,6 @@ package org.laokou.common.ftp;
 
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.laokou.common.ftp.config.SFtpProperties;
 import org.laokou.common.ftp.template.SFtpTemplate;
@@ -33,6 +31,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestConstructor;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +42,7 @@ import java.io.InputStream;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @RequiredArgsConstructor
+@Testcontainers
 @EnableConfigurationProperties
 @ContextConfiguration(classes = { SFtpProperties.class, SFtpTemplate.class })
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
@@ -51,17 +52,8 @@ class SFtpTest {
 
 	private final SFtpProperties sftpProperties;
 
+	@Container
 	static final SFtpContainer sftp = new SFtpContainer(DockerImageNames.sftp()).withPassword("laokou", "laokou123");
-
-	@BeforeAll
-	static void beforeAll() {
-		sftp.start();
-	}
-
-	@AfterAll
-	static void afterAll() {
-		sftp.stop();
-	}
 
 	@DynamicPropertySource
 	static void configureProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
## 由 Sourcery 提供的总结

通过统一集成测试容器的生命周期管理，修复 Maven 测试构建问题。

Bug 修复：
- 通过采用 Testcontainers 的 JUnit 5 生命周期管理机制，修复 Elasticsearch、PostgreSQL、MinIO 和 SFTP 集成测试中的 Maven 测试执行失败问题。

增强内容：
- 统一各集成测试中容器的启动与关闭方式，并调整 Elasticsearch 测试的初始化时机。

测试：
- 更新集成测试，使其声明由 Testcontainers 托管的容器，而不是手动启动和停止容器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Maven test builds by standardizing integration-test container lifecycle management.

Bug Fixes:
- Fix Maven test execution failures by adopting Testcontainers' JUnit 5 lifecycle management for Elasticsearch, PostgreSQL, MinIO, and SFTP integration tests.

Enhancements:
- Standardize container startup and shutdown across integration tests and adjust Elasticsearch test initialization timing.

Tests:
- Update integration tests to declare managed Testcontainers instead of manually starting and stopping containers.

</details>