### PR TITLE
fix: maven构建失败

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,6 +72,6 @@ jobs:
         </settings>
         EOF
     - name: Build with Maven
-      run: mvn -U clean package -T 1.5C -Pdev "-Drevision=4.0.4-SNAPSHOT" -DskipTests
+      run: mvn -U clean package -T 1.5C -Pdev -DskipTests
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.37.9

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Configure Elasticsearch
         run: sudo sysctl -w vm.max_map_count=1048576
       - name: Build with Maven Mvnd
-        run: mvnd -U clean install -T 1.5C -Pdev "-Drevision=4.0.4-SNAPSHOT"
+        run: mvnd -U clean install -T 1.5C -Pdev
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7.0.0
         env:

--- a/laokou-cloud/laokou-gateway/pom.xml
+++ b/laokou-cloud/laokou-gateway/pom.xml
@@ -23,18 +23,18 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cloud</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-gateway</artifactId>
   <description>API网关</description>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-redis</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.tomcat.embed</groupId>
@@ -55,17 +55,17 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-prometheus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <!-- 监控依赖 -->
     <dependency>
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-trace</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sentinel</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.alibaba.csp</groupId>
@@ -134,14 +134,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
@@ -158,7 +158,7 @@
           <!-- main方法的地址 只需要修改这个地址-->
           <mainClass>org.laokou.gateway.GatewayApp</mainClass>
           <!-- Docker镜像名称 -->
-          <imageName>${docker.registry}/${docker.namespace}/${project.artifactId}-native:${reversion}</imageName>
+          <imageName>${docker.registry}/${docker.namespace}/${project.artifactId}-native:${revision}</imageName>
           <jvmArguments>
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED

--- a/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
+++ b/laokou-cloud/laokou-gateway/src/main/java/org/laokou/gateway/GatewayApp.java
@@ -57,7 +57,7 @@ class GatewayApp implements CommandLineRunner {
 
 	// @formatter:off
 	static void main(String[] args) throws UnknownHostException, NoSuchAlgorithmException, KeyManagementException {
-		// mvn -U clean install -pl :laokou-gateway -am "-Drevision=4.0.4-SNAPSHOT" -DskipTests
+		// mvn -U clean install -pl :laokou-gateway -am -DskipTests
 		StopWatch stopWatch = new StopWatch("Gateway应用程序");
 		stopWatch.start();
 		System.setProperty("ENDPOINT", String.format("%s:%s", InetAddress.getLocalHost().getHostAddress(), System.getProperty("server.port", "5555")));

--- a/laokou-cloud/laokou-monitor/pom.xml
+++ b/laokou-cloud/laokou-monitor/pom.xml
@@ -22,17 +22,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cloud</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-monitor</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-prometheus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -77,17 +77,17 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-cloud/laokou-nacos/pom.xml
+++ b/laokou-cloud/laokou-nacos/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>laokou-cloud</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-nacos</artifactId>
 
   <properties>
-    <!--nacos-server版本-->
+    <!-- nacos-server版本 -->
     <nacos-server.version>3.2.4</nacos-server.version>
   </properties>
 

--- a/laokou-cloud/laokou-nacos/src/main/resources/application.properties
+++ b/laokou-cloud/laokou-nacos/src/main/resources/application.properties
@@ -109,8 +109,8 @@ nacos.naming.fuzzy.watch.max.pattern.match.service.count=500
 nacos.config.fuzzy.watch.max.pattern.count=20
 # \u6BCF\u4E2A\u6A21\u7CCA\u6A21\u5F0F\u6700\u591A\u80FD\u5339\u914D500\u4E2A\u914D\u7F6E\u9879
 nacos.config.fuzzy.watch.max.pattern.match.config.count=500
-# \u7981\u7528ai
-nacos.extension.ai.enabled=false
+# \u542F\u7528AI Registry\uFF08MCP\u6CE8\u518C\u9700\u8981\u52A0\u8F7DAI\u8BF7\u6C42\u5904\u7406\u5668\uFF09
+nacos.extension.ai.enabled=true
 # \u7981\u7528\u5E7F\u544A
 nacos.console.ad.enabled=false
 # \u6307\u5B9A\u65E5\u5FD7\u914D\u7F6E\u6587\u4EF6\u8DEF\u5F84

--- a/laokou-cloud/pom.xml
+++ b/laokou-cloud/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-cloud</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-gateway</module>

--- a/laokou-common/laokou-common-ai/pom.xml
+++ b/laokou-common/laokou-common-ai/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-ai</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-common/laokou-common-algorithm/pom.xml
+++ b/laokou-common/laokou-common-algorithm/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-algorithm</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-banner/pom.xml
+++ b/laokou-common/laokou-common-banner/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-banner</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-common/laokou-common-banner/src/main/resources/application-dev.yml
+++ b/laokou-common/laokou-common-banner/src/main/resources/application-dev.yml
@@ -1,3 +1,0 @@
-laokou-version: ${reversion}
-spring-cloud-version: ${spring-cloud.version}
-spring-cloud-alibaba-version: ${spring-cloud-alibaba.version}

--- a/laokou-common/laokou-common-banner/src/main/resources/application-prod.yml
+++ b/laokou-common/laokou-common-banner/src/main/resources/application-prod.yml
@@ -1,3 +1,0 @@
-laokou-version: ${reversion}
-spring-cloud-version: ${spring-cloud.version}
-spring-cloud-alibaba-version: ${spring-cloud-alibaba.version}

--- a/laokou-common/laokou-common-banner/src/main/resources/application-test.yml
+++ b/laokou-common/laokou-common-banner/src/main/resources/application-test.yml
@@ -1,3 +1,0 @@
-laokou-version: ${reversion}
-spring-cloud-version: ${spring-cloud.version}
-spring-cloud-alibaba-version: ${spring-cloud-alibaba.version}

--- a/laokou-common/laokou-common-banner/src/main/resources/banner.txt
+++ b/laokou-common/laokou-common-banner/src/main/resources/banner.txt
@@ -29,7 +29,7 @@ CSDN：https://kcloud.blog.csdn.net
 Juejin：https://juejin.cn/user/160945808873534
 Website：https://laokou.org.cn
 
-版本：${laokou-version}
+版本：${revision}
 
 ${AnsiColor.CYAN}端口：${server.port}，PID：${PID}，启动环境：${spring.profiles.active}
 
@@ -41,8 +41,8 @@ ${java.vm.name} ${java.vendor.version:} (build ${java.runtime.version}，${java.
 ${AnsiColor.BRIGHT_YELLOW}Java 类版本号：${java.class.version}
 
 ${AnsiColor.GREEN}Spring Boot版本：${spring-boot.version}
-${AnsiColor.BRIGHT_GREEN}Spring Cloud版本：${spring-cloud-version}
-${AnsiColor.YELLOW}Spring Cloud Alibaba版本：${spring-cloud-alibaba-version}
+${AnsiColor.BRIGHT_GREEN}Spring Cloud版本：${spring-cloud.version}
+${AnsiColor.YELLOW}Spring Cloud Alibaba版本：${spring-cloud-alibaba.version}
 
 ${AnsiColor.BRIGHT_MAGENTA}时区：${user.timezone}，语言：${user.language}，国家：${user.country}，文件编码：${file.encoding}
 ${AnsiColor.BLUE}JDK所在目录：${java.home}

--- a/laokou-common/laokou-common-context/pom.xml
+++ b/laokou-common/laokou-common-context/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-context</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -24,12 +24,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-core/pom.xml
+++ b/laokou-common/laokou-common-core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>laokou-common-core</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <name>laokou-common-core</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台【核心模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-cors/pom.xml
+++ b/laokou-common/laokou-common-cors/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-cors</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-crypto/pom.xml
+++ b/laokou-common/laokou-common-crypto/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-crypto</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-csv/pom.xml
+++ b/laokou-common/laokou-common-csv/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-csv</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-data-cache/pom.xml
+++ b/laokou-common/laokou-common-data-cache/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-data-cache</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -50,12 +50,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-lock</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.redisson</groupId>
@@ -64,14 +64,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-domain/pom.xml
+++ b/laokou-common/laokou-common-domain/pom.xml
@@ -6,16 +6,16 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-common-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-kafka</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-common/laokou-common-elasticsearch/pom.xml
+++ b/laokou-common/laokou-common-elasticsearch/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-elasticsearch</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>co.elastic.clients</groupId>
@@ -29,14 +29,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-excel/pom.xml
+++ b/laokou-common/laokou-common-excel/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-excel</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-mybatis-plus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
       <exclusions>

--- a/laokou-common/laokou-common-fory/pom.xml
+++ b/laokou-common/laokou-common-fory/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-fory</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -24,14 +24,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
       <scope>test</scope>
       <optional>true</optional>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-grpc-client/pom.xml
+++ b/laokou-common/laokou-common-grpc-client/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-grpc-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-grpc-server/pom.xml
+++ b/laokou-common/laokou-common-grpc-server/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-grpc-server</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-security</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -49,14 +49,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-i18n/pom.xml
+++ b/laokou-common/laokou-common-i18n/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>laokou-common-i18n</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <name>laokou-common-i18n</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台【I18N国际化模块】</description>
   <url>https://koushenhai.github.io/KCloud-Platform-IoT</url>
@@ -79,12 +79,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-banner</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-idempotent/pom.xml
+++ b/laokou-common/laokou-common-idempotent/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-idempotent</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -33,12 +33,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-redis</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-influxdb/pom.xml
+++ b/laokou-common/laokou-common-influxdb/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-influxdb</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-kafka/pom.xml
+++ b/laokou-common/laokou-common-kafka/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-kafka</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-fory</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -32,14 +32,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-lock/pom.xml
+++ b/laokou-common/laokou-common-lock/pom.xml
@@ -6,16 +6,16 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-common-lock</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-redis</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
         <groupId>org.aspectj</groupId>
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-log/pom.xml
+++ b/laokou-common/laokou-common-log/pom.xml
@@ -6,32 +6,32 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-log</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-tenant</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-proto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-grpc-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-log4j2/pom.xml
+++ b/laokou-common/laokou-common-log4j2/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-log4j2</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-mail/pom.xml
+++ b/laokou-common/laokou-common-mail/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-mail</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -17,12 +17,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sensitive</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-mongodb/pom.xml
+++ b/laokou-common/laokou-common-mongodb/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-mongodb</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-mybatis-plus/pom.xml
+++ b/laokou-common/laokou-common-mybatis-plus/pom.xml
@@ -22,17 +22,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-mybatis-plus</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.baomidou</groupId>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-crypto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-fory</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.baomidou</groupId>
@@ -92,24 +92,24 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-context</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-storage</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-nacos/pom.xml
+++ b/laokou-common/laokou-common-nacos/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-nacos</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-reactor</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -73,21 +73,21 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-openapi-doc/pom.xml
+++ b/laokou-common/laokou-common-openapi-doc/pom.xml
@@ -22,17 +22,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-openapi-doc</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>

--- a/laokou-common/laokou-common-oss/pom.xml
+++ b/laokou-common/laokou-common-oss/pom.xml
@@ -3,17 +3,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-oss</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -32,19 +32,19 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-algorithm</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-prometheus/pom.xml
+++ b/laokou-common/laokou-common-prometheus/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-prometheus</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-pulsar/pom.xml
+++ b/laokou-common/laokou-common-pulsar/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-pulsar</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-fory</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -41,14 +41,14 @@
       <artifactId>laokou-common-test</artifactId>
       <scope>test</scope>
       <optional>true</optional>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
       <scope>test</scope>
       <optional>true</optional>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-rate-limiter/pom.xml
+++ b/laokou-common/laokou-common-rate-limiter/pom.xml
@@ -5,22 +5,22 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-rate-limiter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-redis</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-context</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-common/laokou-common-reactor/pom.xml
+++ b/laokou-common/laokou-common-reactor/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-reactor</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-redis/pom.xml
+++ b/laokou-common/laokou-common-redis/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-redis</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -46,19 +46,19 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-secret/pom.xml
+++ b/laokou-common/laokou-common-secret/pom.xml
@@ -22,17 +22,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-secret</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-security/pom.xml
+++ b/laokou-common/laokou-common-security/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-security</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-redis</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-context</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-crypto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -69,14 +69,14 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-sensitive/pom.xml
+++ b/laokou-common/laokou-common-sensitive/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-sensitive</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-sentinel/pom.xml
+++ b/laokou-common/laokou-common-sentinel/pom.xml
@@ -22,17 +22,16 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-sentinel</artifactId>
-  <version>${reversion}</version>
-
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.alibaba.cloud</groupId>

--- a/laokou-common/laokou-common-sftp/pom.xml
+++ b/laokou-common/laokou-common-sftp/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-sftp</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -20,19 +20,19 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-sms/pom.xml
+++ b/laokou-common/laokou-common-sms/pom.xml
@@ -3,17 +3,17 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-sms</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sensitive</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-snail-job/pom.xml
+++ b/laokou-common/laokou-common-snail-job/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-snail-job</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-storage/pom.xml
+++ b/laokou-common/laokou-common-storage/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-storage</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-tdengine</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -29,12 +29,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-influxdb</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-elasticsearch</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-tdengine/pom.xml
+++ b/laokou-common/laokou-common-tdengine/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-common-tdengine</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-tenant/pom.xml
+++ b/laokou-common/laokou-common-tenant/pom.xml
@@ -4,16 +4,16 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-common-tenant</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-mybatis-plus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-common/laokou-common-test/pom.xml
+++ b/laokou-common/laokou-common-test/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-test</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>

--- a/laokou-common/laokou-common-testcontainers/pom.xml
+++ b/laokou-common/laokou-common-testcontainers/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-testcontainers</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/laokou-common/laokou-common-trace/pom.xml
+++ b/laokou-common/laokou-common-trace/pom.xml
@@ -5,22 +5,22 @@
   <parent>
     <artifactId>laokou-common</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-common-trace</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-common/laokou-common-websocket/pom.xml
+++ b/laokou-common/laokou-common-websocket/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-websocket</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-security</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -42,12 +42,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-testcontainers</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/laokou-common/laokou-common-xss/pom.xml
+++ b/laokou-common/laokou-common-xss/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-common</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-common-xss</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -20,18 +20,18 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-cors</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.jsqlparser</groupId>

--- a/laokou-common/pom.xml
+++ b/laokou-common/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>laokou-common</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>laokou-common</name>
   <description>一个企业级微服务架构的云服务多租户IoT平台【公共模块】</description>

--- a/laokou-service/laokou-admin/laokou-admin-adapter/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-adapter/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-admin/laokou-admin-app/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-app/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-admin/laokou-admin-client/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-client/pom.xml
@@ -22,27 +22,27 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sensitive</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-excel</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-crypto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/laokou-service/laokou-admin/laokou-admin-domain/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-domain/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-crypto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-admin/laokou-admin-infrastructure/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-infrastructure/pom.xml
@@ -5,67 +5,67 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-security</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-cors</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-idempotent</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-trace</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-algorithm</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-mybatis-plus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-rate-limiter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-secret</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -88,17 +88,17 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-lock</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-data-cache</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-prometheus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -133,37 +133,37 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-openapi-doc</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-kafka</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sentinel</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-proto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-tenant</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-csv</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-service/laokou-admin/laokou-admin-start/pom.xml
+++ b/laokou-service/laokou-admin/laokou-admin-start/pom.xml
@@ -5,22 +5,22 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-service/laokou-admin/pom.xml
+++ b/laokou-service/laokou-admin/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-admin</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-admin-client</module>

--- a/laokou-service/laokou-ai/pom.xml
+++ b/laokou-service/laokou-ai/pom.xml
@@ -6,9 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-ai</artifactId>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-auth/laokou-auth-adapter/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-adapter/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-auth-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-auth/laokou-auth-app/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-app/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-auth-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-auth/laokou-auth-client/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-client/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-auth/laokou-auth-domain/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-domain/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-domain</artifactId>
@@ -14,17 +14,17 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-crypto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.whvcse</groupId>
@@ -24,67 +24,67 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-rate-limiter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-data-cache</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-auth-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-idempotent</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-security</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-mybatis-plus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sensitive</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sms</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-mail</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-trace</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-cors</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-prometheus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -103,32 +103,32 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-openapi-doc</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-auth-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-kafka</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-sentinel</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-tenant</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-lock</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -145,12 +145,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-proto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-grpc-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-service/laokou-auth/laokou-auth-start/pom.xml
+++ b/laokou-service/laokou-auth/laokou-auth-start/pom.xml
@@ -5,22 +5,22 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-auth-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
@@ -43,7 +43,7 @@
           <!-- main方法的地址 只需要修改这个地址-->
           <mainClass>org.laokou.auth.AuthApp</mainClass>
           <!-- Docker镜像名称 -->
-          <imageName>${docker.registry}/${docker.namespace}/${project.artifactId}-native:${reversion}</imageName>
+          <imageName>${docker.registry}/${docker.namespace}/${project.artifactId}-native:${revision}</imageName>
           <jvmArguments>
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED

--- a/laokou-service/laokou-auth/pom.xml
+++ b/laokou-service/laokou-auth/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-auth</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/laokou-service/laokou-cola/laokou-cola-adapter/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-adapter/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-cola-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-cola/laokou-cola-app/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-app/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-cola-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-cola/laokou-cola-client/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-client/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-cola/laokou-cola-domain/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-domain/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-cola/laokou-cola-infrastructure/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-infrastructure/pom.xml
@@ -6,42 +6,42 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-cola-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-security</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-prometheus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-cola-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-cola/laokou-cola-start/pom.xml
+++ b/laokou-service/laokou-cola/laokou-cola-start/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-cola</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-cola-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-cola/pom.xml
+++ b/laokou-service/laokou-cola/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-cola</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/laokou-service/laokou-iot/laokou-iot-adapter/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-adapter/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-iot</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-iot-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-iot-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-iot/laokou-iot-app/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-app/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-iot-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-iot/laokou-iot-client/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-client/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.laokou</groupId>
         <artifactId>laokou-iot</artifactId>
-        <version>${reversion}</version>
+        <version>${revision}</version>
     </parent>
 
   <artifactId>laokou-iot-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/laokou-service/laokou-iot/laokou-iot-domain/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-domain/pom.xml
@@ -3,22 +3,22 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-service/laokou-iot/laokou-iot-infrastructure/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-infrastructure/pom.xml
@@ -3,62 +3,62 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-iot-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-iot-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-data-cache</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-cors</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-idempotent</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-trace</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-mybatis-plus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -77,17 +77,17 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-openapi-doc</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-kafka</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-websocket</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -96,12 +96,12 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-pulsar</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-storage</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/laokou-service/laokou-iot/laokou-iot-start/pom.xml
+++ b/laokou-service/laokou-iot/laokou-iot-start/pom.xml
@@ -5,22 +5,22 @@
   <parent>
     <artifactId>laokou-iot</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-iot-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-service/laokou-iot/pom.xml
+++ b/laokou-service/laokou-iot/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-iot</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-iot-start</module>

--- a/laokou-service/laokou-logstash/laokou-logstash-adapter/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-adapter/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-logstash</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-logstash-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-logstash-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-logstash/laokou-logstash-app/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-app/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <artifactId>laokou-logstash</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-logstash-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-logstash/laokou-logstash-client/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-client/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-logstash</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-logstash-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-i18n</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-logstash/laokou-logstash-domain/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-domain/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-logstash</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-logstash-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-logstash-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-logstash/laokou-logstash-infrastructure/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-infrastructure/pom.xml
@@ -5,32 +5,32 @@
   <parent>
     <artifactId>laokou-logstash</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-elasticsearch</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-trace</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-logstash-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-kafka</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-logstash/laokou-logstash-start/pom.xml
+++ b/laokou-service/laokou-logstash/laokou-logstash-start/pom.xml
@@ -5,22 +5,22 @@
   <parent>
     <artifactId>laokou-logstash</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-logstash-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-service/laokou-logstash/pom.xml
+++ b/laokou-service/laokou-logstash/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-logstash</artifactId>

--- a/laokou-service/laokou-oss/laokou-oss-adapter/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-adapter/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-oss/laokou-oss-app/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-app/pom.xml
@@ -4,22 +4,22 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-data-cache</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-oss/laokou-oss-client/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-client/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-oss/laokou-oss-domain/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-domain/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-oss/laokou-oss-infrastructure/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-infrastructure/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-prometheus</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-trace</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>org.xerial.snappy</groupId>
@@ -53,32 +53,32 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-oss</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-tenant</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-proto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-data-cache</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-service/laokou-oss/laokou-oss-proto/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-proto/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-proto</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <build>
     <plugins>

--- a/laokou-service/laokou-oss/laokou-oss-start/pom.xml
+++ b/laokou-service/laokou-oss/laokou-oss-start/pom.xml
@@ -4,22 +4,22 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-oss</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-oss-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-test</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/laokou-service/laokou-oss/pom.xml
+++ b/laokou-service/laokou-oss/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-oss</artifactId>
   <packaging>pom</packaging>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <modules>
     <module>laokou-oss-start</module>

--- a/laokou-service/laokou-report/laokou-report-app/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-app/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-report-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-report/laokou-report-client/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-client/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-report/laokou-report-infrastructure/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-infrastructure/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-report-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-report-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-report/laokou-report-start/pom.xml
+++ b/laokou-service/laokou-report/laokou-report-start/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-report</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-report-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-report/pom.xml
+++ b/laokou-service/laokou-report/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>laokou-service</artifactId>
     <groupId>org.laokou</groupId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-report</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-adapter/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-adapter/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-app/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-client/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-client/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-domain/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-domain/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-infrastructure/pom.xml
@@ -4,27 +4,27 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
@@ -47,17 +47,17 @@
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-proto</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-nacos</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-grpc-server</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-proto/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-proto/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-proto</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>

--- a/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/pom.xml
+++ b/laokou-service/laokou-snowflake-id/laokou-snowflake-id-start/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-snowflake-id</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-snowflake-id-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-snowflake-id-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-snowflake-id/pom.xml
+++ b/laokou-service/laokou-snowflake-id/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-snowflake-id</artifactId>
   <packaging>pom</packaging>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-adapter/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-adapter/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-admin-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-app/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-app/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-admin-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>org.laokou</groupId>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-client/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-client/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-domain/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-domain/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-infrastructure/pom.xml
@@ -4,27 +4,27 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-admin-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-admin-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-admin-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>org.laokou</groupId>

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/laokou-standalone-admin-start/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-admin</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-admin-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-admin-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-standalone/laokou-standalone-admin/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-admin/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <artifactId>laokou-standalone-admin</artifactId>
   <packaging>pom</packaging>
 

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-adapter/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-adapter/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-adapter</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-auth-app</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-app/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-app/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-app</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-auth-infrastructure</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>org.laokou</groupId>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-client/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-client/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-client</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-domain/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-domain/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-domain</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
 </project>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-infrastructure/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-infrastructure/pom.xml
@@ -4,27 +4,27 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-infrastructure</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-auth-domain</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-auth-client</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-auth-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/laokou-standalone-auth-start/pom.xml
@@ -4,17 +4,17 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone-auth</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>laokou-standalone-auth-start</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-standalone-auth-adapter</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/laokou-service/laokou-standalone/laokou-standalone-auth/pom.xml
+++ b/laokou-service/laokou-standalone/laokou-standalone-auth/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-standalone</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
 
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <artifactId>laokou-standalone-auth</artifactId>
   <packaging>pom</packaging>
 

--- a/laokou-service/laokou-standalone/pom.xml
+++ b/laokou-service/laokou-standalone/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>laokou-service</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>laokou-standalone</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-standalone-auth</module>

--- a/laokou-service/pom.xml
+++ b/laokou-service/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>laokou-service</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-admin</module>

--- a/laokou-tool/pom.xml
+++ b/laokou-tool/pom.xml
@@ -4,23 +4,23 @@
   <parent>
     <groupId>org.laokou</groupId>
     <artifactId>KCloud-Platform-IoT</artifactId>
-    <version>${reversion}</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>laokou-tool</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
 
   <dependencies>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-core</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.laokou</groupId>
       <artifactId>laokou-common-log4j2</artifactId>
-      <version>${reversion}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.laokou</groupId>
   <artifactId>KCloud-Platform-IoT</artifactId>
-  <version>${reversion}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <modules>
     <module>laokou-common</module>
@@ -67,7 +67,7 @@
   </licenses>
   <properties>
     <!-- 项目版本 -->
-    <reversion>4.0.4-SNAPSHOT</reversion>
+    <revision>4.0.4-SNAPSHOT</revision>
     <!-- JDK版本 -->
     <java.version>25</java.version>
     <!-- 项目编码 -->
@@ -1090,10 +1090,10 @@
           <images>
             <image>
               <!-- 推送仓库/命名空间/仓库名称:镜像版本号 -->
-              <name>${docker.registry}/${docker.namespace}/${project.artifactId}:${reversion}</name>
+              <name>${docker.registry}/${docker.namespace}/${project.artifactId}:${revision}</name>
               <build>
                 <tags>
-                  <tag>${reversion}</tag>
+                  <tag>${revision}</tag>
                 </tags>
                 <!-- 指定dockerfile文件的位置 -->
                 <dockerFile>${project.basedir}/Dockerfile</dockerFile>
@@ -1222,7 +1222,7 @@
 
                 <!-- 检查系统属性 -->
                 <requireProperty>
-                  <property>reversion</property>
+                  <property>revision</property>
                   <message>请检查项目版本</message>
                   <regex>.*\d+.\d+.\d+.*</regex>
                 </requireProperty>


### PR DESCRIPTION
## Sourcery 总结

统一整个项目和 CI 中的 Maven 版本解析，以恢复可靠的构建。

新功能：
- 启用 Nacos AI Registry 支持，以满足 MCP 注册和 AI 请求处理的需求。

错误修复：
- 通过将项目版本引用统一为有效的 revision 属性，并移除冲突的 CI revision 覆盖设置，修复 Maven 构建问题。

增强：
- 将模块、依赖项、父项目、Docker 镜像和验证配置统一为使用 revision 属性。
- 移除不再需要的环境特定 banner 配置文件。

CI：
- 更新 Maven 和 CodeQL 工作流，在构建时不再传递显式的 revision 覆盖值。

杂项：
- 更新网关构建示例，以使用标准化的版本配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize Maven version resolution across the project and CI to restore reliable builds.

New Features:
- Enable Nacos AI Registry support required for MCP registration and AI request handling.

Bug Fixes:
- Fix Maven builds by standardizing project version references on the valid revision property and removing conflicting CI revision overrides.

Enhancements:
- Align module, dependency, parent, Docker image, and validation configuration with the unified revision property.
- Remove environment-specific banner configuration files that are no longer needed.

CI:
- Update Maven and CodeQL workflows to build without passing an explicit revision override.

Chores:
- Update the gateway build example to use the standardized version configuration.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI Registry support is now enabled, allowing AI request processing required for MCP registration.

- **Bug Fixes**
  - Standardized application, dependency, and container version handling across the platform.
  - Continuous integration builds now use the project’s configured revision without applying an external version override.

- **Configuration**
  - Removed redundant environment-specific version settings from banner configuration.
  - Updated banner version placeholders to use the standardized revision and Spring Cloud property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->