### PR TITLE
Dev

### DIFF
--- a/doc/db/kcloud_platform.sql
+++ b/doc/db/kcloud_platform.sql
@@ -65,7 +65,17 @@ CREATE TABLE "public"."sys_dept" (
   "dept_id" int8 NOT NULL DEFAULT 1,
   "pid" int8 NOT NULL,
   "name" varchar(100) NOT NULL,
-  "sort" int4 NOT NULL DEFAULT 1
+  "sort" int4 NOT NULL DEFAULT 1,
+  "level" int4 NOT NULL DEFAULT 1,
+  "level1" int8,
+  "level2" int8,
+  "level3" int8,
+  "level4" int8,
+  "level5" int8,
+  "level6" int8,
+  "level7" int8,
+  "level8" int8,
+  "level9" int8
 );
 COMMENT ON COLUMN "public"."sys_dept"."id" IS 'ID';
 COMMENT ON COLUMN "public"."sys_dept"."creator" IS '创建人';
@@ -75,24 +85,34 @@ COMMENT ON COLUMN "public"."sys_dept"."update_time" IS '修改时间';
 COMMENT ON COLUMN "public"."sys_dept"."del_flag" IS '删除标识 0未删除 1已删除';
 COMMENT ON COLUMN "public"."sys_dept"."version" IS '版本号';
 COMMENT ON COLUMN "public"."sys_dept"."tenant_id" IS '租户ID';
-COMMENT ON COLUMN "public"."sys_cluster"."dept_id" IS '部门ID';
+COMMENT ON COLUMN "public"."sys_dept"."dept_id" IS '部门ID';
 COMMENT ON COLUMN "public"."sys_dept"."pid" IS '部门父节点ID';
 COMMENT ON COLUMN "public"."sys_dept"."name" IS '部门名称';
 COMMENT ON COLUMN "public"."sys_dept"."sort" IS '部门排序';
+COMMENT ON COLUMN "public"."sys_dept"."level" IS '层级';
+COMMENT ON COLUMN "public"."sys_dept"."level1" IS '层级1';
+COMMENT ON COLUMN "public"."sys_dept"."level2" IS '层级2';
+COMMENT ON COLUMN "public"."sys_dept"."level3" IS '层级3';
+COMMENT ON COLUMN "public"."sys_dept"."level4" IS '层级4';
+COMMENT ON COLUMN "public"."sys_dept"."level5" IS '层级5';
+COMMENT ON COLUMN "public"."sys_dept"."level6" IS '层级6';
+COMMENT ON COLUMN "public"."sys_dept"."level7" IS '层级7';
+COMMENT ON COLUMN "public"."sys_dept"."level8" IS '层级8';
+COMMENT ON COLUMN "public"."sys_dept"."level9" IS '层级9';
 COMMENT ON TABLE "public"."sys_dept" IS '部门';
 
 ALTER TABLE "public"."sys_dept" ADD CONSTRAINT "sys_dept_pkey" PRIMARY KEY ("id");
 CREATE INDEX sys_dept_pid_idx ON sys_dept(pid);
-
-INSERT INTO "public"."sys_dept" VALUES (1535858679453085698, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 4, 1, 1, 1, '广州分公司', 2);
-INSERT INTO "public"."sys_dept" VALUES (1535881356595175426, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 18, 1, 1, 1, '长沙分公司', 3);
-INSERT INTO "public"."sys_dept" VALUES (1535887129341599746, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 8, 1, 1, 1, '深圳分公司', 1);
-INSERT INTO "public"."sys_dept" VALUES (1, 1, 1, '2022-11-16 12:12:55', '2023-09-22 11:31:42', 0, 38, 1, 1, 0, '老寇云集团', 1);
-INSERT INTO "public"."sys_dept" VALUES (1584488175088373761, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 43, 1, 1, 1535881356595175426, '研发部', 1);
-INSERT INTO "public"."sys_dept" VALUES (1584488411756171265, 1, 1, '2022-11-02 22:35:30', '2026-06-13 16:18:42.768011', 0, 10, 1, 1, 1535881356595175426, '市场部', 2);
-INSERT INTO "public"."sys_dept" VALUES (1584488411756171266, 1, 1, '2022-11-02 22:35:30', '2026-06-13 16:18:48.186013', 0, 20, 1, 1, 1584488175088373761, '开发组', 1);
-INSERT INTO "public"."sys_dept" VALUES (1584488411756171269, 1, 1, '2023-02-10 22:06:44', '2026-06-13 16:18:51.896852', 0, 9, 1, 1, 1584488175088373761, '测试组', 2);
-INSERT INTO "public"."sys_dept" VALUES (1584488411756171268, 1, 1, '2023-02-10 22:01:36', '2026-06-13 16:18:56.07049', 0, 10, 1, 1, 1584488175088373761, '运维组', 3);
+ALTER TABLE sys_dept ADD CONSTRAINT chk_sys_dept_level CHECK ("level" BETWEEN 1 AND 9);
+INSERT INTO "public"."sys_dept" VALUES (1, 1, 1, '2022-11-16 12:12:55', '2023-09-22 11:31:42', 0, 38, 1, 1, 0, '老寇云集团', 1, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1535887129341599746, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 8, 1, 1, 1, '深圳分公司', 1, 2, 1, 1535887129341599746, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1535858679453085698, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 4, 1, 1, 1, '广州分公司', 2, 2, 1, 1535858679453085698, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1535881356595175426, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 18, 1, 1, 1, '长沙分公司', 3, 2, 1, 1535881356595175426, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1584488175088373761, 1, 1, '2022-11-02 22:35:30', '2023-09-22 11:31:42', 0, 43, 1, 1, 1535881356595175426, '研发部', 1, 3, 1, 1535881356595175426, 1584488175088373761, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1584488411756171265, 1, 1, '2022-11-02 22:35:30', '2026-06-13 16:18:42.768011', 0, 10, 1, 1, 1535881356595175426, '市场部', 2, 3, 1, 1535881356595175426, 1584488411756171265, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1584488411756171268, 1, 1, '2023-02-10 22:01:36', '2026-06-13 16:18:56.07049', 0, 10, 1, 1, 1584488175088373761, '运维组', 3, 4, 1, 1535881356595175426, 1584488175088373761, 1584488411756171268, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1584488411756171269, 1, 1, '2023-02-10 22:06:44', '2026-06-13 16:18:51.896852', 0, 9, 1, 1, 1584488175088373761, '测试组', 2, 4, 1, 1535881356595175426, 1584488175088373761, 1584488411756171269, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO "public"."sys_dept" VALUES (1584488411756171266, 1, 1, '2022-11-02 22:35:30', '2026-06-13 16:18:48.186013', 0, 20, 1, 1, 1584488175088373761, '开发组', 1, 4, 1, 1535881356595175426, 1584488175088373761, 1584488411756171266, NULL, NULL, NULL, NULL, NULL);
 
 -- ----------------------------
 -- -------------字典------------

--- a/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptTreeListQryExe.java
+++ b/laokou-service/laokou-admin/laokou-admin-app/src/main/java/org/laokou/admin/dept/command/query/DeptTreeListQryExe.java
@@ -40,7 +40,7 @@ public class DeptTreeListQryExe {
 	private final DeptMapper deptMapper;
 
 	public Result<List<DeptTreeCO>> execute(DeptTreeListQry qry) {
-		DeptTreeCO co = TreeUtils.buildTreeNode(DeptConvertor.toClientObjectList0(deptMapper.selectObjectList(qry)),
+		DeptTreeCO co = TreeUtils.buildTreeNode(DeptConvertor.toClientObjList(deptMapper.selectObjectList(qry)),
 				DeptTreeCO.class);
 		return Result.ok(co.getChildren());
 	}

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/dept/dto/clientobject/DeptCO.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/dept/dto/clientobject/DeptCO.java
@@ -53,6 +53,11 @@ public class DeptCO extends ClientObject {
 	private Integer sort;
 
 	/**
+	 * 部门层级.
+	 */
+	private Integer level;
+
+	/**
 	 * 创建时间.
 	 */
 	@JsonFormat(pattern = DateConstants.YYYY_B_MM_B_DD_HH_R_MM_R_SS, timezone = DateConstants.DEFAULT_TIMEZONE)

--- a/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/dept/dto/clientobject/DeptTreeCO.java
+++ b/laokou-service/laokou-admin/laokou-admin-client/src/main/java/org/laokou/admin/dept/dto/clientobject/DeptTreeCO.java
@@ -39,4 +39,7 @@ public class DeptTreeCO extends TreeUtils.TreeNode<DeptTreeCO> {
 	@Schema(name = "创建时间", description = "创建时间")
 	private Instant createTime;
 
+	@Schema(name = "部门层级", description = "部门层级")
+	private Integer level;
+
 }

--- a/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/entity/DeptE.java
+++ b/laokou-service/laokou-admin/laokou-admin-domain/src/main/java/org/laokou/admin/dept/model/entity/DeptE.java
@@ -64,4 +64,9 @@ public class DeptE implements Serializable {
 	 */
 	private Integer sort;
 
+	/**
+	 * 部门层级.
+	 */
+	private Integer level;
+
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/convertor/DeptConvertor.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/convertor/DeptConvertor.java
@@ -40,6 +40,7 @@ public class DeptConvertor {
 		deptDO.setPid(deptE.getPid());
 		deptDO.setName(deptE.getName());
 		deptDO.setSort(deptE.getSort());
+		deptDO.setLevel(deptE.getLevel());
 		deptDO.setCreateTime(deptA.getCreateTime());
 		return deptDO;
 	}
@@ -50,6 +51,7 @@ public class DeptConvertor {
 		deptCO.setPid(deptDO.getPid());
 		deptCO.setName(deptDO.getName());
 		deptCO.setSort(deptDO.getSort());
+		deptCO.setLevel(deptDO.getLevel());
 		deptCO.setCreateTime(deptDO.getCreateTime());
 		return deptCO;
 	}
@@ -58,19 +60,19 @@ public class DeptConvertor {
 		return list.stream().map(DeptConvertor::toClientObject).toList();
 	}
 
-	public static DeptTreeCO toClientObject0(DeptDO deptDO) {
+	public static DeptTreeCO toClientObj(DeptDO deptDO) {
 		DeptTreeCO co = new DeptTreeCO();
 		co.setId(deptDO.getId());
 		co.setName(deptDO.getName());
 		co.setPid(deptDO.getPid());
 		co.setSort(deptDO.getSort());
 		co.setCreateTime(deptDO.getCreateTime());
+		co.setLevel(deptDO.getLevel());
 		return co;
-
 	}
 
-	public static List<DeptTreeCO> toClientObjectList0(List<DeptDO> list) {
-		return list.stream().map(DeptConvertor::toClientObject0).toList();
+	public static List<DeptTreeCO> toClientObjList(List<DeptDO> list) {
+		return list.stream().map(DeptConvertor::toClientObj).toList();
 	}
 
 	public static DeptE toEntity(DeptCO deptCO) {
@@ -80,7 +82,23 @@ public class DeptConvertor {
 			.sort(deptCO.getSort())
 			.pid(deptCO.getPid())
 			.name(deptCO.getName())
+			.level(deptCO.getLevel())
 			.build();
+	}
+
+	public static DeptDO toDataObject() {
+		DeptDO deptDO = new DeptDO();
+		deptDO.setLevel(0);
+		deptDO.setLevel1(null);
+		deptDO.setLevel2(null);
+		deptDO.setLevel3(null);
+		deptDO.setLevel4(null);
+		deptDO.setLevel5(null);
+		deptDO.setLevel6(null);
+		deptDO.setLevel7(null);
+		deptDO.setLevel8(null);
+		deptDO.setLevel9(null);
+		return deptDO;
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
@@ -30,7 +30,6 @@ import org.laokou.admin.dept.model.DeptA;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,6 +103,10 @@ public class DeptGatewayImpl implements DeptGateway {
 			rebuildLevel(dptDO, deptDOMap.get(dptDO.getPid()));
 			deptDOMap.put(dptDO.getId(), dptDO);
 		}
+		updateDeptByIds(list);
+	}
+
+	private void updateDeptByIds(List<DeptDO> list) {
 		MybatisBatch.Method<DeptDO> mapperMethod = new MybatisBatch.Method<>(DeptMapper.class);
 		MybatisBatchUtils.execute(sqlSessionFactory, list,
 				mapperMethod.update(item -> Wrappers.lambdaUpdate(DeptDO.class)
@@ -123,41 +126,26 @@ public class DeptGatewayImpl implements DeptGateway {
 	}
 
 	private List<DeptDO> getChildrenList(Long id, Integer level) {
-		return switch (level) {
-			case 1 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
-				.eq(DeptDO::getLevel1, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 2 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+		return deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+			.and(w -> w.eq(DeptDO::getLevel1, id)
+				.or()
 				.eq(DeptDO::getLevel2, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 3 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.or()
 				.eq(DeptDO::getLevel3, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 4 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.or()
 				.eq(DeptDO::getLevel4, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 5 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.or()
 				.eq(DeptDO::getLevel5, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 6 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.or()
 				.eq(DeptDO::getLevel6, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 7 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.or()
 				.eq(DeptDO::getLevel7, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			case 8 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.or()
 				.eq(DeptDO::getLevel8, id)
-				.ne(DeptDO::getId, id)
-				.orderByAsc(DeptDO::getLevel));
-			default -> Collections.emptyList();
-		};
+				.or()
+				.eq(DeptDO::getLevel9, id))
+			.ne(DeptDO::getId, id)
+			.orderByAsc(DeptDO::getLevel));
 	}
 
 	private void rebuildLevel(DeptDO deptDO, DeptDO parentDeptDO) {

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/DeptGatewayImpl.java
@@ -17,7 +17,11 @@
 
 package org.laokou.admin.dept.gatewayimpl;
 
+import com.baomidou.mybatisplus.core.batch.MybatisBatch;
+import com.baomidou.mybatisplus.core.toolkit.MybatisBatchUtils;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSessionFactory;
 import org.laokou.admin.dept.convertor.DeptConvertor;
 import org.laokou.admin.dept.gateway.DeptGateway;
 import org.laokou.admin.dept.gatewayimpl.database.DeptMapper;
@@ -26,6 +30,10 @@ import org.laokou.admin.dept.model.DeptA;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 部门网关实现.
@@ -38,21 +46,180 @@ public class DeptGatewayImpl implements DeptGateway {
 
 	private final DeptMapper deptMapper;
 
+	private final SqlSessionFactory sqlSessionFactory;
+
 	@Override
 	public void createDept(DeptA deptA) {
-		deptMapper.insert(DeptConvertor.toDataObject(deptA));
+		DeptDO deptDO = DeptConvertor.toDataObject(deptA);
+		updateLevels(deptDO);
+		deptMapper.insert(deptDO);
 	}
 
 	@Override
 	public void updateDept(DeptA deptA) {
 		DeptDO deptDO = DeptConvertor.toDataObject(deptA);
+		Long id = deptDO.getId();
+		Integer level = deptDO.getLevel();
 		deptDO.setVersion(deptMapper.selectVersion(deptA.getId()));
-		deptMapper.updateById(deptDO);
+		updateLevels(deptDO);
+		updateDeptById(deptDO);
+		updateChildrenLevels(id, level, deptDO);
+
 	}
 
 	@Override
 	public void deleteDept(Long[] ids) {
 		deptMapper.deleteByIds(Arrays.asList(ids));
+	}
+
+	private void updateLevels(DeptDO deptDO) {
+		DeptDO parentDept = deptMapper.selectById(deptDO.getPid());
+		rebuildLevel(deptDO, parentDept == null ? DeptConvertor.toDataObject() : parentDept);
+	}
+
+	private void updateDeptById(DeptDO deptDO) {
+		deptMapper.update(Wrappers.lambdaUpdate(DeptDO.class)
+			.set(DeptDO::getPid, deptDO.getPid())
+			.set(DeptDO::getSort, deptDO.getSort())
+			.set(DeptDO::getName, deptDO.getName())
+			.set(DeptDO::getLevel, deptDO.getLevel())
+			.set(DeptDO::getLevel1, deptDO.getLevel1())
+			.set(DeptDO::getLevel2, deptDO.getLevel2())
+			.set(DeptDO::getLevel3, deptDO.getLevel3())
+			.set(DeptDO::getLevel4, deptDO.getLevel4())
+			.set(DeptDO::getLevel5, deptDO.getLevel5())
+			.set(DeptDO::getLevel6, deptDO.getLevel6())
+			.set(DeptDO::getLevel7, deptDO.getLevel7())
+			.set(DeptDO::getLevel8, deptDO.getLevel8())
+			.set(DeptDO::getLevel9, deptDO.getLevel9())
+			.set(DeptDO::getVersion, deptDO.getVersion() + 1)
+			.eq(DeptDO::getId, deptDO.getId())
+			.eq(DeptDO::getVersion, deptDO.getVersion()));
+	}
+
+	private void updateChildrenLevels(Long id, Integer level, DeptDO deptDO) {
+		List<DeptDO> list = getChildrenList(id, level);
+		Map<Long, DeptDO> deptDOMap = new LinkedHashMap<>(Map.of(id, deptDO));
+		for (DeptDO dptDO : list) {
+			rebuildLevel(dptDO, deptDOMap.get(dptDO.getPid()));
+			deptDOMap.put(dptDO.getId(), dptDO);
+		}
+		MybatisBatch.Method<DeptDO> mapperMethod = new MybatisBatch.Method<>(DeptMapper.class);
+		MybatisBatchUtils.execute(sqlSessionFactory, list,
+				mapperMethod.update(item -> Wrappers.lambdaUpdate(DeptDO.class)
+					.set(DeptDO::getLevel, item.getLevel())
+					.set(DeptDO::getLevel1, item.getLevel1())
+					.set(DeptDO::getLevel2, item.getLevel2())
+					.set(DeptDO::getLevel3, item.getLevel3())
+					.set(DeptDO::getLevel4, item.getLevel4())
+					.set(DeptDO::getLevel5, item.getLevel5())
+					.set(DeptDO::getLevel6, item.getLevel6())
+					.set(DeptDO::getLevel7, item.getLevel7())
+					.set(DeptDO::getLevel8, item.getLevel8())
+					.set(DeptDO::getLevel9, item.getLevel9())
+					.set(DeptDO::getVersion, item.getVersion() + 1)
+					.eq(DeptDO::getId, item.getId())
+					.eq(DeptDO::getVersion, item.getVersion())));
+	}
+
+	private List<DeptDO> getChildrenList(Long id, Integer level) {
+		return switch (level) {
+			case 1 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel1, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 2 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel2, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 3 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel3, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 4 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel4, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 5 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel5, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 6 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel6, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 7 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel7, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			case 8 -> deptMapper.selectList(Wrappers.lambdaUpdate(DeptDO.class)
+				.eq(DeptDO::getLevel8, id)
+				.ne(DeptDO::getId, id)
+				.orderByAsc(DeptDO::getLevel));
+			default -> Collections.emptyList();
+		};
+	}
+
+	private void rebuildLevel(DeptDO deptDO, DeptDO parentDeptDO) {
+		clearLevels(deptDO);
+		int level = parentDeptDO.getLevel() + 1;
+		deptDO.setLevel(level);
+		copyParentLevels(deptDO, parentDeptDO, level);
+		setCurrentLevel(deptDO, level);
+	}
+
+	private void clearLevels(DeptDO deptDO) {
+		deptDO.setLevel1(null);
+		deptDO.setLevel2(null);
+		deptDO.setLevel3(null);
+		deptDO.setLevel4(null);
+		deptDO.setLevel5(null);
+		deptDO.setLevel6(null);
+		deptDO.setLevel7(null);
+		deptDO.setLevel8(null);
+		deptDO.setLevel9(null);
+	}
+
+	private void copyParentLevels(DeptDO deptDO, DeptDO parentDeptDO, int level) {
+		if (level > 1) {
+			deptDO.setLevel1(parentDeptDO.getLevel1());
+		}
+		if (level > 2) {
+			deptDO.setLevel2(parentDeptDO.getLevel2());
+		}
+		if (level > 3) {
+			deptDO.setLevel3(parentDeptDO.getLevel3());
+		}
+		if (level > 4) {
+			deptDO.setLevel4(parentDeptDO.getLevel4());
+		}
+		if (level > 5) {
+			deptDO.setLevel5(parentDeptDO.getLevel5());
+		}
+		if (level > 6) {
+			deptDO.setLevel6(parentDeptDO.getLevel6());
+		}
+		if (level > 7) {
+			deptDO.setLevel7(parentDeptDO.getLevel7());
+		}
+		if (level > 8) {
+			deptDO.setLevel8(parentDeptDO.getLevel8());
+		}
+	}
+
+	private void setCurrentLevel(DeptDO deptDO, int level) {
+		Long id = deptDO.getId();
+		switch (level) {
+			case 1 -> deptDO.setLevel1(id);
+			case 2 -> deptDO.setLevel2(id);
+			case 3 -> deptDO.setLevel3(id);
+			case 4 -> deptDO.setLevel4(id);
+			case 5 -> deptDO.setLevel5(id);
+			case 6 -> deptDO.setLevel6(id);
+			case 7 -> deptDO.setLevel7(id);
+			case 8 -> deptDO.setLevel8(id);
+			case 9 -> deptDO.setLevel9(id);
+		}
 	}
 
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/database/dataobject/DeptDO.java
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/java/org/laokou/admin/dept/gatewayimpl/database/dataobject/DeptDO.java
@@ -46,4 +46,54 @@ public class DeptDO extends BaseDO {
 	 */
 	private Integer sort;
 
+	/**
+	 * 部门层级.
+	 */
+	private Integer level;
+
+	/**
+	 * 层级1.
+	 */
+	private Long level1;
+
+	/**
+	 * 层级2.
+	 */
+	private Long level2;
+
+	/**
+	 * 层级3.
+	 */
+	private Long level3;
+
+	/**
+	 * 层级4.
+	 */
+	private Long level4;
+
+	/**
+	 * 层级5.
+	 */
+	private Long level5;
+
+	/**
+	 * 层级6.
+	 */
+	private Long level6;
+
+	/**
+	 * 层级7.
+	 */
+	private Long level7;
+
+	/**
+	 * 层级8.
+	 */
+	private Long level8;
+
+	/**
+	 * 层级9.
+	 */
+	private Long level9;
+
 }

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/resources/mapper/dept/DeptMapper.xml
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/src/main/resources/mapper/dept/DeptMapper.xml
@@ -25,6 +25,7 @@
     "name",
     pid,
     "sort",
+    "level",
     create_time
   </sql>
 

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/resources/mapper/dept/DeptMapper.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/resources/mapper/dept/DeptMapper.xml
@@ -25,17 +25,17 @@
         <foreach collection="dataScopes" item="dataScope" separator=" union all ">
           <choose>
             <when test="dataScope != null and dataScope == 'below_dept'">
-              WITH recursive dept_tree as (
-                select
-                id, pid
-                from sys_dept
-                where id = #{user.deptId} and tenant_id = #{user.tenantId}
-                union all
-                select d.id, d.pid
-                from sys_dept d
-                join dept_tree dt on d.pid = dt.id
-              )
-              select id from dept_tree
+              select id from sys_dept where (
+              level1 = #{user.deptId} or
+              level2 = #{user.deptId} or
+              level3 = #{user.deptId} or
+              level4 = #{user.deptId} or
+              level5 = #{user.deptId} or
+              level6 = #{user.deptId} or
+              level7 = #{user.deptId} or
+              level8 = #{user.deptId} or
+              level9 = #{user.deptId}
+              )  and tenant_id = #{user.tenantId}
             </when>
             <when test="dataScope != null and dataScope == 'self_dept'">
               select #{user.deptId}

--- a/ui/src/locales/en-US.ts
+++ b/ui/src/locales/en-US.ts
@@ -408,6 +408,7 @@ export default {
 	// sys/dept
 	'sys.dept.pid': 'Parent Dept',
 	'sys.dept.name': 'Name',
+	'sys.dept.level': 'Level',
 	'sys.dept.sort': 'Sort',
 	'sys.dept.insert': 'Insert Dept',
 	'sys.dept.view': 'View Dept',

--- a/ui/src/locales/zh-CN.ts
+++ b/ui/src/locales/zh-CN.ts
@@ -408,6 +408,7 @@ export default {
 	// sys/dept
 	'sys.dept.pid': '父级部门',
 	'sys.dept.name': '部门名称',
+	'sys.dept.level': '部门层级',
 	'sys.dept.sort': '部门排序',
 	'sys.dept.insert': '新增部门',
 	'sys.dept.view': '查看部门',

--- a/ui/src/pages/Sys/Permission/DeptDrawer.tsx
+++ b/ui/src/pages/Sys/Permission/DeptDrawer.tsx
@@ -28,6 +28,7 @@ type TableColumns = {
 	name: string | undefined;
 	path: string | undefined;
 	sort: number | undefined;
+	level: number | undefined;
 	createTime: string | undefined;
 };
 
@@ -102,6 +103,13 @@ export const DeptDrawer: React.FC<DeptDrawerProps> = ({
 				disabled={loading}
 				name="id"
 				label="ID"
+				hidden={true}
+			/>
+
+			<ProFormText
+				disabled={loading}
+				name="level"
+				label={t('sys.dept.level')}
 				hidden={true}
 			/>
 

--- a/ui/src/pages/Sys/Permission/dept.tsx
+++ b/ui/src/pages/Sys/Permission/dept.tsx
@@ -77,7 +77,7 @@ export default () => {
 			title: t('common.number'),
 			dataIndex: 'index',
 			valueType: 'indexBorder',
-			width: 110,
+			width: 240,
 		},
 		{
 			title: t('sys.dept.name'),
@@ -86,6 +86,13 @@ export default () => {
 			fieldProps: {
 				placeholder: t('sys.dept.placeholder.name'),
 			},
+		},
+		{
+			title: t('sys.dept.level'),
+			dataIndex: 'level',
+			hideInSearch: true,
+			ellipsis: true,
+			width: 80,
 		},
 		{
 			title: t('sys.dept.sort'),


### PR DESCRIPTION
## Sourcery 总结

添加持久化的部门层级元数据，并在后端授权和管理界面中公开部门层级信息。

新功能：
- 添加部门层级和祖先标识符，以支持高效的树形结构和数据范围查询。
- 在部门 API 和管理界面中公开部门层级信息。

错误修复：
- 修正部门列注释，使其引用部门表。

增强功能：
- 在创建、更新或移动部门时维护部门层级元数据，并将变更传播至后代部门。
- 使用基于索引的层级检查替代递归的后代数据范围查询。
- 在数据库映射、转换逻辑、树形响应和本地化界面标签中包含部门层级。

文档：
- 更新部门数据库架构和种子数据以支持部门层级，并强制层级值在 1 到 9 之间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add persisted department hierarchy metadata and expose department levels across backend authorization and administration interfaces.

New Features:
- Add department hierarchy levels and ancestor identifiers to support efficient tree and data-scope queries.
- Expose department level information in department APIs and the administration UI.

Bug Fixes:
- Correct the department column comment to reference the department table.

Enhancements:
- Maintain department hierarchy metadata when creating, updating, or moving departments and propagate changes to descendants.
- Replace recursive descendant data-scope queries with indexed hierarchy-level checks.
- Include department level in database mappings, conversion logic, tree responses, and localized UI labels.

Documentation:
- Update the department database schema and seed data for hierarchy levels and enforce valid levels from 1 through 9.

</details>