### PR TITLE
Dev

### DIFF
--- a/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
+++ b/laokou-common/laokou-common-mybatis-plus/src/test/java/org/laokou/common/mybatisplus/MybatisUtilsTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.laokou.common.core.util.ThreadUtils;
 import org.laokou.common.i18n.dto.PageQuery;
 import org.laokou.common.i18n.util.InstantUtils;
-import org.laokou.common.mybatisplus.config.GlobalTenantLineHandler;
 import org.laokou.common.mybatisplus.mapper.BaseDO;
 import org.laokou.common.mybatisplus.util.MybatisUtils;
 import org.mybatis.spring.annotation.MapperScan;
@@ -41,7 +40,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author laokou
@@ -68,14 +66,6 @@ class MybatisUtilsTest {
 	@DynamicPropertySource
 	static void configureProperties(DynamicPropertyRegistry registry) {
 		registry.add("spring.datasource.dynamic.datasource.master.url", postgres::getJdbcUrl);
-	}
-
-	@Test
-	void test_ignoreTable() {
-		GlobalTenantLineHandler globalTenantLineHandler = new GlobalTenantLineHandler(Set.of("test", "t_user"));
-		Assertions.assertThat(globalTenantLineHandler.ignoreTable("t_user")).isTrue();
-		Assertions.assertThat(globalTenantLineHandler.ignoreTable("t_test")).isFalse();
-		Assertions.assertThat(globalTenantLineHandler.ignoreTable("t_tes1")).isFalse();
 	}
 
 	@Test

--- a/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentService.java
+++ b/laokou-common/laokou-common-security/src/main/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentService.java
@@ -48,8 +48,7 @@ public record RedisOAuth2AuthorizationConsentService(
 
 	@Override
 	public void save(@NonNull OAuth2AuthorizationConsent authorizationConsent) {
-		OAuth2UserConsent oauth2UserConsent = OAuth2ModelMapper.convertOAuth2UserConsent(authorizationConsent);
-		this.userConsentRepository.save(oauth2UserConsent);
+		this.userConsentRepository.save(OAuth2ModelMapper.convertOAuth2UserConsent(authorizationConsent));
 	}
 
 	@Override

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentServiceTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationConsentServiceTest.java
@@ -51,14 +51,6 @@ class RedisOAuth2AuthorizationConsentServiceTest {
 	}
 
 	@Test
-	void test_constructor_throws_exception_when_repository_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> new RedisOAuth2AuthorizationConsentService(null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("UserConsentRepository cannot be null");
-	}
-
-	@Test
 	void test_save_authorizationConsent() {
 		// Given
 		OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent.withId("client-1", "user-1")
@@ -115,30 +107,6 @@ class RedisOAuth2AuthorizationConsentServiceTest {
 		Assertions.assertThat(result).isNotNull();
 		Assertions.assertThat(result.getRegisteredClientId()).isEqualTo("client-1");
 		Assertions.assertThat(result.getPrincipalName()).isEqualTo("user-1");
-	}
-
-	@Test
-	void test_save_throws_exception_when_consent_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> service.save(null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("AuthorizationConsent cannot be null");
-	}
-
-	@Test
-	void test_findById_throws_exception_when_registeredClientId_is_empty() {
-		// Then
-		Assertions.assertThatThrownBy(() -> service.findById("", "user-1"))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("RegisteredClientId cannot be empty");
-	}
-
-	@Test
-	void test_findById_throws_exception_when_principalName_is_empty() {
-		// Then
-		Assertions.assertThatThrownBy(() -> service.findById("client-1", ""))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("PrincipalName cannot be empty");
 	}
 
 }

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationServiceTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisOAuth2AuthorizationServiceTest.java
@@ -59,24 +59,6 @@ class RedisOAuth2AuthorizationServiceTest {
 	}
 
 	@Test
-	void test_constructor_throws_exception_when_registeredClientRepository_is_null() {
-		// Then
-		Assertions
-			.assertThatThrownBy(
-					() -> new RedisOAuth2AuthorizationService(null, authorizationGrantAuthorizationRepository))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("RegisteredClientRepository cannot be null");
-	}
-
-	@Test
-	void test_constructor_throws_exception_when_authorizationGrantAuthorizationRepository_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> new RedisOAuth2AuthorizationService(registeredClientRepository, null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("AuthorizationGrantAuthorizationRepository cannot be null");
-	}
-
-	@Test
 	void test_remove_authorization() {
 		// Given
 		RegisteredClient registeredClient = createRegisteredClient();
@@ -115,30 +97,6 @@ class RedisOAuth2AuthorizationServiceTest {
 
 		// Then
 		Assertions.assertThat(result).isNull();
-	}
-
-	@Test
-	void test_save_throws_exception_when_authorization_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> service.save(null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("Authorization cannot be null");
-	}
-
-	@Test
-	void test_remove_throws_exception_when_authorization_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> service.remove(null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("authorization cannot be null");
-	}
-
-	@Test
-	void test_findById_throws_exception_when_id_is_empty() {
-		// Then
-		Assertions.assertThatThrownBy(() -> service.findById(""))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("id cannot be empty");
 	}
 
 	private RegisteredClient createRegisteredClient() {

--- a/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisRegisteredClientRepositoryTest.java
+++ b/laokou-common/laokou-common-security/src/test/java/org/laokou/common/security/config/RedisRegisteredClientRepositoryTest.java
@@ -53,14 +53,6 @@ class RedisRegisteredClientRepositoryTest {
 	}
 
 	@Test
-	void test_constructor_throws_exception_when_repository_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> new RedisRegisteredClientRepository(null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("RegisteredClientRepository cannot be null");
-	}
-
-	@Test
 	void test_save_registeredClient() {
 		// Given
 		RegisteredClient registeredClient = RegisteredClient.withId("client-1")
@@ -104,30 +96,6 @@ class RedisRegisteredClientRepositoryTest {
 
 		// Then
 		Assertions.assertThat(result).isNull();
-	}
-
-	@Test
-	void test_save_throws_exception_when_client_is_null() {
-		// Then
-		Assertions.assertThatThrownBy(() -> repository.save(null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("RegisteredClient cannot be null");
-	}
-
-	@Test
-	void test_findById_throws_exception_when_id_is_empty() {
-		// Then
-		Assertions.assertThatThrownBy(() -> repository.findById(""))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("Id cannot be empty");
-	}
-
-	@Test
-	void test_findByClientId_throws_exception_when_clientId_is_empty() {
-		// Then
-		Assertions.assertThatThrownBy(() -> repository.findByClientId(""))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("ClientId cannot be empty");
 	}
 
 }

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/resources/mapper/dept/DeptMapper.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/resources/mapper/dept/DeptMapper.xml
@@ -43,7 +43,7 @@
               select dept_id from sys_role_dept
               where role_id in (
                 select role_id from sys_user_role where user_id = #{user.id} and del_flag = 0
-              )
+              ) and del_flag = 0
             </when>
           </choose>
         </foreach>

--- a/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/resources/mapper/role/RoleMapper.xml
+++ b/laokou-service/laokou-auth/laokou-auth-infrastructure/src/main/resources/mapper/role/RoleMapper.xml
@@ -21,9 +21,10 @@
 <mapper namespace="org.laokou.auth.gatewayimpl.database.RoleMapper">
 
   <select id="selectDataScopes" resultType="string">
-    select data_scope from sys_role r
-    join (select role_id from sys_user_role where user_id = #{user.id} and del_flag = 0) ur on ur.role_id = r.id
-    where r.del_flag = 0
+    select data_scope from sys_role
+    where id in (
+        select role_id from sys_user_role where user_id = #{user.id} and del_flag = 0
+    )
   </select>
 
 </mapper>


### PR DESCRIPTION
## Sourcery 总结

修正授权数据范围过滤，并简化相关持久化逻辑和测试覆盖范围。

错误修复：
- 修正部门数据范围过滤，排除逻辑删除的角色-部门映射。
- 优化角色数据范围查询，仅返回与用户关联的活跃角色。

改进：
- 简化 OAuth2 同意信息持久化代码。
- 从 MyBatis 和 Redis OAuth2 测试套件中移除已过时的租户表测试和侧重验证的测试。

测试：
- 精简不再维护的构造函数和参数验证行为相关测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct authorization data-scope filtering and streamline related persistence and test coverage.

Bug Fixes:
- Correct department data-scope filtering to exclude logically deleted role-department mappings.
- Refine role data-scope queries to return only active roles associated with the user.

Enhancements:
- Simplify OAuth2 consent persistence code.
- Remove obsolete tenant-table and validation-focused tests from MyBatis and Redis OAuth2 test suites.

Tests:
- Trim tests covering constructor and argument validation behavior that is no longer maintained.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom data-scope handling so deleted role-to-department mappings are excluded from access results.
  * Updated role data-scope retrieval to provide more consistent authorization results.
  * Improved accuracy when determining which departments and data users can access based on their assigned roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->