### PR TITLE
feat: 修改版本为4.0.4-SNAPSHOT

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -100,45 +100,45 @@ jobs:
           # ========== 构建laokou-gateway ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-gateway
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway:4.0.4-SNAPSHOT
           # ========== 构建laokou-monitor ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-monitor
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-monitor:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-monitor:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-monitor:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-monitor:4.0.4-SNAPSHOT
           # ========== 构建laokou-nacos ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-nacos
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-nacos:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-nacos:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-nacos:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-nacos:4.0.4-SNAPSHOT
           # ========== 构建laokou-auth ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-service/laokou-auth/laokou-auth-start
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-auth-start:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-auth-start:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-auth-start:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-auth-start:4.0.4-SNAPSHOT
           # ========== 构建laokou-admin ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-service/laokou-admin/laokou-admin-start
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-admin-start:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-admin-start:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-admin-start:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-admin-start:4.0.4-SNAPSHOT
           # ========== 构建laokou-logstash ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-service/laokou-logstash/laokou-logstash-start
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-logstash-start:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-logstash-start:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-logstash-start:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-logstash-start:4.0.4-SNAPSHOT
           # ========== 构建laokou-iot ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-service/laokou-iot/laokou-iot-start
           # 使用Dockerfile构建镜像
-          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.3
+          docker build . --file Dockerfile --tag registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.4-SNAPSHOT
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.4-SNAPSHOT
       - name: Build Native Image with GraalVM
         run: |
           # 登录阿里云镜像仓库
@@ -148,4 +148,4 @@ jobs:
           # 构建本地镜像
           mvnd -T 1.5C spring-boot:build-image -DskipTests
           # 推送镜像到镜像仓库
-          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.3
+          docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.4-SNAPSHOT

--- a/doc/deploy/docker-compose/docker-compose.yml
+++ b/doc/deploy/docker-compose/docker-compose.yml
@@ -466,7 +466,7 @@ services:
           cpus: '0.50'
           memory: 1G
   nacos:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-nacos:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-nacos:4.0.4-SNAPSHOT
     container_name: nacos
     # 保持容器在没有守护程序的情况下运行
     tty: true
@@ -485,7 +485,7 @@ services:
     depends_on:
       - postgresql
   monitor:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-monitor:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-monitor:4.0.4-SNAPSHOT
     container_name: monitor
     # 保持容器在没有守护程序的情况下运行
     tty: true
@@ -506,7 +506,7 @@ services:
     networks:
       - iot_network
   gateway:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway:4.0.4-SNAPSHOT
     container_name: gateway
     tty: true
     env_file:
@@ -525,7 +525,7 @@ services:
       - kafka
       - redis
   auth:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-auth-start:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-auth-start:4.0.4-SNAPSHOT
     container_name: auth
     tty: true
     env_file:
@@ -545,7 +545,7 @@ services:
       - kafka
       - redis
   iot:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-iot-start:4.0.4-SNAPSHOT
     container_name: iot
     tty: true
     env_file:
@@ -564,7 +564,7 @@ services:
       - kafka
       - redis
   admin:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-admin-start:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-admin-start:4.0.4-SNAPSHOT
     container_name: admin
     tty: true
     env_file:
@@ -584,7 +584,7 @@ services:
       - kafka
       - redis
   logstash:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-logstash-start:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-logstash-start:4.0.4-SNAPSHOT
     container_name: logstash
     tty: true
     env_file:
@@ -603,7 +603,7 @@ services:
       - elasticsearch
       - kafka
   ui:
-    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/ui:4.0.3
+    image: registry.cn-shenzhen.aliyuncs.com/koushenhai/ui:4.0.4-SNAPSHOT
     container_name: ui
     # 保持容器在没有守护程序的情况下运行
     tty: true

--- a/laokou-cloud/laokou-gateway/pom.xml
+++ b/laokou-cloud/laokou-gateway/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cloud</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-gateway</artifactId>
   <description>API网关</description>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/laokou-cloud/laokou-monitor/pom.xml
+++ b/laokou-cloud/laokou-monitor/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cloud</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-monitor</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-cloud/laokou-nacos/pom.xml
+++ b/laokou-cloud/laokou-nacos/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>laokou-cloud</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-nacos</artifactId>

--- a/laokou-cloud/pom.xml
+++ b/laokou-cloud/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-cloud</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-gateway</module>

--- a/laokou-common/laokou-common-ai/pom.xml
+++ b/laokou-common/laokou-common-ai/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-ai</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-common/laokou-common-algorithm/pom.xml
+++ b/laokou-common/laokou-common-algorithm/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-algorithm</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-banner/pom.xml
+++ b/laokou-common/laokou-common-banner/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-banner</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-common/laokou-common-context/pom.xml
+++ b/laokou-common/laokou-common-context/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-context</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-core/pom.xml
+++ b/laokou-common/laokou-common-core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>laokou-common-core</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <name>laokou-common-core</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台【核心模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>

--- a/laokou-common/laokou-common-cors/pom.xml
+++ b/laokou-common/laokou-common-cors/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-cors</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-crypto/pom.xml
+++ b/laokou-common/laokou-common-crypto/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-crypto</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-csv/pom.xml
+++ b/laokou-common/laokou-common-csv/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-csv</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-data-cache/pom.xml
+++ b/laokou-common/laokou-common-data-cache/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-data-cache</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-domain/pom.xml
+++ b/laokou-common/laokou-common-domain/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-common-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-elasticsearch/pom.xml
+++ b/laokou-common/laokou-common-elasticsearch/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-elasticsearch</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-excel/pom.xml
+++ b/laokou-common/laokou-common-excel/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-excel</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-fory/pom.xml
+++ b/laokou-common/laokou-common-fory/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-fory</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-grpc-client/pom.xml
+++ b/laokou-common/laokou-common-grpc-client/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-grpc-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-grpc-server/pom.xml
+++ b/laokou-common/laokou-common-grpc-server/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-grpc-server</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-i18n/pom.xml
+++ b/laokou-common/laokou-common-i18n/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>laokou-common-i18n</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <name>laokou-common-i18n</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台【I18N国际化模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>
@@ -44,7 +44,7 @@
     </developer>
   </developers>
   <scm>
-    <tag>kcloud-platform-iot-4.0.3.RELEASE</tag>
+    <tag>kcloud-platform-iot-4.0.4.RELEASE</tag>
     <url>https://github.com/KouShenhai/KCloud-Platform-IoT</url>
     <connection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</connection>
     <developerConnection>scm:git:https://github.com/KouShenhai/KCloud-Platform-IoT.git</developerConnection>

--- a/laokou-common/laokou-common-idempotent/pom.xml
+++ b/laokou-common/laokou-common-idempotent/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-idempotent</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-influxdb/pom.xml
+++ b/laokou-common/laokou-common-influxdb/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-influxdb</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-kafka/pom.xml
+++ b/laokou-common/laokou-common-kafka/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-kafka</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-lock/pom.xml
+++ b/laokou-common/laokou-common-lock/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-common-lock</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-log/pom.xml
+++ b/laokou-common/laokou-common-log/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-log</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-log4j2/pom.xml
+++ b/laokou-common/laokou-common-log4j2/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-log4j2</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-mail/pom.xml
+++ b/laokou-common/laokou-common-mail/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-mail</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-mongodb/pom.xml
+++ b/laokou-common/laokou-common-mongodb/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-mongodb</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-mybatis-plus/pom.xml
+++ b/laokou-common/laokou-common-mybatis-plus/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-mybatis-plus</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-nacos/pom.xml
+++ b/laokou-common/laokou-common-nacos/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-nacos</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-openapi-doc/pom.xml
+++ b/laokou-common/laokou-common-openapi-doc/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-openapi-doc</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-openapi-doc/src/main/java/org/laokou/common/openapi/doc/config/OpenApiDocAutoConfig.java
+++ b/laokou-common/laokou-common-openapi-doc/src/main/java/org/laokou/common/openapi/doc/config/OpenApiDocAutoConfig.java
@@ -42,7 +42,7 @@ public class OpenApiDocAutoConfig {
 		return new OpenAPI()
 			.info(new Info().title("API文档")
 				.description("API文档")
-				.version("4.0.3")
+				.version("4.0.4-SNAPSHOT")
 				.contact(new Contact().name("laokou").url("https://github.com/KouShenhai").email("2413176044@qq.com"))
 				.license(new License().name("Apache 2.0").url("https://www.apache.org/licenses/LICENSE-2.0.html")))
 			.externalDocs(new ExternalDocumentation().description("老寇IoT云平台").url("https://github.com/KouShenhai"))

--- a/laokou-common/laokou-common-oss/pom.xml
+++ b/laokou-common/laokou-common-oss/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-oss</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-prometheus/pom.xml
+++ b/laokou-common/laokou-common-prometheus/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-prometheus</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-pulsar/pom.xml
+++ b/laokou-common/laokou-common-pulsar/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-pulsar</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-rate-limiter/pom.xml
+++ b/laokou-common/laokou-common-rate-limiter/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-rate-limiter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-reactor/pom.xml
+++ b/laokou-common/laokou-common-reactor/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-reactor</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-redis/pom.xml
+++ b/laokou-common/laokou-common-redis/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-redis</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-secret/pom.xml
+++ b/laokou-common/laokou-common-secret/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-secret</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-security/pom.xml
+++ b/laokou-common/laokou-common-security/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-security</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-sensitive/pom.xml
+++ b/laokou-common/laokou-common-sensitive/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-sensitive</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-sentinel/pom.xml
+++ b/laokou-common/laokou-common-sentinel/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-sentinel</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-sftp/pom.xml
+++ b/laokou-common/laokou-common-sftp/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-sftp</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-sms/pom.xml
+++ b/laokou-common/laokou-common-sms/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-sms</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-snail-job/pom.xml
+++ b/laokou-common/laokou-common-snail-job/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-snail-job</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-storage/pom.xml
+++ b/laokou-common/laokou-common-storage/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-storage</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-tdengine/pom.xml
+++ b/laokou-common/laokou-common-tdengine/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-common-tdengine</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-tenant/pom.xml
+++ b/laokou-common/laokou-common-tenant/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-common-tenant</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-test/pom.xml
+++ b/laokou-common/laokou-common-test/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-test</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-testcontainers/pom.xml
+++ b/laokou-common/laokou-common-testcontainers/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-testcontainers</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-trace/pom.xml
+++ b/laokou-common/laokou-common-trace/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-trace</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-websocket/pom.xml
+++ b/laokou-common/laokou-common-websocket/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-websocket</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-xss/pom.xml
+++ b/laokou-common/laokou-common-xss/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-common-xss</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/pom.xml
+++ b/laokou-common/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>laokou-common</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>laokou-common</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台【公共模块】</description>

--- a/laokou-service/laokou-admin/laokou-admin-adapter/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-adapter/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-admin/laokou-admin-app/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-app/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-admin/laokou-admin-client/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-client/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-admin/laokou-admin-domain/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-domain/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-admin/laokou-admin-start/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-start/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-admin/pom.xml
+++ b/laokou-service/laokou-admin/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-admin-client</module>

--- a/laokou-service/laokou-ai/pom.xml
+++ b/laokou-service/laokou-ai/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-ai</artifactId>

--- a/laokou-service/laokou-auth/laokou-auth-adapter/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-adapter/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-auth/laokou-auth-app/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-app/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-auth/laokou-auth-client/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-client/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-auth/laokou-auth-domain/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-domain/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-domain</artifactId>

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-auth/laokou-auth-start/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-start/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-auth/pom.xml
+++ b/laokou-service/laokou-auth/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/laokou-service/laokou-cola/laokou-cola-adapter/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-adapter/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-cola/laokou-cola-app/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-app/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-cola/laokou-cola-client/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-client/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-cola/laokou-cola-domain/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-domain/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-cola/laokou-cola-infrastructure/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-infrastructure/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-cola/laokou-cola-start/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-start/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-cola/pom.xml
+++ b/laokou-service/laokou-cola/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-cola</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/laokou-service/laokou-generator/laokou-generator-adapter/pom.xml
+++ b/laokou-service/laokou-generator/laokou-generator-adapter/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-generator</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-generator-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-generator/laokou-generator-app/pom.xml
+++ b/laokou-service/laokou-generator/laokou-generator-app/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-generator</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-generator-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-generator/laokou-generator-client/pom.xml
+++ b/laokou-service/laokou-generator/laokou-generator-client/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-generator</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-generator-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-generator/laokou-generator-domain/pom.xml
+++ b/laokou-service/laokou-generator/laokou-generator-domain/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-generator</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-generator-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-generator/laokou-generator-infrastructure/pom.xml
+++ b/laokou-service/laokou-generator/laokou-generator-infrastructure/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-generator</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-generator-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-generator/laokou-generator-start/pom.xml
+++ b/laokou-service/laokou-generator/laokou-generator-start/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-generator</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-generator-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-generator/pom.xml
+++ b/laokou-service/laokou-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-generator</artifactId>
   <packaging>pom</packaging>

--- a/laokou-service/laokou-iot/laokou-iot-adapter/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-adapter/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-iot</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-iot-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-iot/laokou-iot-app/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-app/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-iot/laokou-iot-client/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-client/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.laokou</groupId>
         <artifactId>laokou-iot</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
   <artifactId>laokou-iot-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-iot/laokou-iot-domain/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-domain/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-iot/laokou-iot-start/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-start/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-iot/pom.xml
+++ b/laokou-service/laokou-iot/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-iot-start</module>

--- a/laokou-service/laokou-logstash/laokou-logstash-adapter/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-adapter/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-logstash</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-logstash-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-logstash/laokou-logstash-app/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-app/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-logstash</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-logstash/laokou-logstash-client/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-logstash</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-logstash-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-logstash/laokou-logstash-domain/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-domain/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-logstash</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-logstash-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-logstash</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-logstash/laokou-logstash-start/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-start/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-logstash</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-logstash/pom.xml
+++ b/laokou-service/laokou-logstash/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash</artifactId>

--- a/laokou-service/laokou-oss/laokou-oss-adapter/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-adapter/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-oss/laokou-oss-app/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-app/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-oss/laokou-oss-client/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-client/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-oss/laokou-oss-domain/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-domain/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-oss/laokou-oss-infrastructure/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-infrastructure/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-oss/laokou-oss-proto/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-proto/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-proto</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/laokou-service/laokou-oss/laokou-oss-start/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-start/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-oss/pom.xml
+++ b/laokou-service/laokou-oss/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-oss</artifactId>
   <packaging>pom</packaging>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <modules>
     <module>laokou-oss-start</module>

--- a/laokou-service/laokou-report/laokou-report-app/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-app/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-report/laokou-report-client/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-client/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-report/laokou-report-infrastructure/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-infrastructure/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-report-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-report/laokou-report-start/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-start/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-report/pom.xml
+++ b/laokou-service/laokou-report/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-adapter/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-adapter/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-client/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-client/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-domain/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-domain/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-proto/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-proto/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-proto</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-snowflake-id/pom.xml
+++ b/laokou-service/laokou-snowflake-id/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-snowflake-id</artifactId>
   <packaging>pom</packaging>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-adapter/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-adapter/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-app/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-app/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-client/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-client/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-domain/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-domain/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <artifactId>laokou-standalone-admin</artifactId>
   <packaging>pom</packaging>
 

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-adapter/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-adapter/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-adapter</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-app/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-app/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-app</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-client/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-client/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-client</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-domain/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-domain/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-domain</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-infrastructure/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-infrastructure/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-infrastructure</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-start</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
 
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <artifactId>laokou-standalone-auth</artifactId>
   <packaging>pom</packaging>
 

--- a/laokou-service/laokou-standalone/pom.xml
+++ b/laokou-service/laokou-standalone/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>laokou-standalone</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-standalone-auth</module>

--- a/laokou-service/pom.xml
+++ b/laokou-service/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-service</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-admin</module>

--- a/laokou-tool/pom.xml
+++ b/laokou-tool/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>laokou-tool</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>KCloud-Platform-IoT</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-common</module>
@@ -67,7 +67,7 @@
   </licenses>
   <properties>
     <!-- 项目版本 -->
-    <project.version>4.0.3</project.version>
+    <project.version>4.0.4-SNAPSHOT</project.version>
     <!-- JDK版本 -->
     <java.version>25</java.version>
     <!--项目编码-->
@@ -955,8 +955,8 @@
         <configuration>
           <!--备份版本-->
           <generateBackupPoms>true</generateBackupPoms>
-          <newVersion>4.0.4-SNAPSHOT</newVersion>
-          <oldVersion>4.0.3</oldVersion>
+          <newVersion>4.0.4</newVersion>
+          <oldVersion>4.0.4-SNAPSHOT</oldVersion>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Sourcery 摘要

将项目在所有构建、模块和部署资源中的开发版本推进至 4.0.4-SNAPSHOT。

增强功能：
- 将项目及所有 Maven 模块的版本从 4.0.3 更新为 4.0.4-SNAPSHOT，包括 API 文档元数据。

构建：
- 更新 Docker 镜像构建和部署引用，以使用 4.0.4-SNAPSHOT 镜像标签。

部署：
- 使 Docker Compose 服务与 4.0.4-SNAPSHOT 容器镜像保持一致。

杂项：
- 更新 Maven 发布元数据，为下一版本 4.0.4 做准备。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Advance the project to the 4.0.4-SNAPSHOT development version across builds, modules, and deployment assets.

Enhancements:
- Advance the project and all Maven modules from version 4.0.3 to 4.0.4-SNAPSHOT, including API documentation metadata.

Build:
- Update Docker image build and deployment references to use the 4.0.4-SNAPSHOT image tags.

Deployment:
- Align Docker Compose services with the 4.0.4-SNAPSHOT container images.

Chores:
- Update Maven release metadata for the next 4.0.4 release.

</details>