### PR TITLE
feat: 调整maven顺序

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,6 +72,6 @@ jobs:
         </settings>
         EOF
     - name: Build with Maven
-      run: mvn -T 1.5C clean package -Pdev -DskipTests -U "-Drevision=4.0.4-SNAPSHOT"
+      run: mvn -U clean package -T 1.5C -Pdev "-Drevision=4.0.4-SNAPSHOT" -DskipTests
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.37.9

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Configure Elasticsearch
         run: sudo sysctl -w vm.max_map_count=1048576
       - name: Build with Maven Mvnd
-        run: mvnd -T 1.5C clean install -Pdev -U "-Drevision=4.0.4-SNAPSHOT"
+        run: mvnd -U clean install -T 1.5C -Pdev "-Drevision=4.0.4-SNAPSHOT"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7.0.0
         env:
@@ -146,6 +146,6 @@ jobs:
           # ========== 构建laokou-gateway-native ==========
           cd /home/runner/work/KCloud-Platform-IoT/KCloud-Platform-IoT/laokou-cloud/laokou-gateway
           # 构建本地镜像
-          mvnd -T 1.5C spring-boot:build-image -DskipTests "-Drevision=4.0.4-SNAPSHOT"
+          mvnd -T 1.5C spring-boot:build-image -DskipTests
           # 推送镜像到镜像仓库
           docker push registry.cn-shenzhen.aliyuncs.com/koushenhai/laokou-gateway-native:4.0.4-SNAPSHOT

--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
@@ -57,6 +57,7 @@ class GatewayApp implements CommandLineRunner {
 
 	// @formatter:off
 	static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
+		// mvn -U clean install -pl :laokou-gateway -am "-Drevision=4.0.4-SNAPSHOT" -DskipTests
 		StopWatch stopWatch = new StopWatch("Gateway应用程序");
 		stopWatch.start();
 		System.setProperty("ENDPOINT", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(), System.getProperty("server.port", "5555")));


### PR DESCRIPTION
## Sourcery 摘要

调整 CI 与网关构建相关的 Maven 命令顺序，统一构建参数并完善本地构建提示。

增强：
- 统一 CodeQL 和 Maven CI 构建中的 Maven 命令行选项顺序。
- 记录用于构建网关模块及其依赖项的推荐 Maven 命令。

CI：
- 更新 CI 构建命令以采用调整后的 Maven 选项顺序，并简化原生网关镜像构建命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整 CI 与网关构建相关的 Maven 命令顺序，统一构建参数并完善本地构建提示。

Enhancements:
- Standardize Maven command-line option ordering across CodeQL and Maven CI builds.
- Document the recommended Maven command for building the gateway module and its dependencies.

CI:
- Update CI build commands to use the revised Maven option ordering and simplify the native gateway image build command.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a build command reference to the gateway application entry point.

- **Chores**
  - Updated Maven workflow command ordering for more consistent build execution.
  - Adjusted the native-image workflow command by removing the revision property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->