### PR TITLE
feat: mqtt发布消息捕获异常

### DIFF
--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClient.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClient.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.laokou.common.core.util.MapUtils;
 import org.laokou.common.core.util.UUIDGenerator;
+import org.laokou.common.i18n.common.exception.BizException;
 import org.laokou.iot.common.config.pulsar.handler.ConnectionStateHandler;
 import org.laokou.iot.common.config.pulsar.handler.State;
 import org.laokou.iot.common.util.VertxMqttUtils;
@@ -161,15 +162,20 @@ final class VertxMqttClient extends AbstractVerticle {
 	 */
 	public void publish(@NonNull String topic, int qos, @NonNull Buffer payload, boolean isDup, boolean isRetain) {
 		if (stopping.get()) {
-			log.error("MQTT客户端正在关闭");
-			return;
+			throw new BizException("B_Mqtt_ClientShuttingDown", "MQTT客户端正在关闭");
 		}
 		if (!mqttClient.isConnected()) {
-			log.error("MQTT客户端未连接");
-			return;
+			throw new BizException("B_Mqtt_ClientNotConnected", "MQTT客户端未连接");
 		}
 		mqttClient.publish(topic, payload, VertxMqttUtils.convertQos(qos), isDup, isRetain)
-			.onFailure(ex -> log.error("MQTT发布消息失败，错误信息：{}", ex.getMessage(), ex));
+			.onSuccess(_ -> log.debug("MQTT发布消息成功"))
+			.recover(ex -> {
+				log.error("MQTT发布消息失败，错误信息：{}", ex.getMessage(), ex);
+				return Future.failedFuture(ex);
+			})
+			.toCompletionStage()
+			.toCompletableFuture()
+			.join();
 	}
 
 	private MqttClient createClient(MqttClientOptions options) {

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClientService.java
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/src/main/java/org/laokou/iot/common/config/mqtt/VertxMqttClientService.java
@@ -22,6 +22,7 @@ import io.vertx.core.Future;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
+import org.laokou.common.i18n.common.exception.BizException;
 import org.laokou.iot.common.config.pulsar.handler.ConnectionStateHandler;
 
 import java.util.ArrayList;
@@ -78,7 +79,7 @@ final class VertxMqttClientService extends AbstractVertxService {
 		try {
 			List<VertxMqttClient> clients = vertxMqttClients;
 			if (clients.isEmpty()) {
-				throw new IllegalStateException("MQTT客户端尚未初始化完成或部署失败");
+				throw new BizException("B_Mqtt_ClientNotInitializedOrDeployFailed", "MQTT客户端尚未初始化完成或部署失败");
 			}
 			int index = ThreadLocalRandom.current().nextInt(clients.size());
 			VertxMqttClient vertxMqttClient = clients.get(index);
@@ -86,6 +87,7 @@ final class VertxMqttClientService extends AbstractVertxService {
 		}
 		catch (Exception ex) {
 			log.error("MQTT发布调用异常，错误信息：{}", ex.getMessage(), ex);
+			throw ex;
 		}
 	}
 


### PR DESCRIPTION
## Sourcery 摘要

使 MQTT 消息发布向调用方报告客户端状态，并返回发布失败信息。

错误修复：
- 将 MQTT 发布失败和无效客户端状态作为业务异常传递，而不是静默记录日志后返回。

功能增强：
- 添加成功日志，并在 MQTT 服务边界传递发布异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make MQTT message publishing report client-state and publish failures to callers.

Bug Fixes:
- Propagate MQTT publishing failures and invalid client states as business exceptions instead of silently logging and returning.

Enhancements:
- Add success logging and preserve publish exceptions through the MQTT service boundary.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MQTT publishing now reports clear business errors when the client is unavailable, stopping, or not connected.
  - Publish failures are now propagated to callers instead of being logged silently.
  - MQTT client initialization and deployment failures now return consistent error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->