### PR TITLE
style: 优化代码风格

### DIFF
--- a/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/TreeUtils.java
+++ b/laokou-common/laokou-common-core/src/main/java/org/laokou/common/core/util/TreeUtils.java
@@ -20,6 +20,7 @@ package org.laokou.common.core.util;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.laokou.common.i18n.common.exception.BizException;
 import org.laokou.common.i18n.dto.ClientObject;
 import org.laokou.common.i18n.util.ObjectUtils;
 
@@ -67,7 +68,7 @@ public final class TreeUtils {
 	 */
 	private static <T extends TreeNode<T>> T buildTreeNode(List<T> treeNodes, T rootNode) {
 		if (ObjectUtils.isNull(rootNode)) {
-			throw new RuntimeException("请构造根节点");
+			throw new BizException("B_Menu_TreeNodeBuildFailed", "请构造根节点");
 		}
 		List<T> nodes = new ArrayList<>(treeNodes);
 		// 添加根节点

--- a/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/handler/CryptoTypeHandler.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/main/java/org/laokou/common/mybatisplus/handler/CryptoTypeHandler.java
@@ -45,9 +45,9 @@ public class CryptoTypeHandler implements TypeHandler<String> {
 			}
 			preparedStatement.setString(parameterIndex, content);
 		}
-		catch (Exception e) {
-			log.error("加密失败，错误信息：{}", e.getMessage(), e);
-			throw new RuntimeException(e);
+		catch (Exception ex) {
+			log.error("加密失败，错误信息：{}", ex.getMessage(), ex);
+			throw new IllegalArgumentException(ex);
 		}
 	}
 
@@ -60,9 +60,9 @@ public class CryptoTypeHandler implements TypeHandler<String> {
 			}
 			return AESUtils.decrypt(data.trim());
 		}
-		catch (Exception e) {
-			log.error("解密失败，错误信息：{}", e.getMessage(), e);
-			throw new RuntimeException(e);
+		catch (Exception ex) {
+			log.error("解密失败，错误信息：{}", ex.getMessage(), ex);
+			throw new IllegalArgumentException(ex);
 		}
 	}
 
@@ -75,9 +75,9 @@ public class CryptoTypeHandler implements TypeHandler<String> {
 			}
 			return AESUtils.decrypt(data.trim());
 		}
-		catch (Exception e) {
-			log.error("解密失败，错误信息：{}", e.getMessage(), e);
-			throw new RuntimeException(e);
+		catch (Exception ex) {
+			log.error("解密失败，错误信息：{}", ex.getMessage(), ex);
+			throw new IllegalArgumentException(ex);
 		}
 	}
 
@@ -90,9 +90,9 @@ public class CryptoTypeHandler implements TypeHandler<String> {
 			}
 			return AESUtils.decrypt(data.trim());
 		}
-		catch (Exception e) {
-			log.error("解密失败，错误信息：{}", e.getMessage(), e);
-			throw new RuntimeException(e);
+		catch (Exception ex) {
+			log.error("解密失败，错误信息：{}", ex.getMessage(), ex);
+			throw new IllegalArgumentException(ex);
 		}
 	}
 

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/OAuth2OpaqueTokenIntrospector.java
@@ -42,6 +42,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
@@ -80,7 +81,7 @@ public record OAuth2OpaqueTokenIntrospector(OAuth2AuthorizationService authoriza
 				throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);
 			}
 			return cachedPrincipal.principal();
-		} catch (Exception ex) {
+		} catch (JwtException ex) {
 			log.debug("JWT解析失败，错误信息：{}", ex.getMessage(), ex);
 			invalidate(token);
 			throw OAuth2ExceptionHandler.getException(StatusCode.UNAUTHORIZED);


### PR DESCRIPTION
## Summary by Sourcery

在树构建、加密类型转换以及 OAuth2 令牌自检流程中改进异常处理。

Bug 修复：
- 将 OAuth2 令牌自检的回退处理限制在 JWT 解析失败的场景中，避免无关异常被误掩盖为未授权响应。

改进：
- 对树构建失败和加密处理器错误使用领域特定异常，以提升错误分类的准确性。

杂项：
- 在相关处理器中统一异常变量的命名方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve exception handling across tree construction, cryptographic type conversion, and OAuth2 token introspection.

Bug Fixes:
- Limit OAuth2 token introspection fallback handling to JWT parsing failures so unrelated exceptions are not masked as unauthorized responses.

Enhancements:
- Use domain-specific exceptions for tree construction failures and crypto handler errors to improve error classification.

Chores:
- Standardize exception variable naming in the affected handlers.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when menu tree construction fails due to a missing root node.
  * Standardized encryption and decryption failure handling with more specific errors.
  * Restricted token invalidation to JWT decoding failures, preserving appropriate unauthorized responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->