### PR TITLE
Dev

### DIFF
--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/exception/handler/ExceptionHandler.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/exception/handler/ExceptionHandler.java
@@ -82,7 +82,7 @@ public class ExceptionHandler implements ErrorWebExceptionHandler, Ordered {
 						return ReactiveResponseUtils.responseOk(exchange, Result.fail(StatusCode.INTERNAL_SERVER_ERROR,
 								MessageUtils.getMessage(StatusCode.INTERNAL_SERVER_ERROR, locale)));
 					}
-					default -> throw new IllegalStateException("Unexpected value: " + statusCode.value());
+					default -> log.error("状态码：{}，网关未知错误，请联系管理员，错误信息：{}", statusCode.value(), ex.getMessage(), ex);
 				}
 			}
 			if (BlockException.isBlockException(ex)) {

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/AbstractVertxService.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/AbstractVertxService.java
@@ -29,7 +29,7 @@ public abstract class AbstractVertxService implements VertxService {
 	protected final AtomicReference<Future<String>> deploymentIdFuture;
 
 	protected AbstractVertxService() {
-		deploymentIdFuture = new AtomicReference<>();
+		deploymentIdFuture = new AtomicReference<>(null);
 	}
 
 	@Override

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/PublishMessageConfig.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/PublishMessageConfig.java
@@ -17,15 +17,11 @@
 
 package org.laokou.iot.common.config.mqtt;
 
+import io.vertx.core.buffer.Buffer;
+
 /**
  * @author laokou
  */
-public interface VertxService {
-
-	void deploy();
-
-	void undeploy();
-
-	void publish(PublishMessageConfig config);
+public record PublishMessageConfig(String topic, int qos, Buffer payload, boolean isDup, boolean isRetain) {
 
 }

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClient.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClient.java
@@ -159,16 +159,17 @@ final class VertxMqttClient extends AbstractVerticle {
 	 * @param isDup if the message is a duplicate
 	 * @param isRetain if the message needs to be retained
 	 */
-	public Future<Integer> publish(@NonNull String topic, int qos, @NonNull Buffer payload, boolean isDup,
-			boolean isRetain) {
+	public void publish(@NonNull String topic, int qos, @NonNull Buffer payload, boolean isDup, boolean isRetain) {
 		if (stopping.get()) {
-			return Future.failedFuture("MQTT客户端正在关闭");
+			log.error("MQTT客户端正在关闭");
+			return;
 		}
-
 		if (!mqttClient.isConnected()) {
-			return Future.failedFuture("MQTT客户端未连接");
+			log.error("MQTT客户端未连接");
+			return;
 		}
-		return mqttClient.publish(topic, payload, VertxMqttUtils.convertQos(qos), isDup, isRetain);
+		mqttClient.publish(topic, payload, VertxMqttUtils.convertQos(qos), isDup, isRetain)
+			.onFailure(ex -> log.error("MQTT发布消息失败，错误信息：{}", ex.getMessage(), ex));
 	}
 
 	private MqttClient createClient(MqttClientOptions options) {

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClientService.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClientService.java
@@ -23,7 +23,10 @@ import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
 import org.laokou.iot.common.config.pulsar.handler.ConnectionStateHandler;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author laokou
@@ -39,6 +42,8 @@ final class VertxMqttClientService extends AbstractVertxService {
 
 	private final List<MessageHandler> messageHandlers;
 
+	private volatile List<VertxMqttClient> vertxMqttClients = List.of();
+
 	public VertxMqttClientService(Vertx vertx, MqttClientConfig config, ConnectionStateHandler connectionStateHandler,
 			List<MessageHandler> messageHandlers) {
 		this.vertx = vertx;
@@ -49,11 +54,16 @@ final class VertxMqttClientService extends AbstractVertxService {
 
 	@Override
 	public Future<String> doDeploy() {
-		return vertx
-			.deployVerticle(() -> new VertxMqttClient(vertx, config, connectionStateHandler, messageHandlers),
-					buildOptions())
-			.onSuccess(deploymentId -> log.info("【Vertx-MQTT-Client】 => MQTT服务部署成功，deploymentId：{}", deploymentId))
-			.onFailure(ex -> log.error("【Vertx-MQTT-Client】 => MQTT服务部署失败", ex));
+		List<VertxMqttClient> clients = new ArrayList<>(4);
+		return vertx.deployVerticle(() -> {
+			VertxMqttClient vertxMqttClient = new VertxMqttClient(vertx, config, connectionStateHandler,
+					messageHandlers);
+			clients.add(vertxMqttClient);
+			return vertxMqttClient;
+		}, buildOptions()).onSuccess(deploymentId -> {
+			vertxMqttClients = List.copyOf(clients);
+			log.info("【Vertx-MQTT-Client】 => MQTT服务部署成功，deploymentId：{}", deploymentId);
+		}).onFailure(ex -> log.error("【Vertx-MQTT-Client】 => MQTT服务部署失败", ex));
 	}
 
 	@Override
@@ -61,6 +71,22 @@ final class VertxMqttClientService extends AbstractVertxService {
 		deploymentIdFuture.get().compose(vertx::undeploy).onSuccess(ignored -> {
 			log.info("【Vertx-MQTT-Client】 => MQTT服务卸载成功");
 		}).onFailure(ex -> log.error("【Vertx-MQTT-Client】 => MQTT服务卸载失败", ex));
+	}
+
+	@Override
+	public void publish(PublishMessageConfig config) {
+		try {
+			List<VertxMqttClient> clients = vertxMqttClients;
+			if (clients.isEmpty()) {
+				throw new IllegalStateException("MQTT客户端尚未初始化完成或部署失败");
+			}
+			int index = ThreadLocalRandom.current().nextInt(clients.size());
+			VertxMqttClient vertxMqttClient = clients.get(index);
+			vertxMqttClient.publish(config.topic(), config.qos(), config.payload(), config.isDup(), config.isRetain());
+		}
+		catch (Exception ex) {
+			log.error("MQTT发布调用异常，错误信息：{}", ex.getMessage(), ex);
+		}
 	}
 
 	private DeploymentOptions buildOptions() {


### PR DESCRIPTION
## Sourcery 摘要

提升 MQTT 发布的可靠性，并支持服务级消息发布，同时使网关错误处理更加稳健。

新功能：
- 添加可配置的 MQTT 消息发布功能，支持主题、QoS、负载、重复和保留设置。
- 通过随机选择客户端，支持在已部署的 MQTT 客户端实例之间进行发布。

错误修复：
- 防止意外的网关错误状态以异常形式传播，改为记录日志。
- 记录 MQTT 发布失败和客户端不可用状态，而不传播失败的 future。

增强功能：
- 跟踪已部署的 MQTT 客户端，并通过 Vert.x 服务抽象提供发布功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve MQTT publishing resilience and enable service-level message publishing while making gateway error handling more robust.

New Features:
- Add configurable MQTT message publishing with topic, QoS, payload, duplicate, and retain settings.
- Support publishing across deployed MQTT client instances through randomized client selection.

Bug Fixes:
- Prevent unexpected gateway error statuses from escaping as exceptions by logging them instead.
- Log MQTT publish failures and unavailable client states without propagating failed futures.

Enhancements:
- Track deployed MQTT clients and expose publishing through the Vert.x service abstraction.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MQTT message publishing support through the IoT service layer.
  - MQTT publishing now supports topic, quality-of-service, payload, duplicate, and retain settings.
  - Messages are distributed across available MQTT clients for improved service handling.

- **Bug Fixes**
  - Unrecognized HTTP response statuses are now logged instead of causing an application state exception.
  - MQTT publishing failures and unavailable client conditions are reported through error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->